### PR TITLE
Add seeded entropy source and dice expression evaluator (#9)

### DIFF
--- a/src/Brp.Core/AssemblyMarker.cs
+++ b/src/Brp.Core/AssemblyMarker.cs
@@ -1,7 +1,0 @@
-namespace Brp.Core;
-
-/// <summary>
-/// Marker type used to locate this assembly from tests. Brp.Core has no public
-/// surface yet; the resolution kernel lands in issues #9 and #10.
-/// </summary>
-public static class AssemblyMarker;

--- a/src/Brp.Core/Dice/DiceExpression.cs
+++ b/src/Brp.Core/Dice/DiceExpression.cs
@@ -1,0 +1,334 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+
+namespace Brp.Core.Dice;
+
+/// <summary>
+/// Optional context threaded into a roll. <see cref="DamageBonus"/> supplies the value
+/// substituted for the <c>db</c> token (Ch 2's damage bonus modifier). If omitted, <c>db</c>
+/// and its halved forms evaluate to zero.
+/// </summary>
+/// <param name="DamageBonus">
+/// The damage bonus expression, e.g. <c>1D4</c> or <c>-1D4</c>. Rolled fresh -- consuming its
+/// own entropy draws -- every time a <c>db</c> or half-<c>db</c> term is evaluated.
+/// </param>
+public readonly record struct DiceContext(DiceExpression? DamageBonus = null);
+
+/// <summary>
+/// An immutable, parsed dice notation expression. Parse once, evaluate many times against
+/// different <see cref="IEntropySource"/> draws -- the expression itself carries no state and
+/// consumes no entropy on its own.
+/// <para>
+/// Grammar: an optionally-signed first term, followed by zero or more explicitly signed terms.
+/// Each term is one of a dice group (<c>NdM</c>, count defaults to 1), a flat integer constant,
+/// the damage-bonus token <c>db</c>, or a halved damage-bonus token (<c>db/2</c> or <c>½db</c>).
+/// Parsing is case-insensitive and tolerant of whitespace anywhere in the string. See Ch 1
+/// (dice notation) and Ch 2 (damage bonus) of the source book.
+/// </para>
+/// </summary>
+public sealed class DiceExpression
+{
+    private const int MaxDiceCount = 1000;
+
+    // Matches one signed term starting at the current position. Alternatives are ordered so
+    // the longer, more specific forms (db/2, ½db) are tried before the bare "db" they would
+    // otherwise be truncated to.
+    private static readonly Regex TokenPattern = new(
+        @"\G(?<sign>[+-])?(?<term>DB/2|½DB|DB|\d*D\d+|\d+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex DicePattern = new(
+        @"^(?<count>\d*)D(?<sides>\d+)$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex HalfDamageBonusPattern = new(
+        @"^(?:DB/2|½DB)$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex DamageBonusPattern = new(
+        @"^DB$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private readonly IReadOnlyList<Term> _terms;
+
+    private DiceExpression(string notation, IReadOnlyList<Term> terms)
+    {
+        Notation = notation;
+        _terms = terms;
+    }
+
+    /// <summary>
+    /// The expression's normalized rendering: uppercase <c>D</c>, explicit dice counts, an
+    /// explicit sign on every term after the first, and <c>DB/2</c> as the canonical spelling
+    /// for either halved-damage-bonus form. Re-parsing this string always yields the same
+    /// <see cref="Notation"/> back.
+    /// </summary>
+    public string Notation { get; }
+
+    /// <summary>Parses dice notation, throwing on anything invalid.</summary>
+    /// <exception cref="FormatException">
+    /// The notation is empty, malformed, uses a zero-sided die, or exceeds the dice-count cap.
+    /// </exception>
+    public static DiceExpression Parse(string notation)
+    {
+        if (!TryParseCore(notation, out var expression, out var error))
+        {
+            throw new FormatException(error);
+        }
+
+        return expression!;
+    }
+
+    /// <summary>Attempts to parse dice notation, returning <see langword="false"/> instead of throwing.</summary>
+    public static bool TryParse(string notation, out DiceExpression? expression) =>
+        TryParseCore(notation, out expression, out _);
+
+    /// <summary>
+    /// Evaluates the expression against <paramref name="entropy"/>, consuming one entropy draw
+    /// per die (rejection sampling may consume more), including any dice rolled indirectly
+    /// through <see cref="DiceContext.DamageBonus"/> when a <c>db</c> term is present.
+    /// </summary>
+    public DiceRoll Roll(IEntropySource entropy, DiceContext context = default)
+    {
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var results = new List<DiceTermResult>(_terms.Count);
+        var rawTotal = 0;
+        foreach (var term in _terms)
+        {
+            var result = term.Evaluate(entropy, context);
+            results.Add(result);
+            rawTotal += result.Value;
+        }
+
+        var total = Math.Max(0, rawTotal);
+        return new DiceRoll(total, rawTotal, results);
+    }
+
+    private static bool TryParseCore(string? notation, out DiceExpression? expression, out string error)
+    {
+        expression = null;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(notation))
+        {
+            error = "Dice notation must not be empty.";
+            return false;
+        }
+
+        var stripped = Regex.Replace(notation, @"\s+", string.Empty);
+        var terms = new List<Term>();
+        var position = 0;
+        var isFirst = true;
+
+        while (position < stripped.Length)
+        {
+            var match = TokenPattern.Match(stripped, position);
+            if (!match.Success || match.Index != position)
+            {
+                error = $"'{notation}' is not a valid dice expression: unrecognized text at '{stripped[position..]}'.";
+                return false;
+            }
+
+            var signGroup = match.Groups["sign"];
+            if (!signGroup.Success && !isFirst)
+            {
+                error = $"'{notation}' is not a valid dice expression: term '{match.Groups["term"].Value}' needs an explicit + or - sign.";
+                return false;
+            }
+
+            var sign = signGroup.Success && signGroup.Value == "-" ? -1 : 1;
+
+            if (!TryBuildTerm(sign, match.Groups["term"].Value, out var term, out error))
+            {
+                return false;
+            }
+
+            terms.Add(term);
+            position += match.Length;
+            isFirst = false;
+        }
+
+        if (terms.Count == 0)
+        {
+            error = $"'{notation}' is not a valid dice expression.";
+            return false;
+        }
+
+        expression = new DiceExpression(BuildNotation(terms), terms);
+        return true;
+    }
+
+    private static bool TryBuildTerm(int sign, string text, out Term term, out string error)
+    {
+        term = null!;
+        error = string.Empty;
+
+        if (HalfDamageBonusPattern.IsMatch(text))
+        {
+            term = new Term(TermKind.HalfDamageBonus, sign, 0, 0, 0);
+            return true;
+        }
+
+        if (DamageBonusPattern.IsMatch(text))
+        {
+            term = new Term(TermKind.DamageBonus, sign, 0, 0, 0);
+            return true;
+        }
+
+        var diceMatch = DicePattern.Match(text);
+        if (diceMatch.Success)
+        {
+            var countText = diceMatch.Groups["count"].Value;
+            long count = 1;
+            if (countText.Length > 0 &&
+                !long.TryParse(countText, NumberStyles.None, CultureInfo.InvariantCulture, out count))
+            {
+                error = $"Dice count '{countText}' is too large.";
+                return false;
+            }
+
+            var sidesText = diceMatch.Groups["sides"].Value;
+            if (!long.TryParse(sidesText, NumberStyles.None, CultureInfo.InvariantCulture, out var sides))
+            {
+                error = $"Die sides '{sidesText}' is too large.";
+                return false;
+            }
+
+            if (count < 1)
+            {
+                error = $"Dice count must be at least 1 (got {count}).";
+                return false;
+            }
+
+            if (count > MaxDiceCount)
+            {
+                error = $"Dice count {count} exceeds the maximum of {MaxDiceCount}.";
+                return false;
+            }
+
+            if (sides < 1 || sides > int.MaxValue)
+            {
+                error = $"A die must have at least 1 side (got {sides}).";
+                return false;
+            }
+
+            term = new Term(TermKind.Dice, sign, (int)count, (int)sides, 0);
+            return true;
+        }
+
+        if (long.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out var constant) &&
+            constant <= int.MaxValue)
+        {
+            term = new Term(TermKind.Constant, sign, 0, 0, (int)constant);
+            return true;
+        }
+
+        error = $"'{text}' is not a recognized dice term.";
+        return false;
+    }
+
+    private static string BuildNotation(IReadOnlyList<Term> terms)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < terms.Count; i++)
+        {
+            var term = terms[i];
+            if (i == 0)
+            {
+                if (term.Sign < 0)
+                {
+                    builder.Append('-');
+                }
+            }
+            else
+            {
+                builder.Append(term.Sign < 0 ? '-' : '+');
+            }
+
+            builder.Append(term.Bare);
+        }
+
+        return builder.ToString();
+    }
+
+    private enum TermKind
+    {
+        Dice,
+        Constant,
+        DamageBonus,
+        HalfDamageBonus,
+    }
+
+    private sealed record Term(TermKind Kind, int Sign, int Count, int Sides, int Constant)
+    {
+        public string Bare => Kind switch
+        {
+            TermKind.Dice => $"{Count}D{Sides}",
+            TermKind.Constant => Constant.ToString(CultureInfo.InvariantCulture),
+            TermKind.DamageBonus => "DB",
+            TermKind.HalfDamageBonus => "DB/2",
+            _ => throw new InvalidOperationException($"Unknown term kind {Kind}."),
+        };
+
+        public DiceTermResult Evaluate(IEntropySource entropy, DiceContext context)
+        {
+            var notation = Sign < 0 ? $"-{Bare}" : Bare;
+
+            switch (Kind)
+            {
+                case TermKind.Dice:
+                    {
+                        var faces = new List<int>(Count);
+                        var sum = 0;
+                        for (var i = 0; i < Count; i++)
+                        {
+                            var face = entropy.NextDie(Sides);
+                            faces.Add(face);
+                            sum += face;
+                        }
+
+                        return new DiceTermResult(notation, Sign * sum, faces);
+                    }
+
+                case TermKind.Constant:
+                    return new DiceTermResult(notation, Sign * Constant, Array.Empty<int>());
+
+                case TermKind.DamageBonus:
+                    {
+                        var (rawTotal, faces) = RollDamageBonus(context.DamageBonus, entropy);
+                        return new DiceTermResult(notation, Sign * rawTotal, faces);
+                    }
+
+                case TermKind.HalfDamageBonus:
+                    {
+                        var (rawTotal, faces) = RollDamageBonus(context.DamageBonus, entropy);
+                        var half = Rounding.Divide(rawTotal, 2, RoundingMode.Up);
+                        return new DiceTermResult(notation, Sign * half, faces);
+                    }
+
+                default:
+                    throw new InvalidOperationException($"Unknown term kind {Kind}.");
+            }
+        }
+
+        private static (int RawTotal, IReadOnlyList<int> Faces) RollDamageBonus(
+            DiceExpression? damageBonus, IEntropySource entropy)
+        {
+            if (damageBonus is null)
+            {
+                return (0, Array.Empty<int>());
+            }
+
+            // A fresh, db-less context: a damage bonus expression referencing "db" itself
+            // (which should not happen in ruleset data) evaluates that inner db as zero
+            // rather than recursing.
+            var roll = damageBonus.Roll(entropy);
+            var faces = roll.Terms.SelectMany(t => t.Faces).ToArray();
+            return (roll.RawTotal, faces);
+        }
+    }
+}

