### PR TITLE
Add the typed modifier pipeline (#11), and settle its ordering (#2, #3)

### DIFF
--- a/docs/decisions/0007-modifier-pipeline.md
+++ b/docs/decisions/0007-modifier-pipeline.md
@@ -1,0 +1,134 @@
+# 0007. Modifier ordering, and difficulty that does not stack
+
+## Status
+
+Accepted — 2026-08-29. Resolves #2 and #3.
+
+Two earlier drafts of this record were wrong. See "How this record was got wrong twice"
+below; the mistakes are kept because the pattern in them is the useful part.
+
+## Context
+
+Computing an effective chance requires two things the engine cannot leave open: the
+order in which different kinds of modifier apply, and whether two sources of the same
+difficulty compound. A gamemaster settles both by judgment. An engine has to commit.
+
+The design pillar in `noir-rpg-framework.md` is that the rating shown to the player is
+the real probability, so whatever the engine does must be explainable in one line of UI.
+
+## Decision
+
+### Ordering — sourced
+
+```
+Gate → Override → PermanentAdditive → Multiplicative → SituationalAdditive → Clamp
+```
+
+Ch 5: System, "Modifying Action Rolls" → "Situational Modifiers" states that a
+situational modifier is applied *after* a skill is modified for being Difficult or Easy,
+expressly so that situational modifiers are not themselves doubled or halved. The same
+passage states that modifiers which are *permanent* — integral to the skill rather than
+external — are figured into the rating *before* it is doubled or halved.
+
+That is two additive stages either side of the multiplicative one.
+
+Gate precedes everything, following from Automatic ("no roll necessary") and Impossible
+("all attempts fail"). Override before the additive stages is **not** a book rule; it is
+an engineering choice, and is recorded as one. The book's override cases are stated as
+flat replacement chances, which makes replacing-then-adjusting the only coherent reading.
+
+Halving rounds **up** — Ch 5, "Difficult Actions" says so explicitly.
+
+Worked examples the implementation reproduces:
+
+| Case | Result |
+|---|---|
+| 65%, firing while engaged in combat (Difficult), dim light (situational −20%) | `65 ÷ 2 = 33`, then `−20` → **13%** |
+| 65%, permanent +10, Difficult | `(65 + 10) ÷ 2` → **38%** |
+
+**Why it matters:** under the rejected ordering a stated −20% quietly becomes −10%
+whenever conditions are also bad, because it is halved along with everything else. The
+source's ordering preserves the weight a modifier says it has.
+
+### Difficulty grades — sourced
+
+Automatic (no roll), Easy (doubled), Average (unmodified), Difficult (halved, round up),
+Impossible (no roll; the book permits a gamemaster to allow a flat 1% at their
+discretion, which the engine does not yet express).
+
+**Easy and Difficult cancel pairwise, and this is sourced** — Ch 7, "Firing Into Combat"
+works exactly this cancellation, where a Difficult condition and an Easy one offset.
+
+### Difficulty does not stack — a house rule, but a supported one
+
+Any number of sources of "Difficult" produce one halving. Easy and Difficult cancel.
+
+The book does not state whether two Difficult grades compound, so the rule itself is
+ours. It is not unsupported, though, and three passages point the same way:
+
+- **Augments** (Ch 3) adjust difficulty by *one step*, "such as turning a Difficult roll
+  into an Average one", and state that only one degree of adjustment is possible.
+  Difficulty is modelled as a position on a ladder, not a multiplier stack.
+- **Disguise** (Ch 3) addresses multiple Difficult conditions directly, and answers with
+  an *additional flat penalty* rather than a second halving.
+- **Simple Fatigue** (Ch 2) expresses severity beyond Difficult as its own named factor,
+  never as two chained halvings.
+
+Rejected: compounding. Stacked halvings reach odds where the roll stops feeling like a
+decision, and a 17% arrived at by two invisible halvings reads as the game cheating even
+when the arithmetic is defensible.
+
+### Range bands are out of scope here
+
+An earlier draft specified range bands in this record. It was wrong in every particular
+and has been removed rather than corrected.
+
+The book's actual bands (Ch 6, "Missile Weapons"; Ch 7, "Extended Range") are mostly the
+difficulty grades themselves — point blank is *Easy*, medium range is *Difficult* — with
+long range a distinct one-fifth factor. There is no general "beyond three times range is
+impossible" rule; that was invented. Correctly implementing the bands also requires
+DEX-derived point-blank distance, weapon-class exceptions, and targeting equipment.
+
+That is combat-layer work, not modifier-pipeline work. Tracked separately.
+
+Consequence worth stating: because medium range *is* a Difficult grade, it collapses
+with other Difficult conditions under the non-stacking rule above. The earlier draft
+introduced a separate multiplicative tier specifically to prevent that collapse, and in
+doing so contradicted the text it should have been citing. The collapse is the book's
+behaviour, not a bug to engineer around.
+
+## How this record was got wrong twice
+
+The first draft framed the ordering as an open question with two candidate answers. The
+book specifies it, and specifies a three-stage scheme neither candidate described.
+
+The second draft fixed the ordering but kept a range-band section written the same way —
+asserted from memory, never checked. A conformance pass found every multiplier and every
+threshold in it wrong, plus a fabricated cutoff.
+
+Both errors have the same shape: a mechanical claim written without opening the book,
+sitting next to claims that were checked, with nothing on the page distinguishing them.
+
+The process correction, which this record now follows: **every mechanical claim in an ADR
+either cites the chapter it was verified against, or says plainly that the source is
+silent and the decision is ours.** Sections above are marked "sourced" or "house rule"
+for exactly this reason. An unmarked assertion is a defect regardless of whether it
+happens to be true.
+
+## Consequences
+
+- Ordering is a named policy holding the stage list as data, not implicit in call order,
+  covered by a test that fails under the collapsed-additive alternative.
+- Multipliers are rational rather than a closed enum, so the pipeline can express factors
+  the difficulty ladder does not cover. It no longer claims to model any particular one.
+- Additive modifiers carry a kind. Situational is the default because it is the common
+  case; permanent is the exception and must be requested.
+- Every modifier carries a source label and the chain renders its own derivation, with
+  the two additive stages distinguishable — "why did my −20% apply after the halving" is
+  precisely the question that rendering exists to answer.
+- Gates short-circuit without consuming entropy, or a save-file replay would desynchronise
+  depending on whether an impossible action was attempted.
+- The 5% floor from ADR 0006 keys on the *base* chance and survives arbitrary penalties.
+  It is applied by the resolver, after this pipeline, not inside it.
+- The gamemaster's discretionary 1% on an Impossible action is not currently expressible,
+  since gates short-circuit before overrides. Latent, not yet wrong.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -15,3 +15,4 @@ supersedes it — the original is not edited or deleted.
 | [0004](0004-agent-team.md) | Model-routed agent team with cross-vendor verification | Accepted |
 | [0005](0005-target-framework.md) | Target net10.0, pinned via global.json | Accepted |
 | [0006](0006-skill-bonus-system.md) | Full Skill Category Bonuses, applied by subtraction | Accepted |
+| [0007](0007-modifier-pipeline.md) | Modifier ordering, and difficulty that does not stack | Accepted |

--- a/src/Brp.Core/Modifiers/AdditiveModifier.cs
+++ b/src/Brp.Core/Modifiers/AdditiveModifier.cs
@@ -1,0 +1,33 @@
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// Distinguishes a modifier that is integral to the skill from one that reflects the situation
+/// the roll is attempted in. Per Ch 5: System, "Modifying Action Rolls", a permanent modifier --
+/// one built into the rating itself, such as specialized training -- is figured in before a
+/// Difficult or Easy grade doubles or halves the chance. A situational modifier -- conditions of
+/// the moment, such as darkness or firing into a melee -- is applied afterward, specifically so
+/// that its stated weight is not itself doubled or halved by the difficulty grade. See ADR 0007
+/// for the resulting stage order.
+/// </summary>
+public enum AdditiveKind
+{
+    /// <summary>Applied after the difficulty multiplier, so its stated weight survives intact.</summary>
+    Situational,
+
+    /// <summary>Applied before the difficulty multiplier, as part of the rating itself.</summary>
+    Permanent,
+}
+
+/// <summary>
+/// A flat percentage adjustment to the running chance -- a penalty or bonus, e.g. firing into
+/// combat at -20% (Ch 7, "Firing Into Combat"). Situational by default: the large majority of
+/// additive modifiers describe the moment rather than the skill -- the book's
+/// situational-modifier tables are the typical case. A caller must opt in to
+/// <see cref="AdditiveKind.Permanent"/> for the exceptional case of a modifier integral to the
+/// rating itself.
+/// </summary>
+/// <param name="Source">What produced this adjustment, e.g. "firing into combat".</param>
+/// <param name="Delta">The signed percentage-point change. Negative values are penalties.</param>
+/// <param name="Kind">Whether this is figured in before or after the difficulty multiplier.</param>
+public sealed record AdditiveModifier(string Source, int Delta, AdditiveKind Kind = AdditiveKind.Situational)
+    : Modifier(Source);

--- a/src/Brp.Core/Modifiers/DifficultyModifier.cs
+++ b/src/Brp.Core/Modifiers/DifficultyModifier.cs
@@ -1,0 +1,37 @@
+namespace Brp.Core.Modifiers;
+
+/// <summary>Which way a difficulty grade pushes the chance.</summary>
+public enum DifficultyDirection
+{
+    /// <summary>An Easy grade: contributes toward a net doubling.</summary>
+    Easier,
+
+    /// <summary>A Difficult grade: contributes toward a net halving.</summary>
+    Harder,
+}
+
+/// <summary>
+/// A difficulty-grade contribution -- Ch 5: System, "Modifying Action Rolls". Per ADR 0007,
+/// difficulty is a <em>state</em>, not a stack: any number of <see cref="DifficultyDirection.Harder"/>
+/// sources collapse into one halving, any number of <see cref="DifficultyDirection.Easier"/>
+/// sources collapse into one doubling, and the two cancel pairwise.
+/// <para>
+/// Deliberately carries no numerator or denominator of its own. The multiplier that a net
+/// difficulty grade actually applies is declared once, as data, on <see cref="ModifierPolicy"/>,
+/// and read from whichever policy a given <see cref="ModifierPipeline.Evaluate"/> call uses --
+/// the same precedent as <see cref="Resolution.ResolutionPolicy"/> owning the resolver's
+/// threshold constants rather than the roll owning them. An earlier revision let a difficulty
+/// contribution carry its own ratio, which meant an off-model ratio (e.g. 1/5) was silently
+/// discarded in favor of a hardcoded halving; removing the fields removes the possibility.
+/// </para>
+/// </summary>
+/// <param name="Source">What produced this grade, e.g. "darkness" or "firing into a melee".</param>
+/// <param name="Direction">Whether this pushes toward Easy or toward Difficult.</param>
+public sealed record DifficultyModifier(string Source, DifficultyDirection Direction) : Modifier(Source)
+{
+    /// <summary>An Easy condition.</summary>
+    public static DifficultyModifier Easy(string source) => new(source, DifficultyDirection.Easier);
+
+    /// <summary>A Difficult condition.</summary>
+    public static DifficultyModifier Difficult(string source) => new(source, DifficultyDirection.Harder);
+}

--- a/src/Brp.Core/Modifiers/GateModifier.cs
+++ b/src/Brp.Core/Modifiers/GateModifier.cs
@@ -1,0 +1,23 @@
+namespace Brp.Core.Modifiers;
+
+/// <summary>Whether a gate forces an action to auto-succeed or forbids it outright.</summary>
+public enum GateKind
+{
+    /// <summary>The action requires no roll and always succeeds.</summary>
+    Automatic,
+
+    /// <summary>The action cannot be attempted at all.</summary>
+    Impossible,
+}
+
+/// <summary>
+/// A modifier that short-circuits the pipeline instead of adjusting the base chance -- for
+/// example a task with no possible failure state, or one that cannot be attempted at all under
+/// the current circumstances. Per ADR 0007, a gate applies before any other stage, bypasses
+/// Override/PermanentAdditive/Multiplicative/SituationalAdditive/Clamp entirely, and consumes
+/// no entropy: no roll is drawn for a gated action, so a save-file replay is unaffected by
+/// whether one was attempted.
+/// </summary>
+/// <param name="Source">What produced this gate.</param>
+/// <param name="Kind">Whether the gated action always succeeds or cannot be attempted.</param>
+public sealed record GateModifier(string Source, GateKind Kind) : Modifier(Source);

--- a/src/Brp.Core/Modifiers/Modifier.cs
+++ b/src/Brp.Core/Modifiers/Modifier.cs
@@ -1,0 +1,15 @@
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// One situational adjustment to a skill's base chance, per Ch 5: System, "Modifying Action
+/// Rolls". Every modifier carries a <see cref="Source"/> label because the design pillar in
+/// <c>noir-rpg-framework.md</c> is that the rating shown to the player is the real probability
+/// -- a chain of anonymous numbers cannot be explained back to the table, but a chain of
+/// labelled ones can. See ADR 0007 for the ordering and difficulty-stacking rules that these
+/// feed into.
+/// </summary>
+/// <param name="Source">
+/// A short label identifying what produced this modifier (e.g. "darkness", "firing into
+/// combat"). Rendered verbatim in <see cref="ModifierChain.Render"/>.
+/// </param>
+public abstract record Modifier(string Source);

--- a/src/Brp.Core/Modifiers/ModifierChain.cs
+++ b/src/Brp.Core/Modifiers/ModifierChain.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+using Brp.Core.Resolution;
+
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// The result of running a set of <see cref="Modifier"/>s through <see cref="ModifierPipeline"/>:
+/// the base chance, either a short-circuiting gate or an ordered list of contributions, and the
+/// final effective chance. Self-describing by design -- ADR 0007 and the transparency pillar in
+/// <c>noir-rpg-framework.md</c> require that the engine can explain how it got a number, not
+/// just report it.
+/// </summary>
+public sealed record ModifierChain
+{
+    /// <summary>The unmodified base chance the chain started from.</summary>
+    public required Percent BaseChance { get; init; }
+
+    /// <summary>Non-null when a gate short-circuited the chain; no roll should be attempted.</summary>
+    public GateKind? Gate { get; init; }
+
+    /// <summary>The source labels responsible for <see cref="Gate"/>. Empty when not gated.</summary>
+    public IReadOnlyList<string> GateSources { get; init; } = [];
+
+    /// <summary>Every applied step, in the order the ordering policy produced them.</summary>
+    public IReadOnlyList<ModifierContribution> Contributions { get; init; } = [];
+
+    /// <summary>The final chance to resolve a roll against. Null when <see cref="IsGated"/>.</summary>
+    public Percent? EffectiveChance { get; init; }
+
+    /// <summary>True when a gate short-circuited the chain -- no roll should be attempted.</summary>
+    public bool IsGated => Gate is not null;
+
+    /// <summary>
+    /// Renders the full derivation, e.g. <c>65% &#8594; 33% (darkness &#247;2) &#8594; 13%
+    /// (firing into combat -20% [situational])</c>, or <c>10% &#8594; Impossible (no way to
+    /// attempt it)</c> when gated.
+    /// </summary>
+    public string Render()
+    {
+        const string arrow = " → ";
+
+        if (IsGated)
+        {
+            return $"{BaseChance}{arrow}{Gate} ({string.Join(", ", GateSources)})";
+        }
+
+        var sb = new StringBuilder(BaseChance.ToString());
+        foreach (var step in Contributions)
+        {
+            sb.Append(arrow).Append(step.ResultingChance).Append(" (").Append(step.Description).Append(')');
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Draws a roll and resolves it via <see cref="SkillResolver"/>, or returns
+    /// <see langword="null"/> without touching <paramref name="entropy"/> when
+    /// <see cref="IsGated"/> -- per ADR 0007, a gate consumes no entropy. The 5%-base-chance
+    /// floor is applied by <see cref="SkillResolver"/> itself, after this chain; it is not
+    /// duplicated here.
+    /// </summary>
+    public RollOutcome? Resolve(IEntropySource entropy, ResolutionPolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(entropy);
+        return IsGated ? null : SkillResolver.Resolve(BaseChance, EffectiveChance!.Value, entropy, policy);
+    }
+}

--- a/src/Brp.Core/Modifiers/ModifierContribution.cs
+++ b/src/Brp.Core/Modifiers/ModifierContribution.cs
@@ -1,0 +1,14 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// One recorded step in a <see cref="ModifierChain"/>'s derivation: the running chance
+/// immediately after this step was applied, and a human-readable description of what caused it.
+/// Recording every step, not just the final total, is what lets
+/// <see cref="ModifierChain.Render"/> explain itself.
+/// </summary>
+/// <param name="Source">The modifier source(s) responsible for this step.</param>
+/// <param name="Description">A short rendering of what happened, e.g. "firing into combat -20%".</param>
+/// <param name="ResultingChance">The running chance immediately after this step.</param>
+public sealed record ModifierContribution(string Source, string Description, Percent ResultingChance);

--- a/src/Brp.Core/Modifiers/ModifierPipeline.cs
+++ b/src/Brp.Core/Modifiers/ModifierPipeline.cs
@@ -1,0 +1,236 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// Turns a base chance and a set of <see cref="Modifier"/>s into a <see cref="ModifierChain"/>,
+/// per ADR 0007: Gate -&gt; Override -&gt; PermanentAdditive -&gt; Multiplicative -&gt;
+/// SituationalAdditive -&gt; Clamp. Additive modifiers split around Multiplicative because Ch 5,
+/// "Modifying Action Rolls" figures a modifier integral to the skill into the rating before a
+/// Difficult/Easy grade doubles or halves it, but applies a modifier describing the moment
+/// afterward, specifically so a stated penalty or bonus is not itself doubled or halved.
+/// Difficulty collapses into a single non-stacking state, with the multiplier values it applies
+/// declared on <see cref="ModifierPolicy"/> rather than hardcoded here; independent rational
+/// multipliers (<see cref="MultiplicativeModifier"/>) compose alongside it. Rules source: Ch 5,
+/// System -- "Modifying Action Rolls".
+/// </summary>
+public static class ModifierPipeline
+{
+    /// <summary>
+    /// Evaluates <paramref name="modifiers"/> against <paramref name="baseChance"/>.
+    /// </summary>
+    /// <param name="baseChance">The skill's unmodified base chance.</param>
+    /// <param name="modifiers">
+    /// The modifiers in effect. Relative order among modifiers of the same kind is preserved
+    /// for rendering (e.g. which additive penalty is listed first), but per ADR 0007 does not
+    /// change the arithmetic result within that kind -- additive deltas of the same
+    /// <see cref="AdditiveKind"/> sum regardless of order, and difficulty collapses to a net
+    /// direction regardless of order.
+    /// </param>
+    /// <param name="policy">
+    /// The stage order and difficulty-multiplier values to apply. Defaults to
+    /// <see cref="ModifierPolicy.Standard"/>, the only policy used in production; other policies
+    /// exist so a test can demonstrate that order, or the multiplier values, change the result.
+    /// </param>
+    /// <param name="roundingMode">
+    /// The rounding mode used by every multiplicative step. Defaults to
+    /// <see cref="RoundingMode.Up"/>, matching ADR 0007's worked example (32.5 rounds to 33,
+    /// not 32) and this codebase's convention of rounding a penalty in the player's favor.
+    /// </param>
+    public static ModifierChain Evaluate(
+        Percent baseChance,
+        IEnumerable<Modifier> modifiers,
+        ModifierPolicy? policy = null,
+        RoundingMode roundingMode = RoundingMode.Up)
+    {
+        ArgumentNullException.ThrowIfNull(modifiers);
+        policy ??= ModifierPolicy.Standard;
+
+        var modifierList = modifiers as IReadOnlyCollection<Modifier> ?? modifiers.ToList();
+        var running = baseChance;
+        var contributions = new List<ModifierContribution>();
+
+        foreach (var stage in policy.Stages)
+        {
+            if (stage == ModifierStage.Gate)
+            {
+                // Ch 5, "Modifying Action Rolls" / ADR 0007: a gate short-circuits everything
+                // else and must not consume entropy, so it is resolved before any roll-shaped
+                // work happens rather than folded into ApplyStage.
+                var gates = modifierList.OfType<GateModifier>().ToList();
+                if (gates.Count == 0)
+                {
+                    continue;
+                }
+
+                // Impossible takes precedence over Automatic when both are asserted at once:
+                // refusing an action is the safer default than silently auto-succeeding it.
+                var kind = gates.Any(g => g.Kind == GateKind.Impossible)
+                    ? GateKind.Impossible
+                    : GateKind.Automatic;
+                var sources = gates.Where(g => g.Kind == kind).Select(g => g.Source).ToList();
+
+                return new ModifierChain
+                {
+                    BaseChance = baseChance,
+                    Gate = kind,
+                    GateSources = sources,
+                    Contributions = contributions,
+                    EffectiveChance = null,
+                };
+            }
+
+            running = ApplyStage(stage, modifierList, running, policy, roundingMode, contributions);
+        }
+
+        return new ModifierChain
+        {
+            BaseChance = baseChance,
+            Contributions = contributions,
+            EffectiveChance = running,
+        };
+    }
+
+    private static Percent ApplyStage(
+        ModifierStage stage,
+        IReadOnlyCollection<Modifier> modifiers,
+        Percent running,
+        ModifierPolicy policy,
+        RoundingMode roundingMode,
+        List<ModifierContribution> contributions)
+    {
+        switch (stage)
+        {
+            case ModifierStage.Override:
+                foreach (var o in modifiers.OfType<OverrideModifier>())
+                {
+                    running = o.Value;
+                    contributions.Add(
+                        new ModifierContribution(o.Source, $"{o.Source} overrides to {o.Value}", running));
+                }
+
+                return running;
+
+            case ModifierStage.PermanentAdditive:
+                return ApplyAdditive(AdditiveKind.Permanent, modifiers, running, contributions);
+
+            case ModifierStage.SituationalAdditive:
+                return ApplyAdditive(AdditiveKind.Situational, modifiers, running, contributions);
+
+            case ModifierStage.Multiplicative:
+                return ApplyMultiplicative(modifiers, running, policy, roundingMode, contributions);
+
+            case ModifierStage.Clamp:
+                // Percent floors at zero on every operation already, so this never changes the
+                // value in practice. Kept explicit because ADR 0007 names Clamp as its own
+                // stage, and because Percent's continuous flooring is only equivalent to a
+                // single end-of-chain clamp because every later stage is multiplicative
+                // (scaling a floored zero can never recover a "true" negative) -- a fact worth
+                // stating rather than leaving implicit.
+                return Percent.Of(running.Value);
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(stage), stage, "Gate is handled by the caller.");
+        }
+    }
+
+    private static Percent ApplyAdditive(
+        AdditiveKind kind,
+        IReadOnlyCollection<Modifier> modifiers,
+        Percent running,
+        List<ModifierContribution> contributions)
+    {
+        // Ch 5, "Modifying Action Rolls": a permanent modifier is figured into the rating
+        // before the difficulty multiplier; a situational one is applied after, so its stated
+        // weight is not itself doubled or halved. Tagging the kind in the description is what
+        // lets Render() answer "why did my -20 apply after the halving?" (ADR 0007).
+        var label = kind == AdditiveKind.Permanent ? "permanent" : "situational";
+
+        foreach (var a in modifiers.OfType<AdditiveModifier>().Where(a => a.Kind == kind))
+        {
+            running = running.Add(a.Delta);
+            var sign = a.Delta >= 0 ? "+" : string.Empty;
+            contributions.Add(
+                new ModifierContribution(a.Source, $"{a.Source} {sign}{a.Delta}% [{label}]", running));
+        }
+
+        return running;
+    }
+
+    private static Percent ApplyMultiplicative(
+        IReadOnlyCollection<Modifier> modifiers,
+        Percent running,
+        ModifierPolicy policy,
+        RoundingMode roundingMode,
+        List<ModifierContribution> contributions)
+    {
+        var plainMultipliers = modifiers.OfType<MultiplicativeModifier>().ToList();
+        foreach (var m in plainMultipliers)
+        {
+            if (m.Numerator <= 0 || m.Denominator <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(modifiers),
+                    $"'{m.Source}' has a non-positive multiplier ({m.Numerator}/{m.Denominator}).");
+            }
+        }
+
+        // Difficulty is a state, not a stack (ADR 0007): any number of Difficult sources
+        // produce one halving, any number of Easy sources produce one doubling, and the two
+        // cancel pairwise. Taking the sign of the sum of each source's own direction (+1 for
+        // Easy, -1 for Difficult) reproduces exactly that: magnitude beyond +/-1 never matters.
+        // The actual multiplier applied comes from the policy, not from the modifier --
+        // DifficultyModifier carries no numerator/denominator of its own (see its remarks).
+        var difficulty = modifiers.OfType<DifficultyModifier>().ToList();
+        if (difficulty.Count > 0)
+        {
+            var net = Math.Sign(difficulty.Sum(d => d.Direction == DifficultyDirection.Easier ? 1 : -1));
+            var sources = string.Join(", ", difficulty.Select(d => d.Source));
+
+            switch (net)
+            {
+                case > 0:
+                    running = running.Scale(policy.EasyNumerator, policy.EasyDenominator, roundingMode);
+                    contributions.Add(new ModifierContribution(
+                        sources, $"{sources} {RenderRatio(policy.EasyNumerator, policy.EasyDenominator)}", running));
+                    break;
+                case < 0:
+                    running = running.Scale(policy.DifficultNumerator, policy.DifficultDenominator, roundingMode);
+                    contributions.Add(new ModifierContribution(
+                        sources,
+                        $"{sources} {RenderRatio(policy.DifficultNumerator, policy.DifficultDenominator)}",
+                        running));
+                    break;
+                default:
+                    contributions.Add(new ModifierContribution(sources, $"{sources} cancel out", running));
+                    break;
+            }
+        }
+
+        // Independent rational multipliers compose alongside the net difficulty grade rather
+        // than folding into it (ADR 0007), applied in the order supplied.
+        foreach (var m in plainMultipliers)
+        {
+            running = running.Scale(m.Numerator, m.Denominator, roundingMode);
+            contributions.Add(
+                new ModifierContribution(m.Source, $"{m.Source} {RenderRatio(m.Numerator, m.Denominator)}", running));
+        }
+
+        return running;
+    }
+
+    private static string RenderRatio(int numerator, int denominator)
+    {
+        if (denominator == 1)
+        {
+            return $"×{numerator}";
+        }
+
+        if (numerator == 1)
+        {
+            return $"÷{denominator}";
+        }
+
+        return $"×{numerator}/{denominator}";
+    }
+}

--- a/src/Brp.Core/Modifiers/ModifierPolicy.cs
+++ b/src/Brp.Core/Modifiers/ModifierPolicy.cs
@@ -1,0 +1,44 @@
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// The stage order and difficulty-multiplier values a <see cref="ModifierPipeline"/> uses, held
+/// as declared data rather than as constants scattered through the pipeline -- the same
+/// precedent as <see cref="Resolution.ResolutionPolicy"/> for the resolver's grading constants.
+/// <para>
+/// Per ADR 0007 and Ch 5: System, "Modifying Action Rolls", ordering changes the result: a 65%
+/// rating with a -20% situational penalty and a halving in near-darkness resolves 65 / 2 = 33
+/// (round up from 32.5), then 33 - 20 = 13%, under Gate -&gt; Override -&gt; PermanentAdditive
+/// -&gt; Multiplicative -&gt; SituationalAdditive -&gt; Clamp -- the book applies the
+/// situational modifier after the difficulty grade specifically so a stated -20% is not itself
+/// halved to -10%. Collapsing both additive stages ahead of Multiplicative instead gives the
+/// rejected 23%.
+/// </para>
+/// </summary>
+/// <param name="Stages">The stages to apply, in order. Repeats and omissions are permitted.</param>
+/// <param name="EasyNumerator">Numerator of the multiplier a net Easy grade applies.</param>
+/// <param name="EasyDenominator">Denominator of the multiplier a net Easy grade applies.</param>
+/// <param name="DifficultNumerator">Numerator of the multiplier a net Difficult grade applies.</param>
+/// <param name="DifficultDenominator">Denominator of the multiplier a net Difficult grade applies.</param>
+public sealed record ModifierPolicy(
+    IReadOnlyList<ModifierStage> Stages,
+    int EasyNumerator,
+    int EasyDenominator,
+    int DifficultNumerator,
+    int DifficultDenominator)
+{
+    /// <summary>The order and values fixed by ADR 0007 and Ch 5. The only policy used by production rulesets.</summary>
+    public static ModifierPolicy Standard { get; } = new(
+        Stages:
+        [
+            ModifierStage.Gate,
+            ModifierStage.Override,
+            ModifierStage.PermanentAdditive,
+            ModifierStage.Multiplicative,
+            ModifierStage.SituationalAdditive,
+            ModifierStage.Clamp,
+        ],
+        EasyNumerator: 2,
+        EasyDenominator: 1,
+        DifficultNumerator: 1,
+        DifficultDenominator: 2);
+}

--- a/src/Brp.Core/Modifiers/ModifierStage.cs
+++ b/src/Brp.Core/Modifiers/ModifierStage.cs
@@ -1,0 +1,28 @@
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// The named stages a <see cref="ModifierPipeline"/> applies, in policy order. Additive
+/// modifiers split into two stages -- Ch 5: System, "Modifying Action Rolls" figures a
+/// permanent modifier into the rating before Difficult/Easy doubles or halves it, and applies a
+/// situational modifier afterward, so its stated weight is not itself doubled or halved.
+/// </summary>
+public enum ModifierStage
+{
+    /// <summary>Automatic/Impossible short-circuits. Consumes no entropy.</summary>
+    Gate,
+
+    /// <summary>Replaces the running chance outright.</summary>
+    Override,
+
+    /// <summary>Flat +/- adjustments integral to the skill rating. Applied before Multiplicative.</summary>
+    PermanentAdditive,
+
+    /// <summary>Net difficulty state, plus independent rational multipliers.</summary>
+    Multiplicative,
+
+    /// <summary>Flat +/- adjustments describing the moment. Applied after Multiplicative.</summary>
+    SituationalAdditive,
+
+    /// <summary>Floors the result at zero. No ceiling.</summary>
+    Clamp,
+}

--- a/src/Brp.Core/Modifiers/MultiplicativeModifier.cs
+++ b/src/Brp.Core/Modifiers/MultiplicativeModifier.cs
@@ -1,0 +1,13 @@
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// An independent rational multiplier applied to the running chance -- Ch 5: System,
+/// "Modifying Action Rolls". Expressed as a fraction rather than a fixed set of named values
+/// because the book's multiplicative modifiers are not limited to doubling or halving.
+/// Difficulty grades are a separate, non-stacking state represented by
+/// <see cref="DifficultyModifier"/>, not by this type -- see ADR 0007.
+/// </summary>
+/// <param name="Source">What produced this multiplier.</param>
+/// <param name="Numerator">The multiplier's numerator. Must be positive.</param>
+/// <param name="Denominator">The multiplier's denominator. Must be positive.</param>
+public sealed record MultiplicativeModifier(string Source, int Numerator, int Denominator) : Modifier(Source);

--- a/src/Brp.Core/Modifiers/OverrideModifier.cs
+++ b/src/Brp.Core/Modifiers/OverrideModifier.cs
@@ -1,0 +1,13 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Modifiers;
+
+/// <summary>
+/// A modifier that replaces the running chance outright rather than adjusting it -- for example
+/// a shield's flat parry chance against missiles (Ch 7, Spot Rules). Per ADR 0007 this stage
+/// runs immediately after Gate and before PermanentAdditive/Multiplicative/SituationalAdditive,
+/// so later stages adjust the replacement value rather than the original base.
+/// </summary>
+/// <param name="Source">What produced this override, e.g. "shield parry".</param>
+/// <param name="Value">The chance to replace the running value with.</param>
+public sealed record OverrideModifier(string Source, Percent Value) : Modifier(Source);

--- a/tests/Brp.Core.Tests/Modifiers/ModifierPipelineTests.cs
+++ b/tests/Brp.Core.Tests/Modifiers/ModifierPipelineTests.cs
@@ -1,0 +1,385 @@
+using Brp.Core.Modifiers;
+using Brp.Core.Primitives;
+using Brp.Core.Resolution;
+using Brp.Core.Tests.Dice;
+
+namespace Brp.Core.Tests.Modifiers;
+
+/// <summary>
+/// Covers the typed modifier pipeline against ADR 0007: Gate -&gt; Override -&gt;
+/// PermanentAdditive -&gt; Multiplicative -&gt; SituationalAdditive -&gt; Clamp, difficulty as a
+/// non-stacking state whose multiplier values live on <see cref="ModifierPolicy"/> rather than
+/// on the modifier or a factory, and independent rational multipliers composing alongside it.
+/// Ch 5: System, "Modifying Action Rolls".
+/// </summary>
+public class ModifierPipelineTests
+{
+    // ---- Each modifier kind in isolation --------------------------------------------------
+
+    [Theory]
+    [InlineData(GateKind.Automatic)]
+    [InlineData(GateKind.Impossible)]
+    public void A_gate_short_circuits_with_no_effective_chance_and_no_contributions(GateKind kind)
+    {
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(50), [new GateModifier("no possible failure", kind)]);
+
+        Assert.True(chain.IsGated);
+        Assert.Equal(kind, chain.Gate);
+        Assert.Equal(["no possible failure"], chain.GateSources);
+        Assert.Null(chain.EffectiveChance);
+        Assert.Empty(chain.Contributions);
+    }
+
+    [Fact]
+    public void An_override_replaces_the_base_chance_outright()
+    {
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(30), [new OverrideModifier("shield parry", Percent.Of(60))]);
+
+        Assert.Equal(Percent.Of(60), chain.EffectiveChance);
+        Assert.Single(chain.Contributions);
+    }
+
+    [Theory]
+    [InlineData(50, -20, 30)]
+    [InlineData(50, 10, 60)]
+    [InlineData(10, -50, 0)] // floors at zero rather than going negative
+    public void A_situational_additive_modifier_applies_a_signed_delta(int baseChance, int delta, int expected)
+    {
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(baseChance), [new AdditiveModifier("penalty or bonus", delta)]);
+
+        Assert.Equal(Percent.Of(expected), chain.EffectiveChance);
+    }
+
+    [Theory]
+    [InlineData(50, -20, 30)]
+    [InlineData(50, 10, 60)]
+    public void A_permanent_additive_modifier_applies_a_signed_delta(int baseChance, int delta, int expected)
+    {
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(baseChance),
+            [new AdditiveModifier("integral trait", delta, AdditiveKind.Permanent)]);
+
+        Assert.Equal(Percent.Of(expected), chain.EffectiveChance);
+    }
+
+    [Theory]
+    [InlineData(2, 1, 100, 200)]  // x2
+    [InlineData(1, 2, 100, 50)]   // half
+    [InlineData(1, 4, 100, 25)]   // quarter
+    [InlineData(1, 4, 45, 12)]    // quarter, with rounding: ceil(45/4) = 12
+    public void A_multiplicative_modifier_applies_a_rational_factor(
+        int numerator, int denominator, int baseChance, int expected)
+    {
+        // The numbers here are illustrative only, chosen to exercise the arithmetic -- this is
+        // not a book rule. MultiplicativeModifier is a generic capability for an arbitrary
+        // independent rational multiplier; what specific multipliers exist (weapon range,
+        // lighting, etc.) is a later Issue's concern.
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(baseChance), [new MultiplicativeModifier("illustrative multiplier", numerator, denominator)]);
+
+        Assert.Equal(Percent.Of(expected), chain.EffectiveChance);
+    }
+
+    // ---- Ordering is a named policy, not implicit in call order -------------------------
+
+    [Fact]
+    public void Standard_order_matches_the_ADR_worked_example()
+    {
+        // Ch 5, "Modifying Action Rolls" / ADR 0007: a 65% rating with a -20% *situational*
+        // penalty (firing into combat) and a halving in near-darkness resolves 65 / 2 = 33
+        // (round up from 32.5), then 33 - 20 = 13%. The situational modifier is applied AFTER
+        // the difficulty grade so its stated -20% is not itself halved to -10%.
+        Modifier[] modifiers =
+        [
+            new AdditiveModifier("firing into combat", -20),
+            DifficultyModifier.Difficult("darkness"),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(65), modifiers);
+
+        Assert.Equal(Percent.Of(13), chain.EffectiveChance);
+    }
+
+    [Fact]
+    public void Collapsing_additive_before_multiplicative_gives_the_rejected_answer()
+    {
+        // Proves ordering is read from the policy, not hardcoded in call order: moving
+        // SituationalAdditive ahead of Multiplicative reproduces the ordering the book (and
+        // ADR 0007) explicitly rejects -- the situational penalty gets halved along with the
+        // base rating instead of applying to what the halved rating already is.
+        var collapsedOrder = ModifierPolicy.Standard with
+        {
+            Stages =
+            [
+                ModifierStage.Gate,
+                ModifierStage.Override,
+                ModifierStage.PermanentAdditive,
+                ModifierStage.SituationalAdditive,
+                ModifierStage.Multiplicative,
+                ModifierStage.Clamp,
+            ],
+        };
+
+        Modifier[] modifiers =
+        [
+            new AdditiveModifier("firing into combat", -20),
+            DifficultyModifier.Difficult("darkness"),
+        ];
+
+        var standard = ModifierPipeline.Evaluate(Percent.Of(65), modifiers);
+        var collapsed = ModifierPipeline.Evaluate(Percent.Of(65), modifiers, collapsedOrder);
+
+        Assert.Equal(Percent.Of(13), standard.EffectiveChance);
+        Assert.Equal(Percent.Of(23), collapsed.EffectiveChance);
+        Assert.NotEqual(standard.EffectiveChance, collapsed.EffectiveChance);
+    }
+
+    [Fact]
+    public void A_permanent_additive_modifier_applies_before_the_difficulty_multiplier()
+    {
+        // Ch 5: a modifier integral to the rating is figured in before Difficult/Easy scales
+        // it. 65 + 10 = 75, then 75 / 2 = 38 (round up from 37.5).
+        Modifier[] modifiers =
+        [
+            new AdditiveModifier("marksmanship training", 10, AdditiveKind.Permanent),
+            DifficultyModifier.Difficult("darkness"),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(65), modifiers);
+
+        Assert.Equal(Percent.Of(38), chain.EffectiveChance);
+    }
+
+    [Fact]
+    public void Permanent_and_situational_additive_modifiers_interleave_around_multiplicative()
+    {
+        // Exercises all three middle stages in one chain: permanent first (65 + 10 = 75),
+        // then multiplicative (75 / 2 = 38, round up from 37.5), then situational last
+        // (38 - 20 = 18).
+        Modifier[] modifiers =
+        [
+            new AdditiveModifier("marksmanship training", 10, AdditiveKind.Permanent),
+            new AdditiveModifier("firing into combat", -20),
+            DifficultyModifier.Difficult("darkness"),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(65), modifiers);
+
+        Assert.Equal(Percent.Of(18), chain.EffectiveChance);
+        Assert.Equal(3, chain.Contributions.Count);
+        Assert.Equal(Percent.Of(75), chain.Contributions[0].ResultingChance); // permanent first
+        Assert.Equal(Percent.Of(38), chain.Contributions[1].ResultingChance); // then multiplicative
+        Assert.Equal(Percent.Of(18), chain.Contributions[2].ResultingChance); // situational last
+    }
+
+    // ---- Difficulty is a state, not a stack ----------------------------------------------
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void Any_number_of_Difficult_sources_produce_exactly_one_halving(int sourceCount)
+    {
+        var modifiers = Enumerable.Range(1, sourceCount)
+            .Select(i => DifficultyModifier.Difficult($"condition {i}"))
+            .Cast<Modifier>()
+            .ToArray();
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(100), modifiers);
+
+        Assert.Equal(Percent.Of(50), chain.EffectiveChance);
+        // One collapsed step for the whole difficulty state, not one per source.
+        Assert.Single(chain.Contributions);
+    }
+
+    [Fact]
+    public void Easy_and_Difficult_cancel_pairwise_to_normal()
+    {
+        Modifier[] modifiers =
+        [
+            DifficultyModifier.Easy("streetwise contact"),
+            DifficultyModifier.Difficult("near-darkness"),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(80), modifiers);
+
+        Assert.Equal(Percent.Of(80), chain.EffectiveChance);
+    }
+
+    [Fact]
+    public void Two_easy_and_one_difficult_net_to_a_single_easy_step_not_a_double_bonus()
+    {
+        // Net direction is the sign of the sum, not the sum itself: 2 Easy - 1 Difficult
+        // nets +1, i.e. one doubling, never two.
+        Modifier[] modifiers =
+        [
+            DifficultyModifier.Easy("home turf"),
+            DifficultyModifier.Easy("plenty of time"),
+            DifficultyModifier.Difficult("hostile crowd"),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(30), modifiers);
+
+        Assert.Equal(Percent.Of(60), chain.EffectiveChance);
+    }
+
+    // ---- Difficulty multiplier values live in policy data, not on the modifier ------------
+
+    [Fact]
+    public void Difficulty_multiplier_values_come_from_policy_not_from_the_modifier()
+    {
+        // DifficultyModifier carries no numerator/denominator of its own -- the multiplier a
+        // net Easy or Difficult grade applies is declared on ModifierPolicy and read at
+        // evaluation time, the same way ResolutionPolicy's threshold constants are read at
+        // resolve time rather than baked into the roll. A custom policy proves the values
+        // really are data: this is not the book's own grade, just a check that the plumbing
+        // reads from the policy that was actually passed in.
+        var customPolicy = ModifierPolicy.Standard with { DifficultNumerator = 1, DifficultDenominator = 5 };
+
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(100), [DifficultyModifier.Difficult("severe hazard")], customPolicy);
+
+        Assert.Equal(Percent.Of(20), chain.EffectiveChance); // 100 * 1/5, not the Standard 1/2
+    }
+
+    // ---- Gates short-circuit and consume no entropy ----------------------------------------
+
+    [Fact]
+    public void Impossible_takes_precedence_when_both_gate_kinds_are_asserted()
+    {
+        Modifier[] modifiers =
+        [
+            new GateModifier("no possible failure", GateKind.Automatic),
+            new GateModifier("impassable obstacle", GateKind.Impossible),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(70), modifiers);
+
+        Assert.Equal(GateKind.Impossible, chain.Gate);
+        Assert.Equal(["impassable obstacle"], chain.GateSources);
+    }
+
+    [Fact]
+    public void A_gated_chain_draws_no_roll_and_consumes_no_entropy()
+    {
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(70), [new GateModifier("impassable obstacle", GateKind.Impossible)]);
+        var entropy = new FixedEntropySource(50);
+
+        var outcome = chain.Resolve(entropy);
+
+        Assert.Null(outcome);
+        Assert.Equal(0, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void An_ungated_chain_draws_exactly_one_roll()
+    {
+        var chain = ModifierPipeline.Evaluate(Percent.Of(50), []);
+        var entropy = new FixedEntropySource(20);
+
+        var outcome = chain.Resolve(entropy);
+
+        Assert.NotNull(outcome);
+        Assert.Equal(20, outcome!.Roll);
+        Assert.Equal(SuccessLevel.Success, outcome.Level);
+        Assert.Equal(1, entropy.DrawCount);
+    }
+
+    // ---- Clamp floors at zero, but does not cap at 100 -------------------------------------
+
+    [Fact]
+    public void Clamp_floors_the_final_chance_at_zero()
+    {
+        var chain = ModifierPipeline.Evaluate(Percent.Of(10), [new AdditiveModifier("severe penalty", -50)]);
+
+        Assert.Equal(Percent.Zero, chain.EffectiveChance);
+    }
+
+    [Fact]
+    public void Clamp_does_not_cap_the_final_chance_at_one_hundred()
+    {
+        var chain = ModifierPipeline.Evaluate(Percent.Of(80), [DifficultyModifier.Easy("perfect conditions")]);
+
+        Assert.Equal(Percent.Of(160), chain.EffectiveChance);
+    }
+
+    // ---- The 5% floor lives in the resolver, applied after this pipeline ------------------
+
+    [Fact]
+    public void The_five_percent_floor_still_rescues_a_roll_after_the_pipeline_crushes_the_chance()
+    {
+        // 10 -> (halved by darkness) 5 -> (situational -8, applied after the halving) floors
+        // at 0. The resolver's 5%-floor rule still rescues a roll of 1-5 because it keys on
+        // the unmodified base chance (10 >= 5), not on this crushed effective chance.
+        Modifier[] modifiers =
+        [
+            new AdditiveModifier("severe penalty", -8),
+            DifficultyModifier.Difficult("near-darkness"),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(10), modifiers);
+        Assert.Equal(Percent.Zero, chain.EffectiveChance);
+
+        var outcome = chain.Resolve(new FixedEntropySource(5));
+
+        Assert.NotNull(outcome);
+        Assert.Equal(SuccessLevel.Success, outcome!.Level);
+    }
+
+    // ---- The chain renders its own derivation ----------------------------------------------
+
+    [Fact]
+    public void Render_matches_the_ADR_worked_example_exactly()
+    {
+        Modifier[] modifiers =
+        [
+            new AdditiveModifier("firing into combat", -20),
+            DifficultyModifier.Difficult("darkness"),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(65), modifiers);
+
+        Assert.Equal("65% → 33% (darkness ÷2) → 13% (firing into combat -20% [situational])", chain.Render());
+    }
+
+    [Fact]
+    public void Render_distinguishes_permanent_from_situational_additive_steps()
+    {
+        Modifier[] modifiers =
+        [
+            new AdditiveModifier("marksmanship training", 10, AdditiveKind.Permanent),
+            new AdditiveModifier("firing into combat", -20),
+            DifficultyModifier.Difficult("darkness"),
+        ];
+
+        var chain = ModifierPipeline.Evaluate(Percent.Of(65), modifiers);
+
+        Assert.Equal(
+            "65% → 75% (marksmanship training +10% [permanent]) → 38% (darkness ÷2) "
+            + "→ 18% (firing into combat -20% [situational])",
+            chain.Render());
+    }
+
+    [Fact]
+    public void Render_describes_a_gate_without_an_effective_chance()
+    {
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(10), [new GateModifier("impassable obstacle", GateKind.Impossible)]);
+
+        Assert.Equal("10% → Impossible (impassable obstacle)", chain.Render());
+    }
+
+    // ---- Guardrails -------------------------------------------------------------------------
+
+    [Fact]
+    public void A_non_positive_multiplier_denominator_throws_rather_than_dividing_by_zero()
+    {
+        var modifiers = new Modifier[] { new MultiplicativeModifier("broken", 1, 0) };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ModifierPipeline.Evaluate(Percent.Of(50), modifiers));
+    }
+}


