### PR TITLE
Add the five-grade resolution kernel with full table conformance (#10)

### DIFF
--- a/src/Brp.Core/Resolution/ResolutionPolicy.cs
+++ b/src/Brp.Core/Resolution/ResolutionPolicy.cs
@@ -1,0 +1,80 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Resolution;
+
+/// <summary>
+/// The constants that define how an action roll is graded.
+/// <para>
+/// These live here rather than as literals scattered through the resolver so that every
+/// value taken from the book is declared in one named place, per the rules-values-as-data
+/// invariant in <c>AGENTS.md</c>. They are deliberately <em>not</em> in ruleset JSON
+/// alongside skill and weapon data: those describe a setting, whereas these describe the
+/// resolution system itself. Changing <see cref="SpecialDivisor"/> from 5 to 4 does not
+/// produce a different setting, it produces a different game.
+/// </para>
+/// <para>
+/// Treat <see cref="Standard"/> as the only supported configuration. The type exists to
+/// make the values explicit and testable, not to invite tuning.
+/// </para>
+/// </summary>
+/// <param name="CriticalDivisor">
+/// A critical succeeds on a roll at or under this fraction of the chance, rounded up
+/// (Ch 5: System, "Critical Success", p.128 -- one twentieth).
+/// </param>
+/// <param name="SpecialDivisor">
+/// A special succeeds on a roll at or under this fraction of the chance, rounded up
+/// (Ch 5, "Special Success", p.128 -- one fifth).
+/// </param>
+/// <param name="AlwaysFailsAtOrAbove">
+/// Rolls at or above this value always fail regardless of chance (Ch 5, "Failure", p.127).
+/// Note this rule is stated for action and skill rolls; resistance rolls are explicitly
+/// exempted -- see the remarks on <see cref="SkillResolver"/>.
+/// </param>
+/// <param name="FumbleBandAnchor">
+/// The fumble band starts at this value plus the (clamped) critical threshold, and always
+/// ends at 100. Derived from the printed Skill Results Table rather than from the prose,
+/// which is off by one at multiples of 20 -- see <see cref="SkillResolver"/>.
+/// </param>
+/// <param name="MinimumSuccessFloorChance">
+/// A skill whose <em>base</em> chance is at least this value always succeeds on a roll at
+/// or under <see cref="MinimumSuccessFloorRoll"/>, however far modifiers have pushed the
+/// effective chance down (Ch 5, "Skill Rolls", p.128).
+/// </param>
+/// <param name="MinimumSuccessFloorRoll">The highest roll the 5% floor rescues.</param>
+public sealed record ResolutionPolicy(
+    int CriticalDivisor,
+    int SpecialDivisor,
+    int AlwaysFailsAtOrAbove,
+    int FumbleBandAnchor,
+    int MinimumSuccessFloorChance,
+    int MinimumSuccessFloorRoll)
+{
+    /// <summary>The values printed in the source book. The only supported configuration.</summary>
+    public static ResolutionPolicy Standard { get; } = new(
+        CriticalDivisor: 20,
+        SpecialDivisor: 5,
+        AlwaysFailsAtOrAbove: 96,
+        FumbleBandAnchor: 95,
+        MinimumSuccessFloorChance: 5,
+        MinimumSuccessFloorRoll: 5);
+
+    /// <summary>Highest possible percentile result. A roll of 00 is read as 100.</summary>
+    public const int MaximumRoll = 100;
+
+    /// <summary>The critical threshold for a given effective chance.</summary>
+    public int CriticalThreshold(Percent effectiveChance) =>
+        Rounding.Divide(effectiveChance.Value, CriticalDivisor, RoundingMode.Up);
+
+    /// <summary>The special threshold for a given effective chance.</summary>
+    public int SpecialThreshold(Percent effectiveChance) =>
+        Rounding.Divide(effectiveChance.Value, SpecialDivisor, RoundingMode.Up);
+
+    /// <summary>
+    /// The lowest roll that fumbles. The band always ends at 100 and narrows by one for each
+    /// step the critical threshold takes, collapsing to 100 alone once critical reaches 5.
+    /// Clamping critical to at least 1 anchors the start at 96 even at chance 0, matching the
+    /// table's lowest printed row rather than drifting below it.
+    /// </summary>
+    public int FumbleThreshold(Percent effectiveChance) =>
+        Math.Min(MaximumRoll, FumbleBandAnchor + Math.Max(1, CriticalThreshold(effectiveChance)));
+}

--- a/src/Brp.Core/Resolution/RollOutcome.cs
+++ b/src/Brp.Core/Resolution/RollOutcome.cs
@@ -1,0 +1,52 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Resolution;
+
+/// <summary>
+/// The full record of one resolved action roll -- not just the grade, but everything that
+/// produced it: the raw roll, the chance it was judged against, and the exact thresholds
+/// computed from that chance. Deliberately never collapsed to a bare <c>bool</c> or a bare
+/// <see cref="SuccessLevel"/>: the game shows the player the real probability behind a
+/// result, which is only possible if the result can explain itself after the fact.
+/// </summary>
+/// <param name="Roll">
+/// The percentile result the grade was decided from, in <c>[1, 100]</c> -- a printed roll of
+/// <c>00</c> is represented as <c>100</c>, per <see cref="Randomness.IEntropySource.NextD100"/>.
+/// </param>
+/// <param name="BaseChance">
+/// The skill's unmodified base chance. Carried for provenance and used only to evaluate the
+/// 5%-floor rule (Ch 5: System, "Skill Rolls", p.128); every other threshold below is derived
+/// from <see cref="EffectiveChance"/> alone.
+/// </param>
+/// <param name="EffectiveChance">
+/// The modified chance of success the roll was actually resolved against. Where that
+/// modified chance came from (situational modifiers, difficulty, etc.) is out of scope here.
+/// </param>
+/// <param name="CriticalThreshold">
+/// A roll at or below this value is a critical success: 1/20th of
+/// <see cref="EffectiveChance"/>, rounded up (Ch 5, "Critical Success", p.128).
+/// </param>
+/// <param name="SpecialThreshold">
+/// A roll at or below this value is a special success: 1/5th of <see cref="EffectiveChance"/>,
+/// rounded up (Ch 5, "Special Success", p.128). This range contains
+/// <see cref="CriticalThreshold"/>'s range; the two never stack -- a roll in both bands
+/// resolves as <see cref="SuccessLevel.Critical"/> only.
+/// </param>
+/// <param name="FumbleThreshold">
+/// A roll at or above this value is a fumble. Always <c>100</c> at most, so a roll of
+/// <c>100</c> (printed <c>00</c>) is unconditionally a fumble (Ch 5, "Fumble", p.127: "A roll
+/// of 00 is always a fumble, no matter what the skill rating is").
+/// </param>
+/// <param name="Level">The resulting grade.</param>
+public sealed record RollOutcome(
+    int Roll,
+    Percent BaseChance,
+    Percent EffectiveChance,
+    Percent CriticalThreshold,
+    Percent SpecialThreshold,
+    Percent FumbleThreshold,
+    SuccessLevel Level)
+{
+    /// <summary>True for <see cref="SuccessLevel.Success"/> or better.</summary>
+    public bool Succeeded => Level >= SuccessLevel.Success;
+}

--- a/src/Brp.Core/Resolution/SkillResolver.cs
+++ b/src/Brp.Core/Resolution/SkillResolver.cs
@@ -1,0 +1,144 @@
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+
+namespace Brp.Core.Resolution;
+
+/// <summary>
+/// Resolves a single <em>skill or action</em> roll into a <see cref="RollOutcome"/>, per
+/// Ch 5: System, "Evaluating Success or Failure", "Skill Rolls", and the Skill Results
+/// Table (BRP ORC Content Document, p.127-128). Combat attacks, experience checks, chases,
+/// Passions, and Sanity all funnel through it.
+/// <para>
+/// <strong>Resistance rolls do not.</strong> Ch 5, "Failure" (p.127) exempts them from the
+/// 96+ rule: with a ten-point characteristic advantage only a roll of 00 fails, and the
+/// printed Resistance Table runs 05 to 95 with no entry beyond. Routing a resistance roll
+/// through <see cref="Resolve(Percent, Percent, int, ResolutionPolicy?)"/> would wrongly
+/// fail it on a 96-99 -- for example a 100% chance with a roll of 96 returns
+/// <see cref="SuccessLevel.Failure"/> here, where the resistance rule says it succeeds.
+/// Resistance is a separate path and is its own Issue.
+/// </para>
+/// </summary>
+public static class SkillResolver
+{
+    /// <summary>
+    /// Resolves an action roll against an already-drawn percentile result.
+    /// </summary>
+    /// <param name="baseChance">
+    /// The skill's unmodified base chance. Used only for the 5%-floor rule (Ch 5, "Skill
+    /// Rolls", p.128): "Any skill which normally has a base chance of 5% or higher always
+    /// succeeds on a roll of 01-05... even if difficulty, conditional modifiers, or other
+    /// factors reduce the skill rating below 5%." Note the floor is keyed on this
+    /// <em>base</em> value, not on <paramref name="effectiveChance"/> -- that is the entire
+    /// content of the rule.
+    /// </param>
+    /// <param name="effectiveChance">
+    /// The modified chance of success to resolve the roll against. Where this comes from
+    /// (situational modifiers, difficulty) is a later Issue's concern; here it is an input.
+    /// </param>
+    /// <param name="roll">A percentile result in <c>[1, 100]</c>, with <c>00</c> as <c>100</c>.</param>
+    /// <param name="policy">
+    /// The grading constants. Defaults to <see cref="ResolutionPolicy.Standard"/>, which holds
+    /// the values printed in the book and is the only supported configuration.
+    /// </param>
+    public static RollOutcome Resolve(
+        Percent baseChance, Percent effectiveChance, int roll, ResolutionPolicy? policy = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(roll, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(roll, ResolutionPolicy.MaximumRoll);
+
+        policy ??= ResolutionPolicy.Standard;
+        var chance = effectiveChance.Value;
+
+        // Ch 5, "Critical Success" / "Special Success": 1/20th and 1/5th of the rating.
+        // The printed table only ever steps a threshold up at a row boundary (e.g. chance 20
+        // and chance 21 both round to critical=1 and critical=2 respectively), which is what
+        // rounding up (ceiling) reproduces; rounding down would put the step one row early.
+        var criticalThreshold = policy.CriticalThreshold(effectiveChance);
+        var specialThreshold = policy.SpecialThreshold(effectiveChance);
+
+        // Skill Results Table: the fumble band always ends at 100 (printed 00) and starts at
+        // 96, narrowing by one for every step the critical threshold takes, down to the
+        // single value 100 once critical reaches 5 (effective chance 81+). Clamping the
+        // critical threshold to at least 1 here anchors the start at 96 even at chance 0,
+        // matching the table's lowest printed row (01-05) rather than drifting below it.
+        var fumbleThreshold = policy.FumbleThreshold(effectiveChance);
+
+        var level = DetermineLevel(
+            policy, baseChance.Value, chance, roll, criticalThreshold, specialThreshold, fumbleThreshold);
+
+        return new RollOutcome(
+            roll,
+            baseChance,
+            effectiveChance,
+            Percent.Of(criticalThreshold),
+            Percent.Of(specialThreshold),
+            Percent.Of(fumbleThreshold),
+            level);
+    }
+
+    /// <summary>
+    /// Resolves an action roll by drawing a fresh percentile result from
+    /// <paramref name="entropy"/>.
+    /// </summary>
+    public static RollOutcome Resolve(
+        Percent baseChance, Percent effectiveChance, IEntropySource entropy, ResolutionPolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(entropy);
+        return Resolve(baseChance, effectiveChance, entropy.NextD100(), policy);
+    }
+
+    private static SuccessLevel DetermineLevel(
+        ResolutionPolicy policy,
+        int baseChance,
+        int effectiveChance,
+        int roll,
+        int criticalThreshold,
+        int specialThreshold,
+        int fumbleThreshold)
+    {
+        // Ch 5, "Failure": "no matter how high the modified base chance, rolls fail on
+        // results of 96 or higher." The same paragraph exempts resistance rolls, which is
+        // why this type is scoped to skill and action rolls -- see the remarks on the class.
+        // Checked first and unconditionally: it caps success at 95
+        // regardless of how large the effective chance is. Ratings above 100% are supported
+        // (the table continues past 120), so without this check a roll of, say, 97 against a
+        // 150% chance would otherwise read as an ordinary success.
+        if (roll >= policy.AlwaysFailsAtOrAbove)
+        {
+            // Ch 5, "Fumble": "A roll of 00 is always a fumble, no matter what the skill
+            // rating is." fumbleThreshold is never greater than 100, so roll == 100 (00)
+            // always satisfies this and falls through to Fumble.
+            return roll >= fumbleThreshold ? SuccessLevel.Fumble : SuccessLevel.Failure;
+        }
+
+        // Skill Results Table, introductory note: "Whenever a roll result is in the range of
+        // both a critical and special success, the results of the critical success... should
+        // be applied, not both." The critical band sits inside the special band (1/20th <=
+        // 1/5th), so testing it first gives exactly that precedence without double-counting.
+        if (roll <= criticalThreshold)
+        {
+            return SuccessLevel.Critical;
+        }
+
+        if (roll <= specialThreshold)
+        {
+            return SuccessLevel.Special;
+        }
+
+        if (roll <= effectiveChance)
+        {
+            return SuccessLevel.Success;
+        }
+
+        // Ch 5, "Skill Rolls": the 5%-floor. Only reachable once an ordinary success against
+        // the effective chance has already failed, and it grants a plain Success -- the book
+        // says "always succeeds", nothing about upgrading to Special or Critical.
+        if (baseChance >= policy.MinimumSuccessFloorChance
+            && roll <= policy.MinimumSuccessFloorRoll)
+        {
+            return SuccessLevel.Success;
+        }
+
+        return SuccessLevel.Failure;
+    }
+}

--- a/src/Brp.Core/Resolution/SuccessLevel.cs
+++ b/src/Brp.Core/Resolution/SuccessLevel.cs
@@ -1,0 +1,31 @@
+namespace Brp.Core.Resolution;
+
+/// <summary>
+/// The five degrees of success for an action roll, per Ch 5: System, "Evaluating Success or
+/// Failure" (BRP ORC Content Document, p.127): "There are five degrees of success for any
+/// type of action roll. Ranked from worst to best, they are as follows: Fumble, Failure,
+/// Success, Special Success, Critical Success."
+/// <para>
+/// The underlying values encode that ranking, so ordinary comparison operators order and
+/// compare grades correctly. This matters beyond display: opposed rolls (Issue #12) decide
+/// their winner by comparing two <see cref="SuccessLevel"/> values, so the order has to be
+/// meaningful, not incidental.
+/// </para>
+/// </summary>
+public enum SuccessLevel
+{
+    /// <summary>The worst possible result. Ch 5, "Fumble".</summary>
+    Fumble = 0,
+
+    /// <summary>An ordinary failed roll. Ch 5, "Failure".</summary>
+    Failure = 1,
+
+    /// <summary>An ordinary successful roll. Ch 5, "Success".</summary>
+    Success = 2,
+
+    /// <summary>A better-than-average success. Ch 5, "Special Success".</summary>
+    Special = 3,
+
+    /// <summary>The best possible result. Ch 5, "Critical Success".</summary>
+    Critical = 4,
+}

--- a/tests/Brp.Core.Tests/Resolution/ResolutionPolicyTests.cs
+++ b/tests/Brp.Core.Tests/Resolution/ResolutionPolicyTests.cs
@@ -1,0 +1,60 @@
+using Brp.Core.Primitives;
+using Brp.Core.Resolution;
+
+namespace Brp.Core.Tests.Resolution;
+
+/// <summary>
+/// Pins the grading constants and the one boundary this kernel deliberately does not own.
+/// </summary>
+public class ResolutionPolicyTests
+{
+    [Fact]
+    public void Standard_policy_holds_the_printed_constants()
+    {
+        var policy = ResolutionPolicy.Standard;
+
+        Assert.Equal(20, policy.CriticalDivisor);
+        Assert.Equal(5, policy.SpecialDivisor);
+        Assert.Equal(96, policy.AlwaysFailsAtOrAbove);
+        Assert.Equal(95, policy.FumbleBandAnchor);
+        Assert.Equal(5, policy.MinimumSuccessFloorChance);
+        Assert.Equal(5, policy.MinimumSuccessFloorRoll);
+        Assert.Equal(100, ResolutionPolicy.MaximumRoll);
+    }
+
+    [Theory]
+    [InlineData(20, 1, 4, 96)]     // lowest band: fumble anchored at 96
+    [InlineData(21, 2, 5, 97)]     // first critical step
+    [InlineData(81, 5, 17, 100)]   // fumble collapses to 00 alone
+    [InlineData(120, 6, 24, 100)]  // last printed row; the min() clamp engages
+    public void Standard_policy_reproduces_printed_thresholds(
+        int chance, int expectedCritical, int expectedSpecial, int expectedFumble)
+    {
+        var policy = ResolutionPolicy.Standard;
+        var effective = Percent.Of(chance);
+
+        Assert.Equal(expectedCritical, policy.CriticalThreshold(effective));
+        Assert.Equal(expectedSpecial, policy.SpecialThreshold(effective));
+        Assert.Equal(expectedFumble, policy.FumbleThreshold(effective));
+    }
+
+    /// <summary>
+    /// Pins the boundary two independent conformance passes flagged. This assertion is
+    /// CORRECT for skill and action rolls -- the book's 96+ rule is unconditional for them.
+    /// It is deliberately WRONG for a resistance roll, which the same paragraph exempts: with
+    /// a ten-point characteristic advantage only a roll of 00 fails.
+    /// <para>
+    /// The test exists so that whoever implements resistance rolls has to confront this rather
+    /// than inherit it. If resistance is ever routed through <see cref="SkillResolver"/>, this
+    /// test still passing is the signal that the exemption was missed.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Skill_rolls_fail_at_96_even_at_full_chance_which_is_why_resistance_is_a_separate_path()
+    {
+        var outcome = SkillResolver.Resolve(Percent.Of(100), Percent.Of(100), roll: 96);
+
+        Assert.Equal(SuccessLevel.Failure, outcome.Level);
+        Assert.False(outcome.Succeeded);
+    }
+}

--- a/tests/Brp.Core.Tests/Resolution/SkillResolverTests.cs
+++ b/tests/Brp.Core.Tests/Resolution/SkillResolverTests.cs
@@ -1,0 +1,188 @@
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+using Brp.Core.Resolution;
+
+namespace Brp.Core.Tests.Resolution;
+
+public class SkillResolverTests
+{
+    [Fact]
+    public void SuccessLevel_is_ordered_worst_to_best()
+    {
+        // Ch 5, "Evaluating Success or Failure": "Ranked from worst to best, they are as
+        // follows: Fumble, Failure, Success, Special Success, Critical Success." Opposed
+        // rolls (a later Issue) decide their winner by comparing two grades, so this order
+        // has to hold under ordinary comparison, not just be a coincidence of declaration.
+        Assert.True(SuccessLevel.Fumble < SuccessLevel.Failure);
+        Assert.True(SuccessLevel.Failure < SuccessLevel.Success);
+        Assert.True(SuccessLevel.Success < SuccessLevel.Special);
+        Assert.True(SuccessLevel.Special < SuccessLevel.Critical);
+    }
+
+    [Fact]
+    public void A_roll_within_both_the_critical_and_special_range_resolves_as_critical_only()
+    {
+        // Skill Results Table, introductory note: "Whenever a roll result is in the range of
+        // both a critical and special success, the results of the critical success (if
+        // appropriate) should be applied, not both." At chance 50, critical = ceil(50/20) = 3
+        // and special = ceil(50/5) = 10, so a roll of 3 is in both ranges.
+        var outcome = SkillResolver.Resolve(Percent.Of(50), Percent.Of(50), roll: 3);
+
+        Assert.Equal(SuccessLevel.Critical, outcome.Level);
+        Assert.NotEqual(SuccessLevel.Special, outcome.Level);
+    }
+
+    [Theory]
+    [InlineData(96)]
+    [InlineData(97)]
+    [InlineData(98)]
+    [InlineData(99)]
+    public void Rolls_of_96_and_above_never_succeed_no_matter_how_high_the_chance(int roll)
+    {
+        // Ch 5, "Failure": "no matter how high the modified base chance, rolls fail on
+        // results of 96 or higher." Using a chance far above 100% to make sure nothing about
+        // "ratings above 100% are supported" is read as overriding this cap.
+        var outcome = SkillResolver.Resolve(Percent.Of(500), Percent.Of(500), roll);
+
+        Assert.True(outcome.Level is SuccessLevel.Failure or SuccessLevel.Fumble);
+    }
+
+    [Fact]
+    public void A_roll_of_100_always_fumbles_regardless_of_chance()
+    {
+        // Ch 5, "Fumble": "A roll of 00 is always a fumble, no matter what the skill rating
+        // is." 00 is represented as 100 (see IEntropySource.NextD100). Chance of 500% is used
+        // to show this holds even for a rating nowhere near the printed table's range.
+        var outcome = SkillResolver.Resolve(Percent.Of(500), Percent.Of(500), roll: 100);
+
+        Assert.Equal(SuccessLevel.Fumble, outcome.Level);
+    }
+
+    [Fact]
+    public void A_roll_of_100_fumbles_even_at_a_zero_chance()
+    {
+        var outcome = SkillResolver.Resolve(Percent.Of(0), Percent.Of(0), roll: 100);
+
+        Assert.Equal(SuccessLevel.Fumble, outcome.Level);
+    }
+
+    [Fact]
+    public void The_5_percent_floor_rescues_a_roll_of_01_to_05_when_the_base_chance_qualifies()
+    {
+        // Ch 5, "Skill Rolls": "Any skill which normally has a base chance of 5% or higher
+        // always succeeds on a roll of 01-05... even if difficulty, conditional modifiers, or
+        // other factors reduce the skill rating below 5%." Base chance 20, modified down to 1
+        // by (unmodeled) penalties; a roll of 4 would ordinarily fail against a chance of 1.
+        var outcome = SkillResolver.Resolve(Percent.Of(20), Percent.Of(1), roll: 4);
+
+        Assert.Equal(SuccessLevel.Success, outcome.Level);
+    }
+
+    [Fact]
+    public void The_5_percent_floor_is_keyed_on_the_base_chance_not_the_effective_one()
+    {
+        // The rule reads "a base chance of 5% or higher", not "an effective chance of 5% or
+        // higher" -- this is the one behavior that would look identical to the ordinary
+        // success check if the floor were (wrongly) keyed on the effective chance instead.
+        // Here the *base* chance is below 5%, so even though the roll is in 01-05, the floor
+        // must not apply, and an effective chance of 1 leaves roll 4 an ordinary failure.
+        var outcome = SkillResolver.Resolve(Percent.Of(4), Percent.Of(1), roll: 4);
+
+        Assert.Equal(SuccessLevel.Failure, outcome.Level);
+    }
+
+    [Fact]
+    public void The_5_percent_floor_does_not_apply_outside_the_01_to_05_roll_range()
+    {
+        // Base chance qualifies (10), but the floor only ever covers rolls 01-05.
+        var outcome = SkillResolver.Resolve(Percent.Of(10), Percent.Of(1), roll: 6);
+
+        Assert.Equal(SuccessLevel.Failure, outcome.Level);
+    }
+
+    [Fact]
+    public void The_5_percent_floor_never_upgrades_a_roll_past_plain_success()
+    {
+        // The book says the roll "always succeeds", not that it upgrades to Special or
+        // Critical. Effective chance 1 gives critical = special = 1 (ceil(1/20) = ceil(1/5) =
+        // 1), so roll 1 would already be Critical without any floor involved; roll 3 is past
+        // both thresholds and should land on plain Success via the floor, not better.
+        var outcome = SkillResolver.Resolve(Percent.Of(20), Percent.Of(1), roll: 3);
+
+        Assert.Equal(SuccessLevel.Success, outcome.Level);
+    }
+
+    [Theory]
+    [InlineData(150, 5, SuccessLevel.Critical)] // critical = ceil(150/20) = 8, so roll 5 qualifies
+    [InlineData(150, 20, SuccessLevel.Special)] // special = ceil(150/5) = 30, so roll 20 qualifies
+    [InlineData(150, 95, SuccessLevel.Success)] // below the always-fails 96 line, above special's 30
+    public void Ratings_above_100_percent_are_supported_natively(int chance, int roll, SuccessLevel expected)
+    {
+        // Ch 5, Skill Results Table: printed rows continue past 100% (101-105 ... 116-120,
+        // "Each +5 | Etc. | Etc. | 00"), so chances above 100 are a normal state, not an error.
+        var outcome = SkillResolver.Resolve(Percent.Of(chance), Percent.Of(chance), roll);
+
+        Assert.Equal(expected, outcome.Level);
+    }
+
+    [Fact]
+    public void RollOutcome_exposes_every_input_that_produced_the_grade()
+    {
+        var outcome = SkillResolver.Resolve(Percent.Of(45), Percent.Of(40), roll: 7);
+
+        Assert.Equal(7, outcome.Roll);
+        Assert.Equal(Percent.Of(45), outcome.BaseChance);
+        Assert.Equal(Percent.Of(40), outcome.EffectiveChance);
+        Assert.Equal(Percent.Of(2), outcome.CriticalThreshold); // ceil(40/20)
+        Assert.Equal(Percent.Of(8), outcome.SpecialThreshold); // ceil(40/5)
+        Assert.Equal(Percent.Of(97), outcome.FumbleThreshold); // row 36-40
+        Assert.Equal(SuccessLevel.Special, outcome.Level); // 2 < 7 <= 8
+    }
+
+    [Theory]
+    [InlineData(SuccessLevel.Fumble, false)]
+    [InlineData(SuccessLevel.Failure, false)]
+    [InlineData(SuccessLevel.Success, true)]
+    [InlineData(SuccessLevel.Special, true)]
+    [InlineData(SuccessLevel.Critical, true)]
+    public void Succeeded_is_true_for_success_or_better(SuccessLevel level, bool expected)
+    {
+        var outcome = new RollOutcome(
+            Roll: 1,
+            BaseChance: Percent.Zero,
+            EffectiveChance: Percent.Zero,
+            CriticalThreshold: Percent.Zero,
+            SpecialThreshold: Percent.Zero,
+            FumbleThreshold: Percent.Of(100),
+            Level: level);
+
+        Assert.Equal(expected, outcome.Succeeded);
+    }
+
+    [Fact]
+    public void Resolve_with_an_entropy_source_draws_exactly_one_D100()
+    {
+        var entropy = new Xoshiro256StarStar(seed: 42);
+        var before = entropy.DrawCount;
+
+        SkillResolver.Resolve(Percent.Of(50), Percent.Of(50), entropy);
+
+        Assert.Equal(before + 1, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void Resolve_rejects_a_null_entropy_source()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => SkillResolver.Resolve(Percent.Of(50), Percent.Of(50), (IEntropySource)null!));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void Resolve_rejects_a_roll_outside_1_to_100(int roll)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => SkillResolver.Resolve(Percent.Of(50), Percent.Of(50), roll));
+    }
+}

--- a/tests/Brp.Core.Tests/Resolution/SkillResultsTableTests.cs
+++ b/tests/Brp.Core.Tests/Resolution/SkillResultsTableTests.cs
@@ -1,0 +1,163 @@
+using Brp.Core.Primitives;
+using Brp.Core.Resolution;
+
+namespace Brp.Core.Tests.Resolution;
+
+/// <summary>
+/// Conformance fixture for the Skill Results Table, Ch 5: System (BRP ORC Content Document,
+/// p.127-128). Transcribed directly from the printed table -- all 24 rows, including the four
+/// rows above 100% -- so a transcription error surfaces as a single named failing row rather
+/// than hiding inside a loop.
+/// <para>
+/// Printed table (Base Chance | Critical | Special | Fumble):
+/// <code>
+/// 01-05   | 01   | 01    | 96-00
+/// 06-10   | 01   | 01-02 | 96-00
+/// 11-15   | 01   | 01-03 | 96-00
+/// 16-20   | 01   | 01-04 | 96-00
+/// 21-25   | 01-02| 01-05 | 97-00
+/// 26-30   | 01-02| 01-06 | 97-00
+/// 31-35   | 01-02| 01-07 | 97-00
+/// 36-40   | 01-02| 01-08 | 97-00
+/// 41-45   | 01-03| 01-09 | 98-00
+/// 46-50   | 01-03| 01-10 | 98-00
+/// 51-55   | 01-03| 01-11 | 98-00
+/// 56-60   | 01-03| 01-12 | 98-00
+/// 61-65   | 01-04| 01-13 | 99-00
+/// 66-70   | 01-04| 01-14 | 99-00
+/// 71-75   | 01-04| 01-15 | 99-00
+/// 76-80   | 01-04| 01-16 | 99-00
+/// 81-85   | 01-05| 01-17 | 00
+/// 86-90   | 01-05| 01-18 | 00
+/// 91-95   | 01-05| 01-19 | 00
+/// 96-00   | 01-05| 01-20 | 00
+/// 101-105 | 01-06| 01-21 | 00
+/// 106-110 | 01-06| 01-22 | 00
+/// 111-115 | 01-06| 01-23 | 00
+/// 116-120 | 01-06| 01-24 | 00
+/// Each +5 | Etc. | Etc.  | 00
+/// </code>
+/// (A base chance of "96-00" reads as 96 through 100; "00" alone as a fumble range reads as
+/// 100 only.)
+/// </para>
+/// </summary>
+public class SkillResultsTableTests
+{
+    /// <summary>
+    /// One entry per printed row: the row's base-chance range, and the printed critical /
+    /// special / fumble-start values (fumble always runs to 100 inclusive).
+    /// </summary>
+    public static TheoryData<string, int, int, int, int, int> PrintedRows => new()
+    {
+        { "01-05", 1, 5, 1, 1, 96 },
+        { "06-10", 6, 10, 1, 2, 96 },
+        { "11-15", 11, 15, 1, 3, 96 },
+        { "16-20", 16, 20, 1, 4, 96 },
+        { "21-25", 21, 25, 2, 5, 97 },
+        { "26-30", 26, 30, 2, 6, 97 },
+        { "31-35", 31, 35, 2, 7, 97 },
+        { "36-40", 36, 40, 2, 8, 97 },
+        { "41-45", 41, 45, 3, 9, 98 },
+        { "46-50", 46, 50, 3, 10, 98 },
+        { "51-55", 51, 55, 3, 11, 98 },
+        { "56-60", 56, 60, 3, 12, 98 },
+        { "61-65", 61, 65, 4, 13, 99 },
+        { "66-70", 66, 70, 4, 14, 99 },
+        { "71-75", 71, 75, 4, 15, 99 },
+        { "76-80", 76, 80, 4, 16, 99 },
+        { "81-85", 81, 85, 5, 17, 100 },
+        { "86-90", 86, 90, 5, 18, 100 },
+        { "91-95", 91, 95, 5, 19, 100 },
+        { "96-00", 96, 100, 5, 20, 100 },
+        { "101-105", 101, 105, 6, 21, 100 },
+        { "106-110", 106, 110, 6, 22, 100 },
+        { "111-115", 111, 115, 6, 23, 100 },
+        { "116-120", 116, 120, 6, 24, 100 },
+    };
+
+    [Fact]
+    public void Printed_rows_cover_all_24_lines_of_the_table()
+    {
+        Assert.Equal(24, PrintedRows.Count);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintedRows))]
+    public void Row_thresholds_match_the_printed_table_at_the_low_end_of_its_range(
+        string row, int chanceLow, int chanceHigh, int expectedCritical, int expectedSpecial, int expectedFumbleStart)
+    {
+        _ = row;
+        _ = chanceHigh;
+        AssertThresholds(chanceLow, expectedCritical, expectedSpecial, expectedFumbleStart);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintedRows))]
+    public void Row_thresholds_match_the_printed_table_at_the_high_end_of_its_range(
+        string row, int chanceLow, int chanceHigh, int expectedCritical, int expectedSpecial, int expectedFumbleStart)
+    {
+        _ = row;
+        _ = chanceLow;
+        AssertThresholds(chanceHigh, expectedCritical, expectedSpecial, expectedFumbleStart);
+    }
+
+    private static void AssertThresholds(
+        int chance, int expectedCritical, int expectedSpecial, int expectedFumbleStart)
+    {
+        // The roll passed in only decides Level, not the thresholds under test, so any
+        // in-range roll works here.
+        var outcome = SkillResolver.Resolve(Percent.Of(chance), Percent.Of(chance), roll: 1);
+
+        Assert.Equal(expectedCritical, outcome.CriticalThreshold.Value);
+        Assert.Equal(expectedSpecial, outcome.SpecialThreshold.Value);
+        Assert.Equal(expectedFumbleStart, outcome.FumbleThreshold.Value); // fumble always runs to 100 (00) from here.
+    }
+
+    [Fact]
+    public void Closed_form_thresholds_agree_with_every_printed_row_at_every_integer_chance_from_1_to_120()
+    {
+        // Strengthens the 24-row spot check above into full coverage: every one of the 120
+        // integer effective-chance values from the printed portion of the table (not just the
+        // 24 row boundaries) must resolve to its row's printed thresholds.
+        var verified = 0;
+
+        foreach (var row in PrintedRows)
+        {
+            var chanceLow = (int)row[1]!;
+            var chanceHigh = (int)row[2]!;
+            var expectedCritical = (int)row[3]!;
+            var expectedSpecial = (int)row[4]!;
+            var expectedFumbleStart = (int)row[5]!;
+
+            for (var chance = chanceLow; chance <= chanceHigh; chance++)
+            {
+                AssertThresholds(chance, expectedCritical, expectedSpecial, expectedFumbleStart);
+                verified++;
+            }
+        }
+
+        Assert.Equal(120, verified);
+    }
+
+    [Theory]
+    [InlineData(121, 500)]
+    [InlineData(500, 2000)]
+    public void Closed_form_thresholds_continue_the_printed_pattern_above_120(int from, int to)
+    {
+        // The table's final row reads "Each +5 | Etc. | Etc. | 00": critical and special keep
+        // climbing by the same 1/20 and 1/5 division past the last printed row (116-120), and
+        // fumble stays pinned at 100 (00) forever, per Ch 5, "Failure" / "Fumble" -- 96 and
+        // above always fails, and 00 always fumbles, regardless of how high the rating goes.
+        for (var chance = from; chance <= to; chance += 7) // odd step: not a multiple of 5 or 20
+        {
+            var outcome = SkillResolver.Resolve(Percent.Of(chance), Percent.Of(chance), roll: 1);
+
+            var expectedCritical = Rounding.Divide(chance, 20, RoundingMode.Up);
+            var expectedSpecial = Rounding.Divide(chance, 5, RoundingMode.Up);
+
+            Assert.Equal(expectedCritical, outcome.CriticalThreshold.Value);
+            Assert.Equal(expectedSpecial, outcome.SpecialThreshold.Value);
+            Assert.Equal(100, outcome.FumbleThreshold.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #10

## Exact behavioral claim

A modified chance plus a percentile roll grades into one of five degrees of success,
matching the printed Skill Results Table on every row, with the full derivation
recoverable from the result.

This is the operation every other rule depends on. An error here is inherited by
every layer above.

## Scope

**Added:** `Resolution/SuccessLevel`, `RollOutcome`, `SkillResolver`,
`ResolutionPolicy`, and three test files.

**Deliberately not included:** where the effective chance comes from (#11), resistance
and opposed rolls (#12 — see below), anything about skills or characteristics.

## Rules conformance

**Three independent transcriptions of the table agree** — the implementer, a Claude
`rules-conformance` pass, and a Codex cross-check, each extracting from the PDF
themselves rather than reading each other's work. 24 rows, 96 cells, zero differences.

All three closed forms checked against **every integer chance from 1 to 120**, by two
verifiers independently, zero mismatches:

```
critical     = ceil(chance / 20)
special      = ceil(chance / 5)
fumble start = min(100, 95 + max(1, critical))
```

Rounding turns out to be load-bearing: half-up rounding — which the superseded 2020
SRD uses — diverges from this table at **54 of 120** chances. That is the concrete
cost of the two-rulebook problem this project started with.

**The book's prose contradicts its own table.** The sentence describing the fumble
band, read literally, is one row narrow at each multiple of 20, and at 100% yields no
fumble range at all despite the same paragraph stating that 00 always fumbles. The
table is authoritative — its preamble is normative where the prose hedges with
"usually" — and the code follows the table and says why.

All six required behaviors verified against the book's own wording rather than the
Issue's paraphrase, including the subtle one: the 5% floor keys on the *base* chance,
not the modified chance.

## Decisions and tradeoffs

**`ResolutionPolicy` instead of literals.** `scope-warden` failed the
rules-values-as-data check on the hardcoded divisors. The implementer's argument —
that kernel arithmetic is not per-ruleset content — is fair, but "this one is
different" is how an invariant erodes. The values now live in one declared, testable
place, documented as the only supported configuration rather than an invitation to
tune. Kept out of ruleset JSON deliberately: skill and weapon data describe a
*setting*, these describe the *system*.

**Scoped the type to skill and action rolls.** Both conformance passes independently
found the class claimed resistance rolls funnel through it. They do not — the book
exempts them from the 96+ rule, since a ten-point characteristic advantage means only
00 fails. Nothing was broken today; the comment is what would have licensed the wrong
wiring in #12.

## Tests and evidence

```
dotnet build   -> Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test    -> Passed! Failed: 0, Passed: 227, Skipped: 0, Total: 227
dotnet format --verify-no-changes -> clean
```

Verified independently of the implementing agent, before and after the review fixes.

`scope-warden`: 6 of 7 pass, item 6 failed and is fixed in this PR.
`rules-conformance` (Opus): CONFIRMED, one finding, fixed.
Codex cross-check: table and formulas confirmed, same finding, fixed.

## Known limitations

- **Resistance rolls are not implemented and must not use this type.** A named test
  pins the boundary: at 100% chance a roll of 96 returns `Failure`, which is correct
  for skill rolls and wrong for resistance. If resistance is ever routed through here,
  that test still passing is the signal the exemption was missed. Flagged on #12.
- `ResolutionPolicy` is constructible with non-standard values. That is the cost of
  making them declared and testable; the docs say plainly that `Standard` is the only
  supported configuration.
- Above the printed range the continuation rule is extrapolated from the book's own
  "Each +5" line. Verified self-consistent, but the book prints no further rows.

## Agent provenance

Implemented by `engine-dev` (Sonnet), gated by `scope-warden` (Haiku), verified by
`rules-conformance` (Opus) and an independent Codex pass. Review findings triaged and
fixed by Claude Opus 5.

ADR 0004 datapoint: ~115k + ~37k + ~72k subagent tokens plus the Codex pass, for the
highest-risk Issue in the project. The cross-vendor check earned its cost — it
independently reached the same defect and rated it more severely, which is what
prompted pinning it with a test rather than only rewording a comment.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).