--- a/src/Brp.Core/Dice/DiceRoll.cs
+++ b/src/Brp.Core/Dice/DiceRoll.cs
@@ -1,0 +1,32 @@
+namespace Brp.Core.Dice;
+
+/// <summary>
+/// One evaluated term of a dice expression.
+/// </summary>
+/// <param name="Notation">The term as written, for display and provenance.</param>
+/// <param name="Value">The term's signed contribution to the total.</param>
+/// <param name="Faces">
+/// Individual die faces, in roll order. Empty for constant terms. Exposed because the
+/// UI shows dice and the replay log has to be able to reconstruct exactly what happened,
+/// neither of which a bare total supports.
+/// </param>
+public sealed record DiceTermResult(string Notation, int Value, IReadOnlyList<int> Faces);
+
+/// <summary>
+/// The result of evaluating a dice expression.
+/// </summary>
+/// <param name="Total">
+/// The sum of all terms, floored at zero. The source states that die rolls are never
+/// modified below zero, so a large negative damage modifier yields no damage rather
+/// than healing the target.
+/// </param>
+/// <param name="RawTotal">
+/// The sum before the zero floor is applied. Kept so a test or a log can tell the
+/// difference between "rolled exactly zero" and "rolled negative and was clamped".
+/// </param>
+/// <param name="Terms">Each term's contribution, in written order.</param>
+public sealed record DiceRoll(int Total, int RawTotal, IReadOnlyList<DiceTermResult> Terms)
+{
+    /// <summary>True when the zero floor changed the result.</summary>
+    public bool WasFloored => RawTotal < 0;
+}

--- a/src/Brp.Core/Primitives/Percent.cs
+++ b/src/Brp.Core/Primitives/Percent.cs
@@ -1,0 +1,36 @@
+namespace Brp.Core.Primitives;
+
+/// <summary>
+/// A percentage chance. Floors at zero and is deliberately <em>not</em> capped at 100:
+/// the source's results table extends past 100% and continues by fives, so ratings above
+/// 100 are a supported state rather than an error.
+/// </summary>
+public readonly record struct Percent : IComparable<Percent>
+{
+    /// <summary>The underlying whole-number percentage. Never negative.</summary>
+    public int Value { get; private init; }
+
+    /// <summary>Zero percent.</summary>
+    public static Percent Zero => default;
+
+    /// <summary>Creates a percentage, flooring at zero.</summary>
+    public static Percent Of(int value) => new() { Value = Math.Max(0, value) };
+
+    /// <summary>Adds a signed modifier, flooring at zero.</summary>
+    public Percent Add(int delta) => Of(Value + delta);
+
+    /// <summary>Scales by a rational factor using the given rounding mode.</summary>
+    public Percent Scale(int numerator, int denominator, RoundingMode mode) =>
+        Of(Rounding.Divide(Value * numerator, denominator, mode));
+
+    /// <inheritdoc />
+    public int CompareTo(Percent other) => Value.CompareTo(other.Value);
+
+    /// <inheritdoc />
+    public override string ToString() => $"{Value}%";
+
+    public static bool operator <(Percent left, Percent right) => left.Value < right.Value;
+    public static bool operator >(Percent left, Percent right) => left.Value > right.Value;
+    public static bool operator <=(Percent left, Percent right) => left.Value <= right.Value;
+    public static bool operator >=(Percent left, Percent right) => left.Value >= right.Value;
+}

--- a/src/Brp.Core/Primitives/Rounding.cs
+++ b/src/Brp.Core/Primitives/Rounding.cs
@@ -1,0 +1,48 @@
+namespace Brp.Core.Primitives;
+
+/// <summary>
+/// Named rounding modes. Every formula in the engine states which mode it uses,
+/// because the source book rounds differently in different places and a silent
+/// mismatch is the classic way an engine drifts from its rulebook.
+/// </summary>
+public enum RoundingMode
+{
+    /// <summary>Toward positive infinity for positives; magnitude-preserving for negatives.</summary>
+    Up,
+
+    /// <summary>Toward zero.</summary>
+    Down,
+
+    /// <summary>Nearest, with exact halves going up.</summary>
+    HalfUp,
+}
+
+/// <summary>Applies a <see cref="RoundingMode"/> to integer division.</summary>
+public static class Rounding
+{
+    /// <summary>
+    /// Divides <paramref name="numerator"/> by <paramref name="denominator"/> using the
+    /// given mode. Sign is preserved: rounding operates on the magnitude, so a mode of
+    /// <see cref="RoundingMode.Up"/> makes a negative result more negative, matching the
+    /// intuition that "round up" means "away from zero" when the book applies it to a
+    /// penalty rather than a bonus.
+    /// </summary>
+    public static int Divide(int numerator, int denominator, RoundingMode mode)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(denominator);
+
+        var negative = (numerator < 0) ^ (denominator < 0);
+        var a = Math.Abs((long)numerator);
+        var b = Math.Abs((long)denominator);
+
+        var magnitude = mode switch
+        {
+            RoundingMode.Up => (a + b - 1) / b,
+            RoundingMode.Down => a / b,
+            RoundingMode.HalfUp => (2 * a + b) / (2 * b),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode)),
+        };
+
+        return (int)(negative ? -magnitude : magnitude);
+    }
+}

--- a/src/Brp.Core/Randomness/EntropyState.cs
+++ b/src/Brp.Core/Randomness/EntropyState.cs
@@ -1,0 +1,13 @@
+namespace Brp.Core.Randomness;
+
+/// <summary>
+/// A snapshot of an <see cref="IEntropySource"/>'s internal state, plus how many draws
+/// it has served. Capturing and restoring this is what makes a save file replay the same
+/// rolls, which is the mechanism behind the pre-seeded roll policy.
+/// </summary>
+/// <param name="S0">Generator word 0.</param>
+/// <param name="S1">Generator word 1.</param>
+/// <param name="S2">Generator word 2.</param>
+/// <param name="S3">Generator word 3.</param>
+/// <param name="DrawCount">Number of raw draws served since seeding.</param>
+public readonly record struct EntropyState(ulong S0, ulong S1, ulong S2, ulong S3, long DrawCount);

--- a/src/Brp.Core/Randomness/IEntropySource.cs
+++ b/src/Brp.Core/Randomness/IEntropySource.cs
@@ -1,0 +1,29 @@
+namespace Brp.Core.Randomness;
+
+/// <summary>
+/// The only way randomness enters the engine. Implementations must be deterministic:
+/// the same seed followed by the same call sequence must produce identical results.
+/// <c>System.Random</c> is banned project-wide, both because it hides state and because
+/// its algorithm is not contractually stable across runtimes -- an upgrade could silently
+/// change every roll in every save file.
+/// </summary>
+public interface IEntropySource
+{
+    /// <summary>Number of raw draws served since seeding. Useful for logging and replay.</summary>
+    long DrawCount { get; }
+
+    /// <summary>Rolls a single die, returning a value in <c>[1, sides]</c> inclusive.</summary>
+    int NextDie(int sides);
+
+    /// <summary>
+    /// Rolls percentile dice, returning a value in <c>[1, 100]</c>. The book reads a
+    /// percentile result of 00 as 100, so this never returns zero.
+    /// </summary>
+    int NextD100();
+
+    /// <summary>Captures the current state for later restoration.</summary>
+    EntropyState Capture();
+
+    /// <summary>Restores a previously captured state, resuming the identical sequence.</summary>
+    void Restore(EntropyState state);
+}

