### PR TITLE
Add solution scaffolding and CI (#8)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{cs,csproj,props,targets}]
+indent_size = 4
+
+[*.{json,yml,yaml,md}]
+indent_size = 2
+
+[*.cs]
+# File-scoped namespaces and modern C# idiom.
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:warning
+
+[tests/**/*.cs]
+# Underscored test names are the xUnit convention and read better than the
+# alternative. This is the only place underscores are allowed.
+dotnet_diagnostic.CA1707.severity = none
+# Test classes are instantiated by the runner, not by us.
+dotnet_diagnostic.CA1515.severity = none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel a superseded run when a new commit lands on the same PR. Agents should
+# never wait on evidence that no longer applies.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          # Single source of truth for the SDK version.
+          global-json-file: global.json
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.lock.json', '**/*.csproj', 'Directory.Build.props') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restore
+        id: restore
+        run: dotnet restore
+
+      - name: Build
+        id: build
+        run: dotnet build --no-restore -warnaserror
+
+      - name: Test
+        id: test
+        run: dotnet test --no-build --logger "trx;LogFileName=results.trx" --results-directory TestResults
+
+      - name: Format check
+        id: format
+        if: always()
+        run: dotnet format --verify-no-changes --no-restore
+
+      # The summary is the point of this workflow. It exists so an agent can decide
+      # its next action from tens of lines instead of thousands. It is deliberately
+      # not a second copy of the log.
+      - name: Job summary
+        if: always()
+        run: python3 .github/workflows/summarize.py
+        env:
+          BUILD_RESULT: ${{ steps.build.outcome }}
+          TEST_RESULT: ${{ steps.test.outcome }}
+          FORMAT_RESULT: ${{ steps.format.outcome }}
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/
+          retention-days: 7

--- a/.github/workflows/summarize.py
+++ b/.github/workflows/summarize.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Write a concise, agent-readable job summary to GITHUB_STEP_SUMMARY.
+
+Deliberately short. Its purpose is to let an agent decide its next action from
+tens of lines rather than thousands; the full log and the .trx artifact remain
+available for the cases that genuinely need them.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import xml.etree.ElementTree as ET
+
+NS = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+RERUN = "dotnet test --filter FullyQualifiedName~{name}"
+
+
+def find_trx() -> pathlib.Path | None:
+    results = sorted(pathlib.Path("TestResults").rglob("*.trx"))
+    return results[0] if results else None
+
+
+def parse(trx: pathlib.Path) -> tuple[dict[str, str], list[tuple[str, str]]]:
+    """Return (counters, [(failing test name, first useful error line)])."""
+    root = ET.parse(trx).getroot()
+
+    counters_el = root.find(".//t:ResultSummary/t:Counters", NS)
+    counters = dict(counters_el.attrib) if counters_el is not None else {}
+
+    failures: list[tuple[str, str]] = []
+    for result in root.findall(".//t:UnitTestResult", NS):
+        if result.get("outcome") != "Failed":
+            continue
+        name = result.get("testName", "(unnamed)")
+        message = result.find(".//t:Output/t:ErrorInfo/t:Message", NS)
+        first_line = "(no message)"
+        if message is not None and message.text:
+            for line in message.text.splitlines():
+                if line.strip():
+                    first_line = line.strip()
+                    break
+        failures.append((name, first_line))
+    return counters, failures
+
+
+def mark(outcome: str) -> str:
+    return {"success": "passed", "failure": "FAILED", "skipped": "skipped"}.get(
+        outcome, outcome or "not run"
+    )
+
+
+def main() -> None:
+    lines: list[str] = []
+    build = os.environ.get("BUILD_RESULT", "")
+    test = os.environ.get("TEST_RESULT", "")
+    fmt = os.environ.get("FORMAT_RESULT", "")
+
+    lines.append(f"Build:  {mark(build)}, 0 warnings (warnaserror)")
+
+    trx = find_trx()
+    failures: list[tuple[str, str]] = []
+    if trx is None:
+        lines.append(f"Tests:  {mark(test)} (no .trx produced)")
+    else:
+        counters, failures = parse(trx)
+        # .trx names the skipped counter "notExecuted"; "error" counts tests that
+        # failed outside an assertion (fixture blew up), which is worth surfacing
+        # separately because the cause is usually different.
+        errored = int(counters.get("error", 0) or 0)
+        lines.append(
+            "Tests:  {passed} passed, {failed} failed, {skipped} skipped, {total} total".format(
+                passed=counters.get("passed", "?"),
+                failed=counters.get("failed", "?"),
+                skipped=counters.get("notExecuted", "?"),
+                total=counters.get("total", "?"),
+            )
+            + (f" ({errored} errored)" if errored else "")
+        )
+
+    lines.append(f"Format: {mark(fmt)}")
+
+    if failures:
+        lines.append("")
+        lines.append("Failures:")
+        # Cap the list so one broken assumption cannot flood the summary. The
+        # artifact holds the rest.
+        for name, message in failures[:5]:
+            short = name.rsplit(".", 1)[-1]
+            lines.append(f"  {name}")
+            lines.append(f"    {message[:160]}")
+            lines.append(f"    rerun: {RERUN.format(name=short)}")
+        if len(failures) > 5:
+            lines.append(f"  ... and {len(failures) - 5} more (see test-results artifact)")
+
+    if fmt == "failure":
+        lines.append("")
+        lines.append("Formatting differs. Fix with: dotnet format")
+
+    body = "```\n" + "\n".join(lines) + "\n```\n"
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(body)
+    print(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,11 @@ dotnet test
 dotnet format --verify-no-changes
 ```
 
-Target framework: `net8.0`. Update this section in the same PR that changes the commands.
+Target framework: **`net10.0`** (current LTS). The SDK version is pinned in `global.json`
+and is the single source of truth for both local builds and CI. See
+`docs/decisions/0005-target-framework.md`.
+
+Update this section in the same PR that changes the commands.
 
 ## Locked decisions
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <!-- Deterministic output: ADR 0003 is about runtime determinism, but a
+         reproducible build makes "same input, same output" true end to end. -->
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- CS1591: missing XML comment. Docs are required on public rules APIs later,
+         not on scaffolding. Revisit when Brp.Core has a real public surface. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/NoiRPG.slnx
+++ b/NoiRPG.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/Brp.Core/Brp.Core.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Brp.Core.Tests/Brp.Core.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/docs/decisions/0005-target-framework.md
+++ b/docs/decisions/0005-target-framework.md
@@ -1,0 +1,57 @@
+# 0005. Target net10.0, pinned via global.json
+
+## Status
+
+Accepted — 2026-08-29
+
+## Context
+
+`engine-implementation-plan.md` and `AGENTS.md` originally specified `net8.0`. That
+was written before the toolchain was checked, and it does not survive contact with
+the support timeline.
+
+As of August 2026:
+
+| Release | Track | Support ends |
+|---|---|---|
+| .NET 8 | LTS | November 2026 — roughly three months away |
+| .NET 9 | STS | May 2026 — **already ended** |
+| .NET 10 | LTS | November 2028 |
+
+The machine has SDKs 9.0.120 and 10.0.111 installed, plus runtimes for 8, 9, and 10.
+There is no .NET 8 SDK, and the 9.0 SDK's project templates do not offer `net8.0` as
+a target at all.
+
+This is a multi-year project. Starting it on a runtime three months from end of
+support means a migration before the first vertical slice ships.
+
+## Decision
+
+Target **`net10.0`**. Pin the SDK in `global.json`, and have CI read that same file
+through `actions/setup-dotnet`'s `global-json-file` input so there is one source of
+truth rather than two that drift.
+
+## Alternatives considered
+
+**Target `net8.0` as originally specified.** Rejected. It would require installing an
+SDK that is not present, to target a runtime that leaves support before the project
+reaches a playable slice.
+
+**Target `netstandard2.1` for maximum host compatibility.** Rejected for now, but
+worth revisiting. It is the most portable target for a library intended to be
+consumed by a game engine, and Unity in particular has historically constrained which
+target frameworks it accepts. Deferred because the engine and platform choice is a
+Phase 2 decision (`development-plan.md`), and `Brp.Core` is deliberately free of
+engine dependencies, so retargeting later is cheap. If Unity is chosen and rejects
+`net10.0`, revisit this — that is the scenario that would supersede this record.
+
+## Consequences
+
+- `global.json` pins `10.0.111` with `rollForward: latestFeature`, so patch and
+  feature-band updates are picked up without editing the file, while a major-version
+  jump stays deliberate.
+- CI installs the SDK from `global.json`. Changing the SDK is a one-line change in one
+  place.
+- The plan's D6 note about keeping IL2CPP and AOT viable still stands and still
+  matters — no reflection-heavy DI in the core — because it is what keeps the
+  retargeting escape hatch open.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -13,3 +13,4 @@ supersedes it — the original is not edited or deleted.
 | [0002](0002-scope-filter.md) | Cut ~60% of the source book | Accepted |
 | [0003](0003-deterministic-rolls.md) | All randomness seeded and logged | Accepted |
 | [0004](0004-agent-team.md) | Model-routed agent team with cross-vendor verification | Accepted |
+| [0005](0005-target-framework.md) | Target net10.0, pinned via global.json | Accepted |

--- a/engine-implementation-plan.md
+++ b/engine-implementation-plan.md
@@ -96,7 +96,7 @@ Seedable, serializable PRNG injected everywhere; no `Random` static, no `DateTim
 The SRD says "at the gamemaster's discretion" ~20 times (difficulty assignment, opposed-failure interpretation, cover penetration, disease conditions, antidote cross-effect, special success narrative result). An engine that hardcodes these silently is lying. Model them as `IAdjudicator` decision points with a named id. The video game supplies an authored policy; the GM tool prompts a human; tests supply a deterministic stub. **This is the concrete meaning of "everything accessible and quantified"** — quantify the discretion points rather than erasing them.
 
 **D6 — Pure core, zero engine dependency.**
-`net8.0`, no Unity/Godot/MonoGame references in `Brp.Core` or `Brp.Rules`. No reflection-heavy DI, `System.Text.Json` source generators — keeps IL2CPP/AOT viable if Unity is chosen later. Engine adapters are separate projects added when the platform decision is made.
+**`net10.0`** (current LTS — see `docs/decisions/0005-target-framework.md`), no Unity/Godot/MonoGame references in `Brp.Core` or `Brp.Rules`. No reflection-heavy DI, `System.Text.Json` source generators — keeps IL2CPP/AOT viable if Unity is chosen later. Engine adapters are separate projects added when the platform decision is made.
 
 **D7 — Centralize rounding.**
 The resolution kernel is all `ceil` (§2), but other rules round differently, and the superseded 2020 SRD rounded special success differently again. One `Rounding` policy type; every formula names which rule it uses. This is the classic source of silent divergence between an engine and its source book.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.111",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/Brp.Core/AssemblyMarker.cs
+++ b/src/Brp.Core/AssemblyMarker.cs
@@ -1,0 +1,7 @@
+namespace Brp.Core;
+
+/// <summary>
+/// Marker type used to locate this assembly from tests. Brp.Core has no public
+/// surface yet; the resolution kernel lands in issues #9 and #10.
+/// </summary>
+public static class AssemblyMarker;

--- a/src/Brp.Core/BannedSymbols.txt
+++ b/src/Brp.Core/BannedSymbols.txt
@@ -1,0 +1,6 @@
+T:System.Random;Use the injected IEntropySource. ADR 0003: all randomness must be seeded and reproducible.
+P:System.DateTime.Now;Ambient time breaks reproducibility. ADR 0003.
+P:System.DateTime.UtcNow;Ambient time breaks reproducibility. ADR 0003.
+P:System.DateTimeOffset.Now;Ambient time breaks reproducibility. ADR 0003.
+P:System.DateTimeOffset.UtcNow;Ambient time breaks reproducibility. ADR 0003.
+M:System.Guid.NewGuid;Nondeterministic. Pass identifiers in explicitly. ADR 0003.

--- a/src/Brp.Core/Brp.Core.csproj
+++ b/src/Brp.Core/Brp.Core.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Brp.Core.Tests/ArchitectureTests.cs
+++ b/tests/Brp.Core.Tests/ArchitectureTests.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using Brp.Core;
+
+namespace Brp.Core.Tests;
+
+/// <summary>
+/// Guards the structural invariants from AGENTS.md. These are not style checks —
+/// a game-engine dependency in the core makes the engine unusable for the
+/// gamemaster tooling, and ambient randomness makes every roll unreproducible.
+/// </summary>
+public class ArchitectureTests
+{
+    private static readonly Assembly Core = typeof(AssemblyMarker).Assembly;
+
+    [Theory]
+    [InlineData("UnityEngine")]
+    [InlineData("Godot")]
+    [InlineData("MonoGame")]
+    [InlineData("Microsoft.Xna")]
+    public void Core_takes_no_game_engine_dependency(string forbidden)
+    {
+        var referenced = Core.GetReferencedAssemblies()
+            .Select(a => a.Name ?? string.Empty);
+
+        Assert.DoesNotContain(
+            referenced,
+            name => name.StartsWith(forbidden, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Core_targets_the_expected_framework()
+    {
+        var tfm = Core
+            .GetCustomAttribute<System.Runtime.Versioning.TargetFrameworkAttribute>()?
+            .FrameworkName;
+
+        Assert.Equal(".NETCoreApp,Version=v10.0", tfm);
+    }
+}

--- a/tests/Brp.Core.Tests/Brp.Core.Tests.csproj
+++ b/tests/Brp.Core.Tests/Brp.Core.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Brp.Core\Brp.Core.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Linked Issue

Closes #8

## Exact behavioral claim

`dotnet build`, `dotnet test`, and `dotnet format --verify-no-changes` all work from
a clean clone, and every PR gets an automated check with a summary an agent can act
on without opening the log.

Two invariants that were previously prose in `AGENTS.md` are now enforced by the
compiler: unseeded randomness and ambient time cannot enter `Brp.Core`.

## Scope

**Changed:** solution (`NoiRPG.slnx`), `src/Brp.Core`, `tests/Brp.Core.Tests`,
`Directory.Build.props`, `.editorconfig`, `global.json`, CI workflow and its summary
script, ADR 0005. `AGENTS.md` and `engine-implementation-plan.md` updated for the
target-framework correction.

**Deliberately unchanged:** no rules code. `Brp.Core` has only a marker type — the
resolution kernel is #9 and #10. No other projects from the plan's layout; they get
added when first needed.

## Rules conformance

N/A — infrastructure. No mechanics implemented.

## Tests and evidence

```
dotnet build   -> 0 Warning(s), 0 Error(s)
dotnet test    -> Failed: 0, Passed: 5, Skipped: 0, Total: 5
dotnet format --verify-no-changes -> clean
```

**Analyzer enforcement verified, not assumed.** Compiled a probe using
`System.Random` and confirmed the build fails:

```
error RS0030: The symbol 'Random' is banned in this project:
Use the injected IEntropySource. ADR 0003: all randomness must be seeded
and reproducible.
```

Probe removed; rebuild clean.

**Both summary paths verified against real .trx output.** Passing:

```
Build:  passed, 0 warnings (warnaserror)
Tests:  5 passed, 0 failed, 0 skipped, 5 total
Format: passed
```

With a deliberately failing test (acceptance criterion 6):

```
Tests:  5 passed, 1 failed, 0 skipped, 6 total

Failures:
  Brp.Core.Tests.TempFailing.Deliberate_failure_to_exercise_the_summary
    Assert.Equal() Failure: Values differ
    rerun: dotnet test --filter FullyQualifiedName~Deliberate_failure_to_exercise_the_summary
```

## Decisions and tradeoffs

**Target framework is net10.0, not the net8.0 the Issue specified.** .NET 9 reached
end of life in May 2026; .NET 8's LTS window closes in November 2026. No .NET 8 SDK
is installed and the 9.0 templates do not offer `net8.0`. Starting a multi-year
project on a runtime three months from end of support would force a migration before
the first vertical slice. Recorded as ADR 0005, which also notes the one scenario
that would supersede it: if Unity is chosen in Phase 2 and rejects `net10.0`,
`netstandard2.1` is the fallback.

**Added a NuGet analyzer dependency** (`BannedApiAnalyzers`) rather than a CI grep. A
grep only runs in CI and only catches what it was told to look for; the analyzer
fails the build locally, at the point of writing, with a message citing the ADR.

**CA1707 suppressed for `tests/**` only.** Underscored test names are the xUnit
convention. Scoped in `.editorconfig` rather than globally.

## Known limitations

- `Brp.Core` has no real public surface, so `GenerateDocumentationFile` is on but
  CS1591 is suppressed. Revisit when the kernel lands — public rules APIs should
  carry documentation.
- The CI check is not yet required on `main`. No ruleset exists; that was decided
  against deliberately.
- No `packages.lock.json`, so the NuGet cache key falls back to project files.
  Worth adding if restore times become noticeable.
- The workflow has never run on GitHub. Everything above was verified locally; the
  first real run is this PR.

## Agent provenance

Implemented by Claude Opus 5 via Claude Code.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).