### PR DESCRIPTION
## Linked Issues

Closes #11 — the pipeline
Closes #2 — does difficulty stack
Closes #3 — modifier ordering

Three Issues deliberately. #2 and #3 are `needs-design` items whose entire deliverable
is a decision, and that decision's artifact is ADR 0007, which lands here. The pipeline
cannot be implemented without both settled, so the coupling is real rather than
incidental.

## Exact behavioral claim

A base chance plus a set of modifiers produces an effective chance, through a named,
ordered, inspectable pipeline that can render its own derivation:

```
65% → 33% (darkness ÷2) → 13% (firing into combat -20% [situational])
```

That rendering is not decoration. The design pillar is that the player sees the real
probability, which is undeliverable if the engine cannot explain how it got there.

## Rules conformance

**Ordering: CONFIRMED against the book.** Ch 5, "Modifying Action Rolls" states that
situational modifiers apply *after* a skill is made Difficult or Easy, expressly so
they are not themselves halved, and that permanent modifiers integral to the skill are
folded in *before*. Two additive stages, not one.

Both worked examples verified: `65% + situational −20% + Difficult = 13%`, and
`65% + permanent +10 + Difficult = 38%`. The halving rounds up, which is the book's
explicit word rather than an inference. All five difficulty grades match.

**Difficulty non-stacking is a house rule and is labelled as one.** The book does not
decide whether two Difficult grades compound. Three passages point the same way —
augments adjust difficulty by one step and say only one step is possible; Disguise
answers multiple Difficult conditions with a flat penalty rather than a second halving;
Simple Fatigue names its own factor instead of chaining halvings.

**Easy/Difficult cancellation IS sourced** — Ch 7, "Firing Into Combat" works exactly
that cancellation. An earlier ADR draft filed this under "the source is silent," which
was wrong and forfeited a real citation.

## What review caught

This PR went through two corrections. Both were errors in the ADR, not the
implementation.

**The ordering was wrong the first time.** The ADR framed it as an open question with
two candidate answers; the book specifies it, and specifies a three-stage scheme
neither candidate described.

**The range-band section was wrong in every particular** — wrong multipliers, wrong
thresholds, a fabricated "beyond three times range is impossible" rule, and Point Blank
missing entirely. Its stated rationale, that range bands are not difficulty, is refuted
by the text: point blank *is* Easy and medium range *is* Difficult, by name. The
separate tier existed to stop range collapsing with other Difficult conditions, and
that collapse is the book's behaviour. Removed and filed as #21 with the wrong values
recorded so they cannot be reintroduced.

**A reproducible defect.** A difficulty modifier could be constructed with any ratio,
and the pipeline silently rewrote it to a halving — a 1/5 became 1/2 with no error.
The implementing agent declined both fixes I offered (private constructor, or
validate-and-throw) and instead removed the ratio fields from difficulty modifiers
entirely, so the defect is unrepresentable rather than guarded. That is the better
call; keeping fields that exist only to be overridden reproduces the same smell.

It substituted a test accordingly: rather than asserting a malformed ratio is rejected
(now impossible), it passes a custom policy of 1/5 and asserts the pipeline applies it,
proving the values are genuinely policy-driven rather than baked in. Endorsed.

**`scope-warden` item 6** failed on the Difficult/Easy multipliers being literals in
factory bodies. Moved into `ModifierPolicy` alongside the stage list, matching the
`ResolutionPolicy` precedent from #10.

**Citation defects:** several files cited a chapter section that does not exist, and an
example attributed a −20% armor figure to a chapter stating armor does not affect
weapon skills at all. Removed and replaced with a correctly-cited real value.

## Tests and evidence

```
dotnet build   -> Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test    -> Passed! Failed: 0, Passed: 259, Skipped: 0, Total: 259
dotnet format --verify-no-changes -> clean
```

Verified independently after each correction. Confirmed by grep that no range-band
claim survives, that the multipliers now live in policy, and that `MultiplierKind` — the
type that made the defect representable — is gone entirely.

## Known limitations

- The gamemaster's discretionary 1% on an Impossible action is not expressible, since
  gates short-circuit before overrides. Latent, not yet wrong; recorded in the ADR.
- Long range's "1/5 of normal" semantics are undecided — resolved against the base or
  as a multiplier on the running value. Flagged on #21 before it calcifies.
- `Percent` permitting values above 100 rests on an *optional* book rule for high-power
  campaigns, not the default. Pre-existing from #10; noted so it is not cited as baseline.

## Agent provenance

Implemented by `engine-dev` (Sonnet) across three passes, gated by `scope-warden`
(Haiku), verified by `rules-conformance` (Opus). The conformance pass found six defects
the implementation and both gates missed, all of them in material I asserted rather than
checked.

## Checklist

- [x] The linked Issues and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).