--- a/src/Brp.Core/Randomness/Xoshiro256StarStar.cs
+++ b/src/Brp.Core/Randomness/Xoshiro256StarStar.cs
@@ -1,0 +1,96 @@
+using System.Numerics;
+
+namespace Brp.Core.Randomness;
+
+/// <summary>
+/// xoshiro256** generator, seeded through SplitMix64.
+/// <para>
+/// Chosen because the algorithm is fixed and published, so a given seed produces the same
+/// stream forever regardless of runtime version. That is the property save-file replay
+/// depends on, and the property <c>System.Random</c> does not offer.
+/// </para>
+/// </summary>
+public sealed class Xoshiro256StarStar : IEntropySource
+{
+    private ulong _s0, _s1, _s2, _s3;
+
+    /// <summary>Creates a generator from a 64-bit seed.</summary>
+    public Xoshiro256StarStar(ulong seed)
+    {
+        // SplitMix64 expands one seed word into four, avoiding the all-zero state and
+        // the poor early output xoshiro shows when seeded with mostly-zero words.
+        var z = seed;
+        _s0 = SplitMix64(ref z);
+        _s1 = SplitMix64(ref z);
+        _s2 = SplitMix64(ref z);
+        _s3 = SplitMix64(ref z);
+    }
+
+    /// <inheritdoc />
+    public long DrawCount { get; private set; }
+
+    private static ulong SplitMix64(ref ulong z)
+    {
+        z += 0x9E3779B97F4A7C15UL;
+        var result = z;
+        result = (result ^ (result >> 30)) * 0xBF58476D1CE4E5B9UL;
+        result = (result ^ (result >> 27)) * 0x94D049BB133111EBUL;
+        return result ^ (result >> 31);
+    }
+
+    private ulong NextUInt64()
+    {
+        var result = BitOperations.RotateLeft(_s1 * 5, 7) * 9;
+
+        var t = _s1 << 17;
+        _s2 ^= _s0;
+        _s3 ^= _s1;
+        _s1 ^= _s2;
+        _s0 ^= _s3;
+        _s2 ^= t;
+        _s3 = BitOperations.RotateLeft(_s3, 45);
+
+        DrawCount++;
+        return result;
+    }
+
+    /// <inheritdoc />
+    public int NextDie(int sides)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(sides, 1);
+        if (sides == 1)
+        {
+            return 1;
+        }
+
+        // Rejection sampling. The naive `value % sides` is biased toward low faces
+        // because 2^64 is not a multiple of most die sizes; on a d6 that skew is small
+        // but it is real, and a rules engine should not ship a loaded die.
+        var n = (ulong)sides;
+        var threshold = unchecked((ulong)-(long)n) % n; // 2^64 mod n
+        ulong draw;
+        do
+        {
+            draw = NextUInt64();
+        }
+        while (draw < threshold);
+
+        return (int)(draw % n) + 1;
+    }
+
+    /// <inheritdoc />
+    public int NextD100() => NextDie(100);
+
+    /// <inheritdoc />
+    public EntropyState Capture() => new(_s0, _s1, _s2, _s3, DrawCount);
+
+    /// <inheritdoc />
+    public void Restore(EntropyState state)
+    {
+        _s0 = state.S0;
+        _s1 = state.S1;
+        _s2 = state.S2;
+        _s3 = state.S3;
+        DrawCount = state.DrawCount;
+    }
+}

--- a/tests/Brp.Core.Tests/ArchitectureTests.cs
+++ b/tests/Brp.Core.Tests/ArchitectureTests.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using Brp.Core;
+using Brp.Core.Randomness;
 
 namespace Brp.Core.Tests;
 
