### PR TITLE
Brief agents with the diff instead of making them find it (#18)

### DIFF
--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -70,6 +70,38 @@ Issue (ready)
 For non-rules work — tooling, CLI, docs, case data — stop after `scope-warden`. The
 expensive verification layers exist for one specific risk and buy nothing elsewhere.
 
+## Briefing agents efficiently
+
+Routing to the right model is only half the saving. The other half is not making the
+agent spend its context rediscovering things you already know.
+
+Measured on #9, where `scope-warden` spent ~52k tokens on a diff worth ~12k. The
+remaining ~40k went to *locating* the change across 28 tool calls and re-reading its
+own contract — not to reading the code.
+
+**Hand the agent the diff. Do not make it assemble one.** Put the output of
+`git diff` (or the file list) directly in the prompt. Discovery turns are the single
+largest avoidable cost in a review agent.
+
+**Use `-U1` for review diffs.** It is free and it trims four lines of context per
+hunk on edit-heavy changes. Do not expect much on commits that are mostly new files —
+git prints added files in full regardless of the context setting, so `-U1` saved
+0.24% on #9 and would have saved far more on a scattered refactor. Reach for `-U0`
+only when the agent is pattern-matching rather than reading for meaning.
+
+**For a pure pattern checklist, skip the diff entirely.** `scope-warden` answers
+questions of the form "does this banned token appear". `git grep` over the changed
+paths answers those far more cheaply than reading any diff, and without the risk of a
+hunk boundary hiding a match.
+
+**Scope what the agent must read.** Name the files it needs. An agent told to "check
+the change" will read the contract, the scope filter, the plan, and then go looking;
+an agent given the diff and one checklist reads two things.
+
+**Say what is already done.** Listing the completed pieces of an Issue, and stating
+plainly not to restructure them, prevents the agent from re-deriving decisions that
+are already settled — and from politely rewriting working code.
+
 ## What this is expected to save
 
 The guide this workflow follows estimates 35-60% token reduction per completed task
@@ -81,3 +113,13 @@ would allow.
 Measure it rather than assuming it. Track, over ten tasks: agent turns from task
 selection to merged PR, clarification questions asked, and tasks reopened because
 acceptance criteria were incomplete.
+
+### Datapoints so far
+
+| Task | Agents | Subagent tokens | Outcome |
+|---|---|---:|---|
+| #9 entropy and dice | `engine-dev` (Sonnet), `scope-warden` (Haiku) | ~128k + ~52k | Merged first try; 144 tests; no rework |
+
+Both would otherwise have run at Opus in the main loop. Note the `scope-warden` cost
+is inflated by the briefing problem described above and should fall substantially
+once the diff is passed in rather than discovered.

--- a/tools/codex-agent.sh
+++ b/tools/codex-agent.sh
@@ -10,7 +10,8 @@
 #
 # Usage:
 #   tools/codex-agent.sh conformance "Verify the Skill Results Table implementation"
-#   tools/codex-agent.sh review
+#   tools/codex-agent.sh review                       # diff vs origin/main
+#   BASE=origin/main tools/codex-agent.sh review      # override the base
 #   tools/codex-agent.sh simcheck "Re-derive the advancement math independently"
 #   DRY_RUN=1 tools/codex-agent.sh conformance "..."   # print the command, run nothing
 #
@@ -58,12 +59,23 @@ Task: ${PROMPT}"
   review)
     EFFORT=high
     SANDBOX=read-only
-    TASK="Review the current branch diff with fresh context. Focus on core rules
-correctness, determinism (no unseeded randomness, no ambient time), and scope
-violations. Ignore style. Report only defects you can demonstrate with a concrete
-failing input.
+    # Pass the diff in rather than making the agent hunt for it. Discovery turns are
+    # the largest avoidable cost in a review agent -- see docs/agent-team.md.
+    # -U1 trims context on edit-heavy diffs and costs nothing on new-file diffs.
+    BASE="${BASE:-origin/main}"
+    DIFF="$(git diff -U1 "${BASE}"...HEAD)"
+    if [[ -z "$DIFF" ]]; then
+      echo "no diff against ${BASE}; nothing to review" >&2
+      exit 0
+    fi
+    TASK="Review the diff below with fresh context. Focus on core rules correctness,
+determinism (no unseeded randomness, no ambient time), and scope violations. Ignore
+style. Report only defects you can demonstrate with a concrete failing input.
 
-${PROMPT}"
+${PROMPT}
+
+--- diff against ${BASE} (-U1) ---
+${DIFF}"
     ;;
   simcheck)
     EFFORT=high


### PR DESCRIPTION
## Linked Issue

Closes #18

## Exact behavioral claim

Review and gate agents are handed the change rather than sent to find it, and the routing doc records how to brief an agent cheaply.

## Scope

**Changed:** `docs/agent-team.md` (new briefing section, datapoints table), `tools/codex-agent.sh` (review role embeds the diff, guards against an empty one).

**Deliberately unchanged:** no agent's model or effort, no routing rules, no agent definitions.

## Rules conformance

N/A — tooling and documentation.

## Tests and evidence

```
bash -n tools/codex-agent.sh        -> syntax OK
DRY_RUN=1 BASE=main tools/codex-agent.sh review
  -> "no diff against main; nothing to review"  (empty-diff guard fires, exit 0)
```

Diff-context measurement on #9's commit, which is what prompted this:

| Context | Bytes | Saving |
|---|---:|---:|
| `-U3` default | 49,290 | — |
| `-U1` | 49,171 | 0.24% |
| `-U0` | 49,155 | 0.27% |

1,242 of 1,244 added lines were in newly-added files, which git prints in full regardless of context setting. Recorded honestly in the doc so nobody expects `-U1` to do more than it does.

## Decisions and tradeoffs

**Adopted `-U1` anyway.** It buys almost nothing on new-file commits but costs nothing and helps on edit-heavy ones. #10 and #11 will be edit-heavy.

**Did not switch `scope-warden` to grep in this PR.** The doc now says a pattern checklist is a grep problem rather than a diff problem, but changing how that agent works is a separate concern from documenting the principle.

## Known limitations

- The datapoints table has one row. It needs several before it says anything.
- The Claude-side agents still discover their own context; only the Codex wrapper was changed, because it is the one with a script to change. Passing diffs to Claude subagents is a prompt-construction habit, not something enforceable in a file.
- The `.claude/agents/*.md` definitions are still not loadable mid-session — they register at startup. Not addressed here.

## Agent provenance

Claude Opus 5 via Claude Code. No subagents; this was a doc change smaller than the cost of briefing one.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented.