### PR TITLE
Adopt full Skill Category Bonuses, applied by subtraction (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A modern-day noir action/mystery RPG — no magic, no unrealistic technology, pr
 | [case-board-test.md](case-board-test.md) | Paper test kit for the case-board deduction loop, with the machine-run Three Doors build audit results. |
 | [cases/SCHEMA.md](cases/SCHEMA.md) | Case data schema v0.1 — the production case format. |
 | [cases/overpass.yaml](cases/overpass.yaml) | Case 01 "The Overpass" — the first case authored as pure data. |
+| [tools/skill_bonus.py](tools/skill_bonus.py) | Skill category bonuses — characteristics, category mapping, and the base-rating derivation. |
 | [tools/case_validator.py](tools/case_validator.py) | Case validator — enforces the Three Doors and junction-point rules, audits build coverage. |
 | [interrogation-cards-overpass.md](interrogation-cards-overpass.md) | Statement card decks for all four Overpass suspects — the interrogation paper-prototype materials. |
 | [paper-kit/overpass-cards.html](paper-kit/overpass-cards.html) | Print-ready paper test kit — open in a browser and print: statement decks, suspect dossiers with trackers, evidence cards, reference cards, build sheets. |

--- a/docs/decisions/0006-skill-bonus-system.md
+++ b/docs/decisions/0006-skill-bonus-system.md
@@ -1,0 +1,100 @@
+# 0006. Full Skill Category Bonuses, applied by subtraction
+
+## Status
+
+Accepted — 2026-08-29. Resolves #1.
+
+## Context
+
+The source offers two mutually exclusive optional systems for letting characteristics
+influence skill ratings, and permits using neither:
+
+- **Skill Category Bonuses** — each of the six skill categories has a primary
+  characteristic (±1% per point from 10), one or two secondaries (±1% per 2 points,
+  magnitude rounded down), and sometimes a negative one (inverted). Bonuses can be
+  negative.
+- **Simpler Skill Bonuses** — the category bonus is half the primary characteristic,
+  rounded up. Always positive, roughly +5 at average characteristics.
+- **Neither** — the skill rating is exactly the number shown.
+
+This blocks Layer 2, because it changes how every skill's effective rating is computed.
+
+It also collides with authored content. `tools/case_validator.py` holds three
+background packages as concrete skill ratings, and `cases/SCHEMA.md` opens a skill
+door at a `min_rating` of 40. Any bonus applied on top of the authored numbers shifts
+ratings across that threshold. Measured before deciding: Simpler would have opened
+the ex-cop's Law door and the ex-soldier's Streetwise door (both 35, both crossing 40
+at +5), and the ex-cop's Fast Talk sits exactly on 40, so a negative bonus closes it.
+
+The Overpass build audit has already needed one repair pass for the ex-soldier coming
+out fallback-heavy, so silently perturbing door coverage was the main risk.
+
+## Decision
+
+**Use full Skill Category Bonuses.**
+
+**Apply them by subtraction, not addition.** The authored ratings in
+`case_validator.py` are treated as **final effective ratings**; base ratings are
+derived:
+
+```
+base = effective - category_bonus
+```
+
+Characteristics come from the source's point-based creation at Normal power level:
+every characteristic starts at 10, 24 points to spend, DEX/INT/POW cost 3 per point,
+STR/CON/SIZ/CHA cost 1, reductions refund at the same rate.
+
+`tools/skill_bonus.py` holds the characteristic sets, the category mapping, and the
+formulas. `--check` asserts the point-buy totals are exact and that base plus bonus
+reproduces every authored rating.
+
+### Skill categories for the canonical 18
+
+Taken from the source's own skill-list-by-category via each NoiRPG skill's book
+equivalent. Three of these are counter-intuitive and were wrong in a first pass:
+
+| Skill | Category | Note |
+|---|---|---|
+| Research | **Perception** | Not Mental. Likely the most-rolled skill in the game. |
+| First Aid | **Mental** | Not Manipulation. |
+| Drive | **Physical** | Not Manipulation. |
+
+The rest: Streetwise, Law, Accounting → Mental. Insight, Spot → Perception. Fast Talk,
+Persuade, Intimidate → Communication. Photography, Locksmith → Manipulation. Firearms,
+Brawl → Combat. Shadow, Stealth, Dodge → Physical.
+
+Intimidate is the only skill with no book equivalent; Communication is the natural home.
+
+## Alternatives considered
+
+**Neither.** Simplest, and the strongest fit for the transparency pillar — the
+displayed percentage would be the whole truth with nothing derived behind it. Rejected
+in favour of build differentiation: characteristics doing real work is what makes the
+point-buy step a meaningful choice rather than a formality.
+
+**Simpler Skill Bonuses.** Rejected: it is uniformly positive, so it adds a flat
+inflation to every character rather than differentiating them, which buys the cost of
+a bonus system without the benefit.
+
+**Applying the bonus additively on top of the authored ratings.** Rejected. It would
+have shifted two doors open in an already-audited case and forced a rebalance of
+content that is currently validated.
+
+## Consequences
+
+- **Audited cases are unaffected by construction.** Effective ratings are unchanged,
+  `case_validator.py` needs no edit, and the Overpass audit reproduces exactly —
+  verified, including the ex-soldier's single intended fallback on cc3.
+- **INT is the dominant characteristic and this needs watching.** It is primary for
+  Communication, Mental, and Perception, and secondary for Combat and Manipulation —
+  five of six categories, and 10 of the canonical 18 skills. In an investigation game
+  where Mental and Perception skills carry the load, an INT-maximising build may
+  dominate despite INT already costing 3 points. Revisit if playtesting shows builds
+  collapsing toward one shape.
+- SIZ only ever hurts (negative for Physical, nothing else), and CHA touches only
+  Communication. Both are cheap at 1 point per point, which is roughly right.
+- Layer 2 is unblocked. `SkillDefinition` must carry a category, and effective rating
+  becomes base plus category bonus, recomputed whenever a characteristic changes.
+- The engine must implement this as a ruleset-configurable policy, since ADR 0002
+  keeps rules values as data. The other two options stay expressible.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,3 +14,4 @@ supersedes it — the original is not edited or deleted.
 | [0003](0003-deterministic-rolls.md) | All randomness seeded and logged | Accepted |
 | [0004](0004-agent-team.md) | Model-routed agent team with cross-vendor verification | Accepted |
 | [0005](0005-target-framework.md) | Target net10.0, pinned via global.json | Accepted |
+| [0006](0006-skill-bonus-system.md) | Full Skill Category Bonuses, applied by subtraction | Accepted |

--- a/tools/skill_bonus.py
+++ b/tools/skill_bonus.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Skill category bonuses for NoiRPG (docs/decisions/0006-skill-bonus-system.md).
+
+Computes each background package's skill category bonuses from its characteristics,
+then derives the BASE skill ratings that reproduce the authored effective ratings in
+tools/case_validator.py.
+
+The direction matters. The authored BUILDS numbers are treated as FINAL EFFECTIVE
+ratings, and base ratings are derived by subtracting the bonus:
+
+    base = effective - category_bonus
+
+Doing it the other way round -- treating the authored numbers as base and adding a
+bonus on top -- would shift every rating and silently change which doors open in
+already-audited cases. This way the Overpass audit is preserved by construction,
+while characteristics still drive skill ratings for any character the player builds.
+
+Usage:
+    tools/skill_bonus.py            # report bonuses and derived base ratings
+    tools/skill_bonus.py --check    # verify effective ratings round-trip; exit 1 if not
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+# --- Point-buy (source: point-based character creation, Normal power level) --------
+# Every characteristic starts at 10. 24 points to spend. DEX/INT/POW cost 3 per
+# point; STR/CON/SIZ/CHA cost 1. Reducing below 10 refunds at the same rate.
+# Range 3-21.
+POINT_BUDGET = 24
+COSTS = {"STR": 1, "CON": 1, "SIZ": 1, "CHA": 1, "DEX": 3, "INT": 3, "POW": 3}
+
+# --- Category formulas (source: Skill Category Modifiers) -------------------------
+# primary: +/-1 per point from 10
+# secondary: +/-1 per 2 points from 10, magnitude rounded down
+# negative: inverted primary
+# EDU is not used in NoiRPG, so Mental has POW as its only secondary.
+CATEGORIES = {
+    "Combat": {"primary": "DEX", "secondary": ["INT", "STR"], "negative": []},
+    "Communication": {"primary": "INT", "secondary": ["POW", "CHA"], "negative": []},
+    "Manipulation": {"primary": "DEX", "secondary": ["INT", "STR"], "negative": []},
+    "Mental": {"primary": "INT", "secondary": ["POW"], "negative": []},
+    "Perception": {"primary": "INT", "secondary": ["POW", "CON"], "negative": []},
+    "Physical": {"primary": "DEX", "secondary": ["STR", "CON"], "negative": ["SIZ"]},
+}
+
+# --- The canonical 18, mapped to book categories ----------------------------------
+# Assignments come from the book's Skill List by Category, via each NoiRPG skill's
+# book equivalent. Intimidate is the only one with no book equivalent; Communication
+# is the natural home.
+SKILL_CATEGORY = {
+    "Streetwise": "Mental",        # Knowledge (Streetwise)
+    "Law": "Mental",               # Knowledge (Law)
+    "Accounting": "Mental",        # Knowledge (Accounting)
+    "First Aid": "Mental",         # First Aid is Mental in the source, not Manipulation
+    "Insight": "Perception",
+    "Research": "Perception",      # Perception, not Mental
+    "Spot": "Perception",
+    "Fast Talk": "Communication",
+    "Persuade": "Communication",
+    "Intimidate": "Communication",  # original skill; no book equivalent
+    "Photography": "Manipulation",  # Art (Photography)
+    "Locksmith": "Manipulation",    # Fine Manipulation
+    "Firearms": "Combat",
+    "Brawl": "Combat",
+    "Shadow": "Physical",           # Stealth, used for tailing
+    "Stealth": "Physical",
+    "Dodge": "Physical",
+    "Drive": "Physical",            # Physical in the source, not Manipulation
+}
+
+# --- Background packages ----------------------------------------------------------
+# Each spends exactly POINT_BUDGET. Shapes chosen to match the packages' fiction:
+# the cop is a rounded generalist, the accountant trades physicality for INT/POW,
+# the soldier trades INT/CHA for DEX/STR/CON.
+CHARACTERISTICS = {
+    "ex-cop": {"STR": 12, "CON": 13, "SIZ": 12, "INT": 13, "POW": 10, "DEX": 12, "CHA": 12},
+    "ex-accountant": {"STR": 8, "CON": 12, "SIZ": 11, "INT": 15, "POW": 12, "DEX": 10, "CHA": 12},
+    "ex-soldier": {"STR": 14, "CON": 14, "SIZ": 12, "INT": 10, "POW": 11, "DEX": 14, "CHA": 9},
+}
+
+# Authored effective ratings. Must stay in sync with BUILDS in case_validator.py.
+EFFECTIVE = {
+    "ex-cop": {"Streetwise": 65, "Intimidate": 65, "Firearms": 60, "Spot": 60,
+               "Insight": 55, "First Aid": 45, "Fast Talk": 40, "Law": 35,
+               "Photography": 30, "Accounting": 15},
+    "ex-accountant": {"Accounting": 70, "Research": 65, "Law": 55, "Insight": 50,
+                      "Persuade": 50, "Fast Talk": 45, "Photography": 25,
+                      "First Aid": 25, "Streetwise": 20},
+    "ex-soldier": {"Firearms": 70, "Dodge": 60, "Brawl": 55, "Spot": 55,
+                   "First Aid": 50, "Intimidate": 50, "Drive": 45, "Stealth": 45,
+                   "Streetwise": 35, "Persuade": 25},
+}
+
+
+def point_cost(chars: dict[str, int]) -> int:
+    return sum((value - 10) * COSTS[name] for name, value in chars.items())
+
+
+def signed_half(delta: int) -> int:
+    """+/-1 per 2 points from 10, magnitude rounded down."""
+    return int(math.copysign(abs(delta) // 2, delta)) if delta else 0
+
+
+def category_bonus(chars: dict[str, int], category: str) -> int:
+    spec = CATEGORIES[category]
+    bonus = chars[spec["primary"]] - 10
+    for name in spec["secondary"]:
+        bonus += signed_half(chars[name] - 10)
+    for name in spec["negative"]:
+        bonus -= chars[name] - 10
+    return bonus
+
+
+def bonuses_for(build: str) -> dict[str, int]:
+    chars = CHARACTERISTICS[build]
+    return {cat: category_bonus(chars, cat) for cat in CATEGORIES}
+
+
+def base_ratings(build: str) -> dict[str, int]:
+    """Derive base ratings that reproduce the authored effective ratings."""
+    bonus = bonuses_for(build)
+    return {
+        skill: rating - bonus[SKILL_CATEGORY[skill]]
+        for skill, rating in EFFECTIVE[build].items()
+    }
+
+
+def report() -> None:
+    for build in CHARACTERISTICS:
+        chars = CHARACTERISTICS[build]
+        cost = point_cost(chars)
+        flag = "" if cost == POINT_BUDGET else f"  <-- SPENDS {cost}, BUDGET {POINT_BUDGET}"
+        print(f"\n{build}{flag}")
+        print("  " + "  ".join(f"{k} {v}" for k, v in chars.items()))
+        bonus = bonuses_for(build)
+        print("  bonuses: " + "  ".join(f"{c} {v:+d}" for c, v in bonus.items()))
+        print(f"  {'skill':<12} {'base':>5} {'bonus':>6} {'effective':>10}")
+        for skill, eff in sorted(EFFECTIVE[build].items(), key=lambda kv: -kv[1]):
+            cat = SKILL_CATEGORY[skill]
+            print(f"  {skill:<12} {eff - bonus[cat]:>5} {bonus[cat]:>+6} {eff:>10}")
+
+
+def check() -> int:
+    """Base + bonus must reproduce the authored effective ratings exactly."""
+    failures = []
+    for build in CHARACTERISTICS:
+        cost = point_cost(CHARACTERISTICS[build])
+        if cost != POINT_BUDGET:
+            failures.append(f"{build}: spends {cost}, budget is {POINT_BUDGET}")
+        bonus = bonuses_for(build)
+        for skill, base in base_ratings(build).items():
+            got = base + bonus[SKILL_CATEGORY[skill]]
+            want = EFFECTIVE[build][skill]
+            if got != want:
+                failures.append(f"{build}/{skill}: {got} != {want}")
+    for skill in EFFECTIVE["ex-cop"] | EFFECTIVE["ex-accountant"] | EFFECTIVE["ex-soldier"]:
+        if skill not in SKILL_CATEGORY:
+            failures.append(f"{skill} has no category")
+    if failures:
+        print("FAIL")
+        for line in failures:
+            print("  " + line)
+        return 1
+    print("OK: point-buy totals correct; base + bonus reproduces every authored rating")
+    print("    -> door coverage in audited cases is unchanged by construction")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    raise SystemExit(check() if args.check else (report() or 0))


### PR DESCRIPTION
## Linked Issue

Closes #1

## Exact behavioral claim

Characteristics now influence skill ratings, via the full category-bonus system.
Background packages have concrete characteristics for the first time, the canonical
18 skills are assigned to categories, and the derivation is checkable rather than
asserted.

This unblocks Layer 2 without disturbing any authored content.

## Scope

**Changed:** `tools/skill_bonus.py` (new), ADR 0006, README and decision index.

**Deliberately unchanged:** `tools/case_validator.py`, `cases/overpass.yaml`, and
every authored rating. That is the point of the approach below — no rebalance pass.

## Rules conformance

Source: the optional skill-category-bonus system and point-based character creation.

- Bonus formulas verified against **all six worked examples** in the source: primary
  ±1 per point from 10, secondary ±1 per 2 points with magnitude rounded down,
  negative inverted. All six reproduce exactly.
- Skill categories taken from the source's own skill-list-by-category rather than
  inferred. **Three were wrong in my first pass** — Research is Perception (not
  Mental), First Aid is Mental (not Manipulation), Drive is Physical (not
  Manipulation). Research being Perception matters most, since it is likely the
  most-rolled skill in the game.
- EDU is not used in NoiRPG, so Mental has POW as its only secondary.
- Point-buy uses the source's Normal power level: 24 points, DEX/INT/POW at 3.

## Decisions and tradeoffs

**Applied by subtraction, not addition.** Authored ratings are treated as final
effective; base is derived as `effective - bonus`.

Doing it the other way would have shifted ratings across the schema's `min_rating` of
40. Measured before choosing: the simpler bonus system would have opened the ex-cop's
Law door and the ex-soldier's Streetwise door (both 35, both crossing 40 at +5), and
the ex-cop's Fast Talk sits exactly on 40 so a negative bonus closes it. Given the
Overpass audit already needed one repair pass, silently perturbing coverage was the
main risk. Subtraction removes it by construction.

**Full bonuses over the simpler variant.** The simpler system is uniformly positive,
so it inflates every character rather than differentiating them — the cost of a bonus
system without the benefit.

## Tests and evidence

```
python3 tools/skill_bonus.py --check
OK: point-buy totals correct; base + bonus reproduces every authored rating
    -> door coverage in audited cases is unchanged by construction

python3 tools/case_validator.py cases/overpass.yaml
PASS  5 core clues, 22 doors, 20 evidence items, 2/3 junctions
```

The audit output is byte-identical to before this change, including the ex-soldier's
single fallback on cc3 — which `case-board-test.md` records as intended texture.

Resulting category bonuses:

| Build | Combat | Comm | Manip | Mental | Percep | Physical |
|---|---:|---:|---:|---:|---:|---:|
| ex-cop | +4 | +4 | +4 | +3 | +4 | +2 |
| ex-accountant | +1 | +7 | +1 | +6 | +7 | −1 |
| ex-soldier | +6 | +0 | +6 | +0 | +2 | +6 |

## Known limitations

- **INT is dominant and this should be watched.** It is primary for Communication,
  Mental, and Perception and secondary for Combat and Manipulation — five of six
  categories, reaching 10 of the canonical 18 skills. In an investigation game an
  INT-maximising build may flatten build variety despite INT costing 3 per point.
  Recorded in the ADR; revisit after playtesting rather than pre-emptively.
- Only three background packages have characteristics. The framework also mentions
  ex-journalist and ex-lawyer, which do not yet exist in `case_validator.py`.
- The bonus is not yet implemented in the engine. Layer 2 is unblocked, not built.
- Characteristic sets are authored to match each package's fiction, not tuned. They
  spend the budget exactly but have not been playtested.

## Agent provenance

Implemented by Claude Opus 5 via Claude Code.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).