@@ -10,7 +10,7 @@ namespace Brp.Core.Tests;
 /// </summary>
 public class ArchitectureTests
 {
-    private static readonly Assembly Core = typeof(AssemblyMarker).Assembly;
+    private static readonly Assembly Core = typeof(IEntropySource).Assembly;
 
     [Theory]
     [InlineData("UnityEngine")]

--- a/tests/Brp.Core.Tests/Dice/DiceExpressionTests.cs
+++ b/tests/Brp.Core.Tests/Dice/DiceExpressionTests.cs
@@ -1,0 +1,353 @@
+using Brp.Core.Dice;
+using Brp.Core.Randomness;
+
+namespace Brp.Core.Tests.Dice;
+
+public class DiceExpressionTests
+{
+    // Every notation form the in-scope rules use (per Issue #9), with its valid Total range
+    // when rolled with no damage bonus in context.
+    public static TheoryData<string, int, int> ValidNotationRanges => new()
+    {
+        { "3D6", 3, 18 },
+        { "2D6+6", 8, 18 },
+        { "1D8", 1, 8 },
+        { "1D3", 1, 3 },
+        { "2D8", 2, 16 },
+        { "1D10", 1, 10 },
+        { "1D100", 1, 100 },
+        { "1D8+2", 3, 10 },
+        { "1D6+1", 2, 7 },
+        { "1D10+3", 4, 13 },
+        { "2D6+2", 4, 14 },
+        { "1D3+1", 2, 4 },
+        { "1D6-2", 0, 4 }, // floors at zero, so the low end is 0 rather than -1
+        { "1D10+1D4", 2, 14 },
+        { "D6", 1, 6 }, // omitted count means 1
+        { "d6", 1, 6 }, // case-insensitive
+        { "3d6", 3, 18 }, // case-insensitive with a count
+        { " 3 D 6 + 2 ", 5, 20 }, // whitespace-tolerant
+        { "+1D6", 1, 6 }, // leading sign allowed
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidNotationRanges))]
+    public void Notation_forms_parse_and_evaluate_in_range(string notation, int min, int max)
+    {
+        var expression = DiceExpression.Parse(notation);
+        IEntropySource entropy = new Xoshiro256StarStar(seed: 1);
+
+        for (var i = 0; i < 200; i++)
+        {
+            var roll = expression.Roll(entropy);
+            Assert.InRange(roll.Total, min, max);
+        }
+    }
+
+    [Fact]
+    public void Db_with_no_damage_bonus_in_context_evaluates_to_zero()
+    {
+        var expression = DiceExpression.Parse("1D8+2+db");
+        IEntropySource entropy = new Xoshiro256StarStar(seed: 7);
+
+        for (var i = 0; i < 200; i++)
+        {
+            var roll = expression.Roll(entropy);
+            Assert.InRange(roll.Total, 3, 10);
+
+            var dbTerm = roll.Terms[^1];
+            Assert.Equal(0, dbTerm.Value);
+            Assert.Empty(dbTerm.Faces);
+        }
+    }
+
+    [Fact]
+    public void Db_with_damage_bonus_in_context_is_added()
+    {
+        var expression = DiceExpression.Parse("1D8+2+db");
+        var damageBonus = DiceExpression.Parse("1D4");
+        var context = new DiceContext(damageBonus);
+        IEntropySource entropy = new Xoshiro256StarStar(seed: 7);
+
+        for (var i = 0; i < 200; i++)
+        {
+            var roll = expression.Roll(entropy, context);
+            Assert.InRange(roll.Total, 4, 14);
+        }
+    }
+
+    [Theory]
+    [InlineData("½db")]
+    [InlineData("db/2")]
+    [InlineData("DB/2")]
+    public void Half_damage_bonus_forms_round_a_positive_modifier_up(string notation)
+    {
+        var expression = DiceExpression.Parse(notation);
+
+        // A constant-only damage bonus needs no entropy to evaluate, keeping the halving
+        // arithmetic isolated from die rolls.
+        var context = new DiceContext(DiceExpression.Parse("5"));
+        IEntropySource entropy = new Xoshiro256StarStar(seed: 3);
+
+        Assert.Equal(3, expression.Roll(entropy, context).Total); // ceil(5/2) = 3
+    }
+
+    [Fact]
+    public void Half_damage_bonus_of_a_negative_modifier_rounds_up_in_magnitude_before_flooring()
+    {
+        var expression = DiceExpression.Parse("db/2");
+        var context = new DiceContext(DiceExpression.Parse("-3"));
+        IEntropySource entropy = new Xoshiro256StarStar(seed: 3);
+
+        var roll = expression.Roll(entropy, context);
+
+        // -3 halved, rounding the magnitude up, is -2 (not -1). The Total then floors at
+        // zero, but RawTotal must show the true -2 so the two behaviors are distinguishable.
+        Assert.Equal(-2, roll.RawTotal);
+        Assert.Equal(0, roll.Total);
+        Assert.True(roll.WasFloored);
+    }
+
+    [Fact]
+    public void Db_and_half_db_forms_agree_given_the_same_damage_bonus_and_entropy()
+    {
+        var dbHalf1 = DiceExpression.Parse("½db");
+        var dbHalf2 = DiceExpression.Parse("db/2");
+        var damageBonus = DiceExpression.Parse("2D4");
+        var context = new DiceContext(damageBonus);
+
+        for (var seed = 0; seed < 50; seed++)
+        {
+            IEntropySource entropyA = new Xoshiro256StarStar((ulong)seed);
+            IEntropySource entropyB = new Xoshiro256StarStar((ulong)seed);
+
+            var rollA = dbHalf1.Roll(entropyA, context);
+            var rollB = dbHalf2.Roll(entropyB, context);
+
+            Assert.Equal(rollA.Total, rollB.Total);
+            Assert.Equal(rollA.RawTotal, rollB.RawTotal);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidNotationRanges))]
+    public void Notation_round_trips_through_parse_and_render(string notation, int min, int max)
+    {
+        Assert.True(min <= max); // sanity check on the shared theory data, not the behavior under test
+
+        var once = DiceExpression.Parse(notation).Notation;
+        var twice = DiceExpression.Parse(once).Notation;
+
+        Assert.Equal(once, twice);
+    }
+
+    [Theory]
+    [InlineData("d6", "1D6")]
+    [InlineData("D6", "1D6")]
+    [InlineData("3d6", "3D6")]
+    [InlineData(" 1d8 + 2 ", "1D8+2")]
+    [InlineData("+1D6", "1D6")]
+    [InlineData("-1D6", "-1D6")]
+    [InlineData("1D6-2", "1D6-2")]
+    [InlineData("½db", "DB/2")]
+    [InlineData("db/2", "DB/2")]
+    [InlineData("DB", "DB")]
+    [InlineData("db", "DB")]
+    [InlineData("1D8+2+db", "1D8+2+DB")]
+    public void Notation_normalizes_as_expected(string notation, string expectedNotation)
+    {
+        Assert.Equal(expectedNotation, DiceExpression.Parse(notation).Notation);
+    }
+
+    [Fact]
+    public void Negative_modifier_driving_below_zero_floors_the_total_but_keeps_a_negative_RawTotal()
+    {
+        var expression = DiceExpression.Parse("1D6-2");
+        IEntropySource entropy = new FixedEntropySource(1); // 1 - 2 = -1
+
+        var roll = expression.Roll(entropy);
+
+        Assert.Equal(0, roll.Total);
+        Assert.Equal(-1, roll.RawTotal);
+        Assert.True(roll.WasFloored);
+    }
+
+    [Fact]
+    public void A_result_that_does_not_go_negative_is_not_marked_as_floored()
+    {
+        var expression = DiceExpression.Parse("1D6-2");
+        IEntropySource entropy = new FixedEntropySource(6); // 6 - 2 = 4
+
+        var roll = expression.Roll(entropy);
+
+        Assert.Equal(4, roll.Total);
+        Assert.Equal(4, roll.RawTotal);
+        Assert.False(roll.WasFloored);
+    }
+
+    [Fact]
+    public void Individual_faces_are_recoverable_and_consistent_with_the_term_value()
+    {
+        var expression = DiceExpression.Parse("3D6");
+        IEntropySource entropy = new FixedEntropySource(2, 3, 4);
+
+        var roll = expression.Roll(entropy);
+        var term = Assert.Single(roll.Terms);
+
+        int[] expectedFaces = [2, 3, 4];
+        Assert.Equal(expectedFaces, term.Faces);
+        Assert.Equal(9, term.Value);
+        Assert.Equal(9, roll.Total);
+        Assert.Equal(9, roll.RawTotal);
+    }
+
+    [Fact]
+    public void A_negative_dice_term_keeps_positive_faces_but_a_negative_value()
+    {
+        var expression = DiceExpression.Parse("-1D6");
+        IEntropySource entropy = new FixedEntropySource(5);
+
+        var roll = expression.Roll(entropy);
+        var term = Assert.Single(roll.Terms);
+
+        int[] expectedFaces = [5];
+        Assert.Equal(expectedFaces, term.Faces);
+        Assert.Equal(-5, term.Value);
+        Assert.Equal(-5, roll.RawTotal);
+        Assert.Equal(0, roll.Total);
+    }
+
+    [Fact]
+    public void Db_term_propagates_the_underlying_dice_faces_in_roll_order()
+    {
+        var expression = DiceExpression.Parse("1D8+2+db");
+        var damageBonus = DiceExpression.Parse("1D4");
+        var context = new DiceContext(damageBonus);
+        IEntropySource entropy = new FixedEntropySource(5, 3); // 1D8 -> 5, then the db's 1D4 -> 3
+
+        var roll = expression.Roll(entropy, context);
+
+        int[] diceFaces = [5];
+        int[] damageBonusFaces = [3];
+        Assert.Equal(diceFaces, roll.Terms[0].Faces);
+        Assert.Empty(roll.Terms[1].Faces);
+        Assert.Equal(damageBonusFaces, roll.Terms[2].Faces);
+        Assert.Equal(3, roll.Terms[2].Value);
+        Assert.Equal(10, roll.Total); // 5 + 2 + 3
+    }
+
+    [Fact]
+    public void Half_db_term_propagates_the_underlying_dice_faces()
+    {
+        var expression = DiceExpression.Parse("½db");
+        var damageBonus = DiceExpression.Parse("2D4");
+        var context = new DiceContext(damageBonus);
+        IEntropySource entropy = new FixedEntropySource(1, 4); // db rolls to 1 + 4 = 5
+
+        var roll = expression.Roll(entropy, context);
+        var term = Assert.Single(roll.Terms);
+
+        int[] expectedFaces = [1, 4];
+        Assert.Equal(expectedFaces, term.Faces);
+        Assert.Equal(3, term.Value); // ceil(5 / 2)
+    }
+
+    [Fact]
+    public void Same_seed_and_call_sequence_produces_an_identical_roll_sequence()
+    {
+        var expression = DiceExpression.Parse("3D6+1D4+db");
+        var context = new DiceContext(DiceExpression.Parse("1D4"));
+
+        IEntropySource entropyA = new Xoshiro256StarStar(seed: 2468);
+        IEntropySource entropyB = new Xoshiro256StarStar(seed: 2468);
+
+        for (var i = 0; i < 300; i++)
+        {
+            var rollA = expression.Roll(entropyA, context);
+            var rollB = expression.Roll(entropyB, context);
+
+            Assert.Equal(rollA.Total, rollB.Total);
+            Assert.Equal(rollA.RawTotal, rollB.RawTotal);
+            Assert.Equal(
+                rollA.Terms.SelectMany(t => t.Faces),
+                rollB.Terms.SelectMany(t => t.Faces));
+        }
+    }
+
+    [Fact]
+    public void Capture_and_restore_mid_sequence_resumes_an_identical_roll_sequence()
+    {
+        var expression = DiceExpression.Parse("2D6+1D8+db");
+        var context = new DiceContext(DiceExpression.Parse("1D4-1"));
+        var entropy = new Xoshiro256StarStar(seed: 909);
+
+        for (var i = 0; i < 50; i++)
+        {
+            expression.Roll(entropy, context);
+        }
+
+        var checkpoint = entropy.Capture();
+
+        var continuedA = new List<(int Total, int RawTotal)>();
+        for (var i = 0; i < 100; i++)
+        {
+            var roll = expression.Roll(entropy, context);
+            continuedA.Add((roll.Total, roll.RawTotal));
+        }
+
+        entropy.Restore(checkpoint);
+
+        var continuedB = new List<(int Total, int RawTotal)>();
+        for (var i = 0; i < 100; i++)
+        {
+            var roll = expression.Roll(entropy, context);
+            continuedB.Add((roll.Total, roll.RawTotal));
+        }
+
+        Assert.Equal(continuedA, continuedB);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("1D")]
+    [InlineData("D")]
+    [InlineData("0D6")]
+    [InlineData("1D0")]
+    [InlineData("1001D6")]
+    [InlineData("1D6+")]
+    [InlineData("++1D6")]
+    [InlineData("1D6++2")]
+    [InlineData("1D6*2")]
+    [InlineData("sdb")]
+    [InlineData("1.5D6")]
+    [InlineData("-")]
+    public void Invalid_notation_fails_TryParse_and_throws_on_Parse(string notation)
+    {
+        Assert.False(DiceExpression.TryParse(notation, out var expression));
+        Assert.Null(expression);
+        Assert.Throws<FormatException>(() => DiceExpression.Parse(notation));
+    }
+
+    [Fact]
+    public void Parse_throws_null_for_null_notation()
+    {
+        Assert.Throws<FormatException>(() => DiceExpression.Parse(null!));
+        Assert.False(DiceExpression.TryParse(null!, out _));
+    }
+
+    [Fact]
+    public void Exceeding_the_dice_count_cap_names_the_cap_in_the_message()
+    {
+        var exception = Assert.Throws<FormatException>(() => DiceExpression.Parse("1001D6"));
+        Assert.Contains("1000", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Roll_rejects_a_null_entropy_source()
+    {
+        var expression = DiceExpression.Parse("1D6");
+        Assert.Throws<ArgumentNullException>(() => expression.Roll(null!));
+    }
+}

--- a/tests/Brp.Core.Tests/Dice/FixedEntropySource.cs
+++ b/tests/Brp.Core.Tests/Dice/FixedEntropySource.cs
@@ -1,0 +1,41 @@
+using Brp.Core.Randomness;
+
+namespace Brp.Core.Tests.Dice;
+
+/// <summary>
+/// A test double that serves a pre-scripted sequence of die faces instead of generating them.
+/// Used where a test needs to pin exact faces (to check floor/rounding/face-recovery behavior)
+/// rather than merely asserting a value falls in range.
+/// </summary>
+internal sealed class FixedEntropySource : IEntropySource
+{
+    private readonly Queue<int> _values;
+
+    public FixedEntropySource(params int[] values) => _values = new Queue<int>(values);
+
+    public long DrawCount { get; private set; }
+
+    public int NextDie(int sides)
+    {
+        if (_values.Count == 0)
+        {
+            throw new InvalidOperationException("FixedEntropySource has no more scripted values.");
+        }
+
+        DrawCount++;
+        var value = _values.Dequeue();
+        if (value < 1 || value > sides)
+        {
+            throw new InvalidOperationException(
+                $"Scripted value {value} is out of range for a d{sides}.");
+        }
+
+        return value;
+    }
+
+    public int NextD100() => NextDie(100);
+
+    public EntropyState Capture() => new(0, 0, 0, 0, DrawCount);
+
+    public void Restore(EntropyState state) => DrawCount = state.DrawCount;
+}

--- a/tests/Brp.Core.Tests/Primitives/PercentTests.cs
+++ b/tests/Brp.Core.Tests/Primitives/PercentTests.cs
@@ -1,0 +1,64 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Tests.Primitives;
+
+public class PercentTests
+{
+    [Theory]
+    [InlineData(-50, 0)]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(37, 37)]
+    [InlineData(100, 100)]
+    [InlineData(150, 150)] // the source's results table continues past 100%
+    public void Of_floors_at_zero_and_permits_values_above_100(int input, int expected)
+    {
+        Assert.Equal(expected, Percent.Of(input).Value);
+    }
+
+    [Fact]
+    public void Zero_is_the_default_value()
+    {
+        Assert.Equal(0, Percent.Zero.Value);
+        Assert.Equal(default, Percent.Zero);
+    }
+
+    [Theory]
+    [InlineData(50, 10, 60)]
+    [InlineData(50, -60, 0)] // floors at zero rather than going negative
+    [InlineData(0, -5, 0)]
+    [InlineData(100, 20, 120)] // above 100 is a supported state
+    public void Add_applies_a_signed_delta_and_floors_at_zero(int start, int delta, int expected)
+    {
+        Assert.Equal(expected, Percent.Of(start).Add(delta).Value);
+    }
+
+    [Fact]
+    public void Scale_uses_the_given_rounding_mode()
+    {
+        Assert.Equal(50, Percent.Of(100).Scale(1, 2, RoundingMode.Up).Value);
+        Assert.Equal(51, Percent.Of(101).Scale(1, 2, RoundingMode.Up).Value); // ceil(50.5)
+        Assert.Equal(50, Percent.Of(101).Scale(1, 2, RoundingMode.Down).Value); // floor(50.5)
+    }
+
+    [Fact]
+    public void Comparison_operators_and_CompareTo_order_by_value()
+    {
+        var low = Percent.Of(10);
+        var high = Percent.Of(90);
+
+        Assert.True(low < high);
+        Assert.True(high > low);
+        Assert.True(low <= Percent.Of(10));
+        Assert.True(high >= Percent.Of(90));
+        Assert.True(low.CompareTo(high) < 0);
+        Assert.True(high.CompareTo(low) > 0);
+        Assert.Equal(0, low.CompareTo(Percent.Of(10)));
+    }
+
+    [Fact]
+    public void ToString_renders_a_percent_sign()
+    {
+        Assert.Equal("42%", Percent.Of(42).ToString());
+    }
+}

--- a/tests/Brp.Core.Tests/Primitives/RoundingTests.cs
+++ b/tests/Brp.Core.Tests/Primitives/RoundingTests.cs
@@ -1,0 +1,55 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Tests.Primitives;
+
+public class RoundingTests
+{
+    [Theory]
+    [InlineData(7, 2, 4)] // 3.5 -> 4
+    [InlineData(6, 2, 3)] // exact
+    [InlineData(-7, 2, -4)] // -3.5 -> -4 (away from zero)
+    [InlineData(-6, 2, -3)] // exact, negative
+    [InlineData(1, 3, 1)] // 0.33 -> 1
+    [InlineData(0, 5, 0)]
+    [InlineData(7, -2, -4)] // negative denominator: sign still preserved, magnitude rounds up
+    [InlineData(-7, -2, 4)] // double negative -> positive
+    public void Up_rounds_away_from_zero(int numerator, int denominator, int expected)
+    {
+        Assert.Equal(expected, Rounding.Divide(numerator, denominator, RoundingMode.Up));
+    }
+
+    [Theory]
+    [InlineData(7, 2, 3)] // 3.5 -> 3
+    [InlineData(6, 2, 3)] // exact
+    [InlineData(-7, 2, -3)] // -3.5 -> -3 (toward zero)
+    [InlineData(-6, 2, -3)]
+    [InlineData(1, 3, 0)] // 0.33 -> 0
+    [InlineData(0, 5, 0)]
+    public void Down_rounds_toward_zero(int numerator, int denominator, int expected)
+    {
+        Assert.Equal(expected, Rounding.Divide(numerator, denominator, RoundingMode.Down));
+    }
+
+    [Theory]
+    [InlineData(5, 2, 3)] // 2.5 -> 3 (half goes up)
+    [InlineData(-5, 2, -3)] // -2.5 -> -3 (half goes up in magnitude)
+    [InlineData(4, 2, 2)] // exact
+    [InlineData(7, 2, 4)] // 3.5 -> 4
+    [InlineData(-7, 2, -4)] // -3.5 -> -4
+    [InlineData(6, 4, 2)] // 1.5 -> 2
+    [InlineData(1, 4, 0)] // 0.25 -> 0
+    [InlineData(0, 5, 0)]
+    public void HalfUp_rounds_to_nearest_with_exact_halves_up(int numerator, int denominator, int expected)
+    {
+        Assert.Equal(expected, Rounding.Divide(numerator, denominator, RoundingMode.HalfUp));
+    }
+
+    [Theory]
+    [InlineData(RoundingMode.Up)]
+    [InlineData(RoundingMode.Down)]
+    [InlineData(RoundingMode.HalfUp)]
+    public void Divide_by_zero_throws(RoundingMode mode)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Rounding.Divide(5, 0, mode));
+    }
+}

--- a/tests/Brp.Core.Tests/Randomness/Xoshiro256StarStarTests.cs
+++ b/tests/Brp.Core.Tests/Randomness/Xoshiro256StarStarTests.cs
@@ -1,0 +1,141 @@
+using Brp.Core.Randomness;
+
+namespace Brp.Core.Tests.Randomness;
+
+public class Xoshiro256StarStarTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(6)]
+    [InlineData(8)]
+    [InlineData(10)]
+    [InlineData(12)]
+    [InlineData(20)]
+    [InlineData(100)]
+    public void NextDie_only_ever_returns_values_in_range(int sides)
+    {
+        var entropy = new Xoshiro256StarStar(seed: 12345);
+
+        for (var i = 0; i < 5000; i++)
+        {
+            var face = entropy.NextDie(sides);
+            Assert.InRange(face, 1, sides);
+        }
+    }
+
+    [Fact]
+    public void NextDie_with_one_side_always_returns_one()
+    {
+        var entropy = new Xoshiro256StarStar(seed: 999);
+
+        for (var i = 0; i < 50; i++)
+        {
+            Assert.Equal(1, entropy.NextDie(1));
+        }
+    }
+
+    [Fact]
+    public void NextDie_rejects_non_positive_sides()
+    {
+        var entropy = new Xoshiro256StarStar(seed: 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => entropy.NextDie(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => entropy.NextDie(-6));
+    }
+
+    [Fact]
+    public void NextD100_only_ever_returns_1_through_100()
+    {
+        var entropy = new Xoshiro256StarStar(seed: 424242);
+
+        for (var i = 0; i < 5000; i++)
+        {
+            Assert.InRange(entropy.NextD100(), 1, 100);
+        }
+    }
+
+    [Fact]
+    public void Same_seed_and_call_sequence_reproduces_an_identical_long_sequence()
+    {
+        var first = new Xoshiro256StarStar(seed: 77);
+        var second = new Xoshiro256StarStar(seed: 77);
+
+        var firstSequence = new List<int>();
+        var secondSequence = new List<int>();
+
+        for (var i = 0; i < 1000; i++)
+        {
+            // Vary the call shape (mixed die sizes and d100 reads) so the assertion covers
+            // more than "the same die repeated" -- the whole call sequence must line up.
+            firstSequence.Add(i % 5 == 0 ? first.NextD100() : first.NextDie((i % 20) + 1));
+            secondSequence.Add(i % 5 == 0 ? second.NextD100() : second.NextDie((i % 20) + 1));
+        }
+
+        Assert.Equal(firstSequence, secondSequence);
+        Assert.Equal(first.DrawCount, second.DrawCount);
+    }
+
+    [Fact]
+    public void Different_seeds_produce_different_sequences()
+    {
+        var first = new Xoshiro256StarStar(seed: 1);
+        var second = new Xoshiro256StarStar(seed: 2);
+
+        var firstSequence = Enumerable.Range(0, 50).Select(_ => first.NextDie(1_000_000)).ToList();
+        var secondSequence = Enumerable.Range(0, 50).Select(_ => second.NextDie(1_000_000)).ToList();
+
+        Assert.NotEqual(firstSequence, secondSequence);
+    }
+
+    [Fact]
+    public void Capture_and_restore_mid_sequence_resumes_identically()
+    {
+        var source = new Xoshiro256StarStar(seed: 2024);
+
+        for (var i = 0; i < 37; i++)
+        {
+            source.NextDie((i % 10) + 2);
+        }
+
+        var checkpoint = source.Capture();
+
+        var continuedA = new List<int>();
+        for (var i = 0; i < 200; i++)
+        {
+            continuedA.Add(i % 7 == 0 ? source.NextD100() : source.NextDie((i % 12) + 2));
+        }
+
+        source.Restore(checkpoint);
+
+        var continuedB = new List<int>();
+        for (var i = 0; i < 200; i++)
+        {
+            continuedB.Add(i % 7 == 0 ? source.NextD100() : source.NextDie((i % 12) + 2));
+        }
+
+        Assert.Equal(continuedA, continuedB);
+    }
+
+    [Fact]
+    public void Capture_returns_the_current_draw_count_and_restore_reinstates_it()
+    {
+        var source = new Xoshiro256StarStar(seed: 55);
+
+        for (var i = 0; i < 25; i++)
+        {
+            source.NextDie(6);
+        }
+
+        var checkpoint = source.Capture();
+        Assert.Equal(checkpoint.DrawCount, source.DrawCount);
+
+        source.NextDie(6);
+        Assert.NotEqual(checkpoint.DrawCount, source.DrawCount);
+
+        source.Restore(checkpoint);
+        Assert.Equal(checkpoint.DrawCount, source.DrawCount);
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #9

## Exact behavioral claim

Randomness enters the engine through exactly one injected, seedable, serializable
interface, and the dice notation the in-scope rules use can be parsed and evaluated
with individual die faces preserved.

This is what makes pre-seeded rolls, save-file replay, regression tests over a
stochastic system, and balance simulation possible. Without it none of Layer 0's
consumers can be tested at all.

## Scope

**Added:** `Primitives/` (`Percent`, `Rounding`), `Randomness/` (`IEntropySource`,
`EntropyState`, `Xoshiro256StarStar`), `Dice/` (`DiceExpression`, `DiceContext`,
`DiceRoll`, `DiceTermResult`), and five test files.

**Removed:** `AssemblyMarker` — `ArchitectureTests` now anchors on `IEntropySource`,
a real type, rather than a placeholder.

**Deliberately not included:** grading a roll into success levels (#10), any
modifier pipeline (#11), any characteristic or skill concept.

## Rules conformance

Notation forms and the zero-floor rule come from the source's dice conventions; the
damage-modifier tokens from its damage rules. No table-backed rule is implemented
here, so there is no conformance fixture to reproduce — that starts at #10.

`scope-warden` gate: **all seven items pass.** No out-of-scope content, no reference
to the superseded source, no banned APIs, no engine dependency.

## Tests and evidence

```
dotnet build   -> Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test    -> Passed! Failed: 0, Passed: 144, Skipped: 0, Total: 144
dotnet format --verify-no-changes -> clean (exit 0)
```

Verified independently of the implementing agent's report.

## Decisions and tradeoffs

**Xoshiro256** rather than `System.Random`.** Two reasons, and the second is the one
that matters: `System.Random` is banned by our own analyzer, but more importantly its
algorithm is not contractually stable across runtimes. A framework upgrade could
silently change every roll in every existing save file. A published, fixed algorithm
cannot.

**Rejection sampling for die rolls.** Naive `value % sides` is biased toward low
faces because 2^64 is not a multiple of most die sizes. The skew is tiny on a d6, but
a rules engine should not ship a loaded die.

**Damage-bonus terms contribute `RawTotal`, not `Total`.** Reviewed this one closely
because it is easy to get backwards. If the nested roll's floored total were used, a
negative damage modifier such as `-1D6` would contribute 0 instead of subtracting —
silently deleting the rule. Only the outer total floors at zero. Covered by a test
asserting that half of a −3 modifier is −2, not −1, since rounding is
magnitude-preserving.

**`Notation` is a fixed point, not a literal round-trip.** `Parse(x).Notation` need
not equal `x`, but re-parsing it is stable. Canonical form uppercases `D`, makes
counts explicit, and renders both `½db` and `db/2` as `DB/2` for ASCII diffability.

**A recursion guard on `db`.** A malformed damage-bonus expression that itself
references `db` evaluates the inner token as zero rather than looping.

## Known limitations

- `Percent.Scale` and the `Rounding` modes exist but nothing consumes them yet; they
  land properly with the modifier pipeline in #11.
- No `IEntropySource` implementation is wired to a save file yet. `Capture`/`Restore`
  is tested in isolation; the pre-seeded roll policy is built on it but not built here.
- Dice count is capped at 1000. Arbitrary, but it turns a pathological input into a
  clear `FormatException` rather than a hang.

## Agent provenance

Implemented by the `engine-dev` agent (Sonnet, medium effort) per `docs/agent-team.md`
routing, gated by `scope-warden` (Haiku, low effort). Damage-bonus semantics and the
verification commands were reviewed independently by Claude Opus 5 before commit.

First real datapoint for ADR 0004's measurement request: ~128k subagent tokens on
Sonnet plus ~52k on Haiku, for work that would otherwise have run at Opus in the main
loop.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).