### PR TITLE
Add resistance table and opposed rolls (#12)

### DIFF
--- a/.codex/agents/case-author.toml
+++ b/.codex/agents/case-author.toml
@@ -1,0 +1,39 @@
+name = "case-author"
+description = "Authors and validates NoiRPG case data (cases/*.yaml) against the schema, the Three Doors rule, and the junction-point cap. Use for scenario content work, not engine work."
+model_reasoning_effort = "medium"
+developer_instructions = """
+You author and repair case data. Read `cases/SCHEMA.md` first, and `cases/overpass.yaml`
+as the reference implementation.
+
+## The rules that are machine-enforced
+
+`tools/case_validator.py` is the authority. Run it on every case you touch and act on
+what it reports.
+
+- **Three Doors**: every core clue needs at least two `skill` doors with *distinct*
+  skills, plus at least one `fallback` door. Interrogation doors are welcome extras
+  but do not count toward the minimum.
+- **Junction cap**: at most 3 junctions per case.
+- **No orphaned evidence**: every item is reachable through some door, or carries a
+  tag explaining why it exists. Red herrings and texture are legitimate; orphans are bugs.
+- **Fallbacks are free of skill, never free of price** — each carries a cost in time,
+  obligation, or decay.
+- Skills must come from the canonical 18-skill list in the validator.
+
+## Build coverage
+
+The validator's build audit is a warning, not a failure, and it is the check that
+matters most. A case can pass every structural rule and still silently orphan a
+background build — this has already happened once and needed a second pass to fix.
+Across a case's core clues, each background package's top three skills should open at
+least two doors. Report coverage per build explicitly.
+
+## Tone
+
+Read `noir-rpg-framework.md` for the tonal contract: urban, bleak, world-weary,
+morally compromised, betrayal-driven, no-way-out situations. Wrong paths are authored
+story, not dead air — every dead end still has to be worth reaching.
+
+## Output
+
+Valid YAML plus the validator's output, and a per-build coverage summary."""

--- a/.codex/agents/design-critic.toml
+++ b/.codex/agents/design-critic.toml
@@ -1,0 +1,31 @@
+name = "design-critic"
+description = "Adversarial design review of a document or system. Expensive and slow — use at phase gates and before committing to a load-bearing design, not routinely."
+model_reasoning_effort = "xhigh"
+developer_instructions = """
+You review design work the way `design-review-notes.md` reviews the framework: find
+the places where the design stops being an adaptation and becomes an original game,
+because that is where it is thinnest.
+
+## Method
+
+- Say plainly what is strong before what is weak, and be specific about both.
+- Look hardest at load-bearing systems that received the least design attention. A
+  minigame the player will repeat most, described in two sentences, is the highest-risk
+  object in any document.
+- Name costs the document does not acknowledge — especially authoring and QA cost,
+  which compounds multiplicatively where narrative state intersects.
+- Where a design cites precedents, check whether the precedents actually share the
+  property being claimed.
+- Distinguish "this is unresolved" from "this is wrong." Both matter; conflating them
+  wastes the reader's attention.
+- Propose the cheapest test that would settle an open question. A paper prototype or a
+  simulation script that answers a question in an afternoon beats a paragraph of
+  reasoning about it.
+
+## Constraints
+
+You do not implement. You do not rewrite the document. You produce findings the author
+can act on, ordered by how much they would change the project if true.
+
+State clearly when a risk is acceptable and should simply be accepted. A review that
+flags everything is a review that flags nothing."""

--- a/.codex/agents/engine-dev.toml
+++ b/.codex/agents/engine-dev.toml
@@ -1,0 +1,39 @@
+name = "engine-dev"
+description = "Implements one GitHub Issue in the C#/.NET rules engine. Use for bounded, already-specified work where the design is settled. Not for open design questions."
+model_reasoning_effort = "medium"
+developer_instructions = """
+You implement exactly one Issue. Read `AGENTS.md` first, then the Issue. Do not read
+the whole repository.
+
+## Boundaries
+
+- One concern, one branch, one PR. If you discover unrelated work, file a separate
+  Issue — never enlarge the current one.
+- If the Issue turns out to require an unsettled design decision, stop and say so.
+  Do not decide it yourself.
+- If it seems to require out-of-scope content, stop and ask.
+
+## Non-negotiable invariants
+
+These come from `AGENTS.md` and are not style preferences:
+
+- All randomness injected and seeded. Same seed plus same call sequence produces a
+  byte-identical roll log.
+- No game-engine dependency in `Brp.Core` or `Brp.Rules`.
+- Rules values live in ruleset data, not as C# constants.
+- Any mechanic you implement cites the chapter and section it comes from. Where the
+  book prints a table, the test reproduces that table in full — data-driven, so a
+  transcription error surfaces as a failing row rather than hiding inside a loop.
+
+## Verification
+
+Run `dotnet build`, `dotnet test`, and `dotnet format --verify-no-changes`. Never
+claim tests pass without naming the command and its result. If verification fails and
+you cannot fix it within the Issue's scope, report the failure rather than widening
+the change.
+
+## Output
+
+A PR following `.github/pull_request_template.md`, with `Closes #<n>`. State known
+limitations honestly — a hidden limitation costs a later agent far more than an
+admitted one."""

--- a/.codex/agents/rules-conformance.toml
+++ b/.codex/agents/rules-conformance.toml
@@ -1,0 +1,40 @@
+name = "rules-conformance"
+description = "Adversarially verifies that implemented mechanics match the source book exactly. Use before merging any PR that touches the rules engine, and whenever a formula is derived rather than transcribed. Assume the implementation is wrong until proven otherwise."
+model_reasoning_effort = "high"
+developer_instructions = """
+You verify that the engine matches the book. Your default assumption is that it does
+not. A finding you cannot demonstrate with a specific row, value, or worked example
+is not a finding — discard it rather than reporting a suspicion.
+
+## Why this role exists at high effort
+
+This project's most expensive failure mode is a plausible-looking formula derived
+from the wrong source or the wrong rounding rule. It is invisible in review, passes
+casual testing, and silently corrupts every layer above. Two documented near-misses:
+
+- Two Chaosium books were in this repo. They have different success grades and
+  different threshold rounding. Code derived from the wrong one looks entirely correct.
+- The special-success threshold is `ceil` in the current source but round-half-up in
+  the superseded one, and the prose in one of them contradicts its own table.
+
+## Method
+
+1. Open the book yourself. Do not accept a formula from `engine-implementation-plan.md`
+   or from any Issue as authoritative — those are derivations and may be wrong. The
+   printed table is the authority.
+2. For any table-backed rule, verify **every printed row**, including above-100% rows.
+   Report the row count you actually checked.
+3. For any derived closed-form rule, attempt to **falsify** it: find a value where the
+   formula and the printed table disagree. Report the first disagreement or state
+   plainly that you found none across the full range.
+4. Check rounding explicitly at every boundary. Most divergences live there.
+5. Check the stated-but-easily-dropped rules: grade precedence where ranges overlap,
+   caps that hold regardless of rating, floors on modified values, and behavior past 100%.
+6. Confirm no out-of-scope mechanic crept in (`orc-scope-filter.md`).
+
+## Output
+
+For each rule checked: the rule, the section it comes from, how many rows or values
+you verified, and a verdict of CONFIRMED or a specific defect with the input that
+breaks it. Rank defects most severe first. Say plainly when something is correct —
+a clean verdict is a real result."""

--- a/.codex/agents/rules-extractor.toml
+++ b/.codex/agents/rules-extractor.toml
@@ -1,0 +1,36 @@
+name = "rules-extractor"
+description = "Extracts tables, values, and stat blocks from the ORC Content Document into ruleset JSON. Use for high-volume, mechanical transcription where precision matters more than judgment. Not for deciding what a rule means."
+model_reasoning_effort = "medium"
+developer_instructions = """
+You transcribe rules data from the source book into ruleset JSON. You are a careful
+copyist, not a designer.
+
+## Source
+
+`BasicRoleplaying-ORC-Content-Document.pdf`. Extract with `pdftotext` (no `-layout`;
+the document is single-column and linear). Page breaks appear as form feeds, which
+break naive greps — account for them.
+
+**Never read `BRP SRD 1.0.2.pdf`.** It is a different, superseded document whose
+tables produce wrong values. If it is present, ignore it.
+
+## Rules
+
+1. Transcribe what is printed. If a value looks wrong, transcribe it anyway and note
+   the discrepancy in your output. Do not silently correct the book.
+2. Where the book prints a table, capture **every row**, including rows above 100%
+   and any "and so on" continuation rule. Never sample.
+3. Take **modern-era base chances**, never historical, wherever a skill lists both.
+4. Consult `orc-scope-filter.md` before extracting. If the content is out of scope,
+   stop and report rather than extracting it.
+5. Preserve the chapter and section you took each value from. Every emitted record
+   carries its source citation.
+
+## Output
+
+Ruleset JSON under `src/Brp.Data/`, plus a short report naming: what you extracted,
+which section it came from, row counts, and any discrepancy between the book's prose
+and its tables. Discrepancies are the most valuable thing you produce — the prose and
+the tables genuinely disagree in places.
+
+Do not write C#. Do not interpret a rule's meaning."""

--- a/.codex/agents/scope-warden.toml
+++ b/.codex/agents/scope-warden.toml
@@ -1,0 +1,31 @@
+name = "scope-warden"
+description = "Checks a diff or file set against the scope filter and source-text rules. Cheap mechanical gate — run on every rules-engine PR before more expensive review. Not a code reviewer."
+model_reasoning_effort = "low"
+developer_instructions = """
+You run one checklist against a change. You do not review code quality, design, or
+correctness — other agents do that. Be fast and literal.
+
+## Checklist
+
+1. **Out-of-scope content.** Per `orc-scope-filter.md`: no magic, sorcery, spells,
+   psychic powers, superpowers, mutations, the Projection skill, power points as a
+   spendable pool, powered or enchanted equipment, pre-modern or science-fiction
+   weapons and armor, aircraft, watercraft, spacecraft, or fantasy creatures.
+2. **Wrong source.** No reference to, or values derived from, `BRP SRD 1.0.2.pdf`.
+   Flag any four-grade success model — the current source has five.
+3. **Era baselines.** Where a skill has both a modern and a historical base chance,
+   the modern value must be used.
+4. **Determinism.** No `System.Random` static, no ambient time, no unseeded
+   randomness in `Brp.Core` or `Brp.Rules`.
+5. **Engine independence.** No Unity, Godot, or MonoGame reference in `Brp.Core` or
+   `Brp.Rules`.
+6. **Data not constants.** Values from the book belong in ruleset data, not hardcoded
+   in C#.
+7. **Skill naming.** The canonical skill list is the framework's 18, as hardcoded in
+   `tools/case_validator.py`. Do not accept renames to the book's names — existing
+   tooling depends on the framework names.
+
+## Output
+
+A short pass/fail per item with file and line for any failure. Nothing else. If
+everything passes, say so in one line."""

--- a/src/Brp.Core/Contests/IAdjudicator.cs
+++ b/src/Brp.Core/Contests/IAdjudicator.cs
@@ -1,0 +1,88 @@
+using Brp.Core.Resolution;
+
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// A named gamemaster-adjudication point: a decision the source book explicitly leaves to the
+/// gamemaster's judgment rather than defining mechanically.
+/// </summary>
+public enum OpposedRollDecisionId
+{
+    /// <summary>
+    /// Both participants in an opposed skill roll landed on the <em>same</em> failing degree --
+    /// Fumble vs Fumble, or Failure vs Failure. This is <em>not</em> the general "nobody
+    /// succeeded" case: Ch 5, "Evaluating Success or Failure" (p.127) ranks all five degrees
+    /// worst-to-best with Fumble below Failure, and "Opposed Skill Rolls" (p.130) says the
+    /// highest degree of success wins the contest over that same ladder -- so Failure vs Fumble
+    /// is mechanically determined (Failure wins) and is resolved directly, never routed here.
+    /// <para>
+    /// What genuinely has no answer is two participants tied on the <em>same</em> failing
+    /// degree. The book's tiebreak for a shared degree -- "the higher die roll wins the contest,
+    /// giving the advantage to characters with higher skill ratings" (p.131) -- relies on a
+    /// roll-under system where a higher roll (while still within a band) reflects a higher
+    /// skill. That rationale inverts for two failures: a higher roll there is simply a worse
+    /// miss, not a sign of higher skill, so the stated reason for the tiebreak gives no guidance
+    /// about who "wins" a tie between two failures. That is the actual gap the book leaves to
+    /// the table, and it is routed here instead of picked silently.
+    /// See <see cref="Contests.OpposedSkillResolver"/>.
+    /// </para>
+    /// </summary>
+    BothPartiesFailed,
+
+    /// <summary>
+    /// Both participants achieved the same degree of success and rolled the identical
+    /// percentile result. The book's stated tiebreak -- "the higher die roll wins the contest"
+    /// (p.131) -- has nothing left to compare in this case; the book does not say what happens
+    /// next.
+    /// </summary>
+    RollsIdenticalAfterTiebreak,
+}
+
+/// <summary>
+/// The result of a gamemaster-adjudication decision: who, if anyone, prevails.
+/// </summary>
+public enum OpposedRollOutcome
+{
+    /// <summary>The first participant prevails.</summary>
+    ParticipantAWins,
+
+    /// <summary>The second participant prevails.</summary>
+    ParticipantBWins,
+
+    /// <summary>Neither participant prevails.</summary>
+    NoContest,
+}
+
+/// <summary>
+/// A gamemaster-discretion decision point, modeled as a first-class port rather than an
+/// omission -- the source book says "at the gamemaster's discretion" throughout, and a rules
+/// engine that hardcodes those calls silently is lying about what it implements. A GM tool can
+/// prompt a human through this interface; an unattended simulation or video game can supply an
+/// authored policy; tests can supply a deterministic stub. See
+/// <c>engine-implementation-plan.md</c>, decision D5.
+/// </summary>
+public interface IAdjudicator
+{
+    /// <summary>
+    /// Decides the outcome of a contest the rules do not resolve mechanically. Implementations
+    /// may consult anything outside the two roll outcomes themselves (narrative stakes, a human
+    /// gamemaster, a house rule); the caller only needs an answer.
+    /// </summary>
+    OpposedRollOutcome Decide(
+        OpposedRollDecisionId decisionId, RollOutcome participantA, RollOutcome participantB);
+}
+
+/// <summary>
+/// The documented default policy for every <see cref="OpposedRollDecisionId"/>: nobody
+/// prevails. Chosen because it is the most narratively neutral answer to "the book does not say"
+/// -- it asserts nothing the book didn't -- and it is what a table typically means by "you both
+/// fail" or "call it a draw." Callers with a house rule (or a human gamemaster) should supply
+/// their own <see cref="IAdjudicator"/> instead of relying on this default.
+/// </summary>
+public sealed class DefaultAdjudicator : IAdjudicator
+{
+    /// <inheritdoc />
+    public OpposedRollOutcome Decide(
+        OpposedRollDecisionId decisionId, RollOutcome participantA, RollOutcome participantB) =>
+        OpposedRollOutcome.NoContest;
+}

--- a/src/Brp.Core/Contests/OpposedRollResult.cs
+++ b/src/Brp.Core/Contests/OpposedRollResult.cs
@@ -1,0 +1,33 @@
+using Brp.Core.Resolution;
+
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// The full record of one resolved opposed skill roll, per Ch 5: System, "Opposed Skill Rolls"
+/// (BRP ORC Content Document, p.130). Carries both participants' original
+/// <see cref="Resolution.RollOutcome"/>s unmodified -- <see cref="WinningLevel"/> is the
+/// separate, possibly-degraded degree the contest actually resolves to, so the record can
+/// explain both "what each side rolled" and "what the contest decided" without collapsing one
+/// into the other.
+/// </summary>
+/// <param name="ParticipantA">The first participant's own resolved skill roll, unmodified.</param>
+/// <param name="ParticipantB">The second participant's own resolved skill roll, unmodified.</param>
+/// <param name="Outcome">Who, if anyone, prevails.</param>
+/// <param name="WinningLevel">
+/// The prevailing side's degree of success after the degrade rule is applied, or
+/// <see langword="null"/> when <see cref="Outcome"/> is <see cref="OpposedRollOutcome.NoContest"/>.
+/// </param>
+/// <param name="DegradeApplied">
+/// The number of degrees <see cref="WinningLevel"/> was shifted down from the winner's own
+/// rolled level, per Ch 5, "Opposed Skill Rolls", p.130-131 (the sentence crosses the page
+/// break): "if the loser's skill roll was successful, they modify the winner's degree of
+/// success, shifting it downward one degree for every degree of success they achieve above
+/// failure." Zero when the loser did not succeed, or when the contest was decided by the
+/// tiebreak rule instead.
+/// </param>
+public sealed record OpposedRollResult(
+    RollOutcome ParticipantA,
+    RollOutcome ParticipantB,
+    OpposedRollOutcome Outcome,
+    SuccessLevel? WinningLevel,
+    int DegradeApplied);

--- a/src/Brp.Core/Contests/OpposedSkillResolver.cs
+++ b/src/Brp.Core/Contests/OpposedSkillResolver.cs
@@ -1,0 +1,129 @@
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+using Brp.Core.Resolution;
+
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// Resolves an <em>opposed skill roll</em> -- two ordinary skill rolls compared against each
+/// other -- per Ch 5: System, "Opposed Skill Rolls" (BRP ORC Content Document, p.130-131; the
+/// quote below crosses the page break): "When two skills are opposed, both characters roll
+/// against their respective skills. The character that achieves the highest degree of success
+/// wins the contest. However, if the loser's skill roll was successful, they modify the winner's
+/// degree of success, shifting it downward one degree for every degree of success they achieve
+/// above failure. If both parties achieve the same degree of success, the higher die roll wins
+/// the contest, giving the advantage to characters with higher skill ratings."
+/// <para>
+/// Both rolls are ordinary skill rolls -- unlike a resistance roll, an opposed skill roll is not
+/// exempt from the 96+ automatic-failure rule, so each side is resolved through
+/// <see cref="SkillResolver"/> exactly as a solo skill roll would be. The book documents this
+/// method as its default; it separately lists alternate opposed-roll systems (highest successful
+/// result, opposed skill subtraction, the resistance table) as gamemaster options -- out of
+/// scope here.
+/// </para>
+/// </summary>
+public static class OpposedSkillResolver
+{
+    /// <summary>
+    /// Resolves an opposed roll from two already-resolved skill rolls.
+    /// </summary>
+    /// <param name="participantA">The first participant's resolved skill roll.</param>
+    /// <param name="participantB">The second participant's resolved skill roll.</param>
+    /// <param name="adjudicator">
+    /// Supplies the answer for contests the book leaves to gamemaster interpretation (see
+    /// <see cref="OpposedRollDecisionId"/>). Defaults to <see cref="DefaultAdjudicator"/>.
+    /// </param>
+    public static OpposedRollResult Resolve(
+        RollOutcome participantA, RollOutcome participantB, IAdjudicator? adjudicator = null)
+    {
+        ArgumentNullException.ThrowIfNull(participantA);
+        ArgumentNullException.ThrowIfNull(participantB);
+        adjudicator ??= new DefaultAdjudicator();
+
+        if (participantA.Level == participantB.Level)
+        {
+            if (participantA.Level < SuccessLevel.Success)
+            {
+                // Tied on the *same* failing degree (both Fumble, or both Failure). This is the
+                // one case the book truly leaves open -- see OpposedRollDecisionId.BothPartiesFailed
+                // for why the tiebreak's stated rationale does not transfer here. It is not picked
+                // silently.
+                var bothFailedOutcome = adjudicator.Decide(
+                    OpposedRollDecisionId.BothPartiesFailed, participantA, participantB);
+                return new OpposedRollResult(participantA, participantB, bothFailedOutcome, null, 0);
+            }
+
+            // Same degree, both >= Success: "the higher die roll wins the contest, giving the
+            // advantage to characters with higher skill ratings" (p.131). No degrade is mentioned
+            // for this branch -- the winner keeps their rolled level as-is.
+            if (participantA.Roll != participantB.Roll)
+            {
+                var aRollWins = participantA.Roll > participantB.Roll;
+                return new OpposedRollResult(
+                    participantA,
+                    participantB,
+                    aRollWins ? OpposedRollOutcome.ParticipantAWins : OpposedRollOutcome.ParticipantBWins,
+                    participantA.Level,
+                    0);
+            }
+
+            // Same degree and the identical roll: the stated tiebreak has nothing left to compare.
+            // The book does not say what happens next. See OpposedRollDecisionId.RollsIdenticalAfterTiebreak.
+            var tieOutcome = adjudicator.Decide(
+                OpposedRollDecisionId.RollsIdenticalAfterTiebreak, participantA, participantB);
+            return new OpposedRollResult(participantA, participantB, tieOutcome, null, 0);
+        }
+
+        // Different degrees: Ch 5, "Evaluating Success or Failure" (p.127) ranks all five degrees
+        // on one ladder (Fumble < Failure < Success < Special < Critical), and "Opposed Skill
+        // Rolls" (p.130) says the highest degree wins the contest over that same ladder -- so this
+        // covers Failure beating Fumble exactly as mechanically as Special beating Success. No
+        // adjudication is needed: the book is not silent here, it is silent only when the shared
+        // degree is a tied failure (handled above).
+        var aWins = participantA.Level > participantB.Level;
+        var winner = aWins ? participantA : participantB;
+        var loser = aWins ? participantB : participantA;
+
+        // "if the loser's skill roll was successful, they modify the winner's degree of
+        // success, shifting it downward one degree for every degree of success they achieve
+        // above failure." Failure is the zero point of "degrees above failure", so a
+        // Success loser (one degree above Failure) shifts the winner down by one, a Special
+        // loser by two, a Critical loser by three. No degrade at all if the loser did not
+        // succeed -- including when the loser merely Fumbled while the winner only Failed.
+        var degrade = loser.Level >= SuccessLevel.Success
+            ? (int)loser.Level - (int)SuccessLevel.Failure
+            : 0;
+
+        // The winner strictly outranks the loser here, and a loser can only earn a degrade
+        // by having succeeded (>= Success, value 2), so the degraded result is provably never
+        // pushed below Success -- the clamp is a defensive floor, not a reachable branch.
+        var winningLevel = (SuccessLevel)Math.Max((int)SuccessLevel.Fumble, (int)winner.Level - degrade);
+
+        return new OpposedRollResult(
+            participantA,
+            participantB,
+            aWins ? OpposedRollOutcome.ParticipantAWins : OpposedRollOutcome.ParticipantBWins,
+            winningLevel,
+            degrade);
+    }
+
+    /// <summary>
+    /// Resolves an opposed roll by drawing both sides' percentile results from
+    /// <paramref name="entropy"/> and resolving each through <see cref="SkillResolver"/> before
+    /// comparing them.
+    /// </summary>
+    public static OpposedRollResult Resolve(
+        Percent baseChanceA,
+        Percent effectiveChanceA,
+        Percent baseChanceB,
+        Percent effectiveChanceB,
+        IEntropySource entropy,
+        IAdjudicator? adjudicator = null,
+        ResolutionPolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(entropy);
+        var participantA = SkillResolver.Resolve(baseChanceA, effectiveChanceA, entropy, policy);
+        var participantB = SkillResolver.Resolve(baseChanceB, effectiveChanceB, entropy, policy);
+        return Resolve(participantA, participantB, adjudicator);
+    }
+}

--- a/src/Brp.Core/Contests/ResistanceOutcome.cs
+++ b/src/Brp.Core/Contests/ResistanceOutcome.cs
@@ -1,0 +1,45 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// The full record of one resolved resistance roll, per Ch 5: System, "Resistance Rolls" and
+/// "The Resistance Table" (BRP ORC Content Document, p.129).
+/// <para>
+/// Deliberately binary, not graded on the five-level <c>Resolution.SuccessLevel</c> scale: Ch 5,
+/// "Critical Results, Special Successes, and Fumbles on Resistance Rolls" (p.130) states
+/// "Usually resistance rolls have yes/no results -- success or failure -- but your gamemaster
+/// <em>may choose</em> to characterize results more granularly" -- finer grading is an explicit
+/// gamemaster option, not the default result shape, so this type does not carry a
+/// <c>SuccessLevel</c>.
+/// </para>
+/// </summary>
+/// <param name="Roll">
+/// The percentile result the outcome was decided from, in <c>[1, 100]</c> -- a printed roll of
+/// <c>00</c> is represented as <c>100</c>.
+/// </param>
+/// <param name="Active">The active characteristic (or other measurable quantity) rated.</param>
+/// <param name="Passive">The passive characteristic (or other measurable quantity) resisted.</param>
+/// <param name="Chance">
+/// The linear chance the resistance formula computes: <c>50% + 5% x (Active - Passive)</c>
+/// (Ch 5, "Resistance Rolls", p.129). Only meaningful as the roll target inside the printed
+/// table's bounds -- see <see cref="IsAutomaticSuccess"/> / <see cref="IsAutomaticFailure"/> for
+/// what governs the result outside them. Floored at zero per <see cref="Percent"/>.
+/// </param>
+/// <param name="IsAutomaticSuccess">
+/// True when the characteristic difference puts the roll in the table's automatic-success zone
+/// (Ch 5, "The Resistance Table" caption, p.130: "over 95% in the range of automatic success").
+/// </param>
+/// <param name="IsAutomaticFailure">
+/// True when the characteristic difference puts the roll in the table's automatic-failure zone
+/// (same caption: "Changes below 05% are in the range of automatic failure").
+/// </param>
+/// <param name="Succeeded">The resolved yes/no result.</param>
+public sealed record ResistanceOutcome(
+    int Roll,
+    int Active,
+    int Passive,
+    Percent Chance,
+    bool IsAutomaticSuccess,
+    bool IsAutomaticFailure,
+    bool Succeeded);

--- a/src/Brp.Core/Contests/ResistancePolicy.cs
+++ b/src/Brp.Core/Contests/ResistancePolicy.cs
@@ -1,0 +1,57 @@
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// The constants that define the Resistance Table, Ch 5: System, "Resistance Rolls" (BRP ORC
+/// Content Document, p.129): "The base chance of a resistance roll equals 50% + (active
+/// characteristic x 5) - (passive characteristic x 5)... Differences of 10 points or more
+/// result in automatic success or failure."
+/// <para>
+/// These live in one named place rather than as literals in <see cref="ResistanceResolver"/>,
+/// mirroring <c>Resolution.ResolutionPolicy</c> -- the same rationale applies: these describe
+/// the resolution system itself, not a setting, so they are not ruleset JSON.
+/// </para>
+/// <para>
+/// Treat <see cref="Standard"/> as the only supported configuration, exactly as
+/// <c>ResolutionPolicy.Standard</c> is documented.
+/// </para>
+/// </summary>
+/// <param name="ParityChance">
+/// The chance when the active and passive factors are equal (Ch 5, "Resistance Rolls", p.129:
+/// "If the active and passive factors are equal, the active factor has a 50% chance of
+/// success.").
+/// </param>
+/// <param name="PercentPerPointOfDifference">
+/// The chance shifts by this many percentage points for every point the active factor differs
+/// from the passive factor -- up, in the active party's favor, or down, in the passive party's
+/// (Ch 5, "Resistance Rolls", p.129).
+/// </param>
+/// <param name="AutomaticFailureBelow">
+/// A computed chance strictly below this value is automatic failure. Taken from the table's own
+/// caption (p.130: "Changes below 05% are in the range of automatic failure"), which is exactly
+/// the linear formula's value at the last printed row (a 9-point disadvantage yields this value
+/// itself, still printed and rollable, in 15 of the table's cells; a 10-point disadvantage yields
+/// one step further down and is the first automatic cell).
+/// </param>
+/// <param name="AutomaticSuccessAbove">
+/// A computed chance strictly above this value is automatic success (same caption, p.130: "and
+/// over 95% in the range of automatic success").
+/// </param>
+/// <param name="MaximumRoll">
+/// The highest percentile result. A printed roll of 00 is read as this value -- see
+/// <see cref="Randomness.IEntropySource.NextD100"/>.
+/// </param>
+public sealed record ResistancePolicy(
+    int ParityChance,
+    int PercentPerPointOfDifference,
+    int AutomaticFailureBelow,
+    int AutomaticSuccessAbove,
+    int MaximumRoll)
+{
+    /// <summary>The values printed in the source book. The only supported configuration.</summary>
+    public static ResistancePolicy Standard { get; } = new(
+        ParityChance: 50,
+        PercentPerPointOfDifference: 5,
+        AutomaticFailureBelow: 5,
+        AutomaticSuccessAbove: 95,
+        MaximumRoll: 100);
+}

--- a/src/Brp.Core/Contests/ResistanceResolver.cs
+++ b/src/Brp.Core/Contests/ResistanceResolver.cs
@@ -1,0 +1,100 @@
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// Resolves a single resistance roll into a <see cref="ResistanceOutcome"/>, per Ch 5: System,
+/// "Resistance Rolls" and "The Resistance Table" (BRP ORC Content Document, p.129).
+/// <para>
+/// <strong>This does not use <c>Resolution.SkillResolver</c>.</strong> Ch 5, "Failure" (p.127)
+/// explicitly carves resistance rolls out of the skill kernel's 96+ automatic-failure rule: "The
+/// exception are resistance rolls, where a difference of 10 characteristic points is enough to
+/// make only a roll of 00 a failure." The printed Resistance Table's own caption agrees: cells
+/// run 05 to 95 with nothing printed beyond -- differences of 10+ points are automatic, not a
+/// continuation of the percentage scale. Routing a 10-point-advantage resistance roll through
+/// <c>SkillResolver</c> would wrongly fail it on a 96-99, where this rule says it succeeds.
+/// </para>
+/// </summary>
+public static class ResistanceResolver
+{
+    /// <summary>
+    /// Resolves a resistance roll against an already-drawn percentile result.
+    /// </summary>
+    /// <param name="active">
+    /// The active characteristic -- "the party or force trying to influence the passive factor"
+    /// (Ch 5, "Resistance Rolls", p.129).
+    /// </param>
+    /// <param name="passive">The passive characteristic being resisted.</param>
+    /// <param name="roll">A percentile result in <c>[1, 100]</c>, with <c>00</c> as <c>100</c>.</param>
+    /// <param name="policy">
+    /// The resistance constants. Defaults to <see cref="ResistancePolicy.Standard"/>, the only
+    /// supported configuration.
+    /// </param>
+    public static ResistanceOutcome Resolve(
+        int active, int passive, int roll, ResistancePolicy? policy = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(roll, 1);
+        policy ??= ResistancePolicy.Standard;
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(roll, policy.MaximumRoll);
+
+        // Ch 5, "Resistance Rolls", p.129: "The base chance of a resistance roll equals 50% +
+        // (active characteristic x 5) - (passive characteristic x 5)." Algebraically identical
+        // to parity plus the per-point step times the raw difference; Percent floors at zero,
+        // which only matters deep in the automatic-failure zone where this value is not used as
+        // a roll target anyway (see below).
+        var rawChance = policy.ParityChance
+            + policy.PercentPerPointOfDifference * (active - passive);
+        var chance = Percent.Of(rawChance);
+
+        // Table caption, p.130: "Changes below 05% are in the range of automatic failure and
+        // over 95% in the range of automatic success." This is the same linear formula, just
+        // read off its own printed bounds -- not a separately-tuned threshold.
+        var isAutomaticSuccess = rawChance > policy.AutomaticSuccessAbove;
+        var isAutomaticFailure = rawChance < policy.AutomaticFailureBelow;
+
+        bool succeeded;
+        if (isAutomaticSuccess)
+        {
+            // Ch 5, "Failure", p.127: "The exception are resistance rolls, where a difference of
+            // 10 characteristic points is enough to make only a roll of 00 a failure." Automatic
+            // success is not unconditional -- it is unconditional except for the top roll, which
+            // still fails. p.127 states this as a standing rule. The Resistance Rolls section on
+            // p.129 separately offers relief in *both* directions as gamemaster-optional --
+            // "your gamemaster may allow a roll of 01... to succeed or 00 to fail, respectively,
+            // where results would otherwise be automatic" -- so the book states this same 00-fails
+            // behavior twice: once as optional (p.129), once as a standing rule (p.127). We follow
+            // p.127, the stricter and unconditional statement.
+            succeeded = roll < policy.MaximumRoll;
+        }
+        else if (isAutomaticFailure)
+        {
+            // No standing-rule exception is stated for this side: p.127 only carves out the
+            // 00-fails case for the automatic-success zone above. p.129's "gamemaster may allow a
+            // roll of 01... to succeed... where results would otherwise be automatic" covers this
+            // zone symmetrically, but only as an explicitly optional variant, never elevated to a
+            // standing rule the way the 00-fails case is -- so the default here is unconditional
+            // failure.
+            succeeded = false;
+        }
+        else
+        {
+            // Ordinary resistance roll: "For success, roll 1D100 equal to or less than the
+            // indicated number" (table caption, p.130).
+            succeeded = roll <= chance.Value;
+        }
+
+        return new ResistanceOutcome(roll, active, passive, chance, isAutomaticSuccess, isAutomaticFailure, succeeded);
+    }
+
+    /// <summary>
+    /// Resolves a resistance roll by drawing a fresh percentile result from
+    /// <paramref name="entropy"/>.
+    /// </summary>
+    public static ResistanceOutcome Resolve(
+        int active, int passive, IEntropySource entropy, ResistancePolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(entropy);
+        return Resolve(active, passive, entropy.NextD100(), policy);
+    }
+}

--- a/tests/Brp.Core.Tests/Contests/OpposedSkillResolverTests.cs
+++ b/tests/Brp.Core.Tests/Contests/OpposedSkillResolverTests.cs
@@ -1,0 +1,189 @@
+using Brp.Core.Contests;
+using Brp.Core.Primitives;
+using Brp.Core.Resolution;
+using Brp.Core.Tests.Dice;
+
+namespace Brp.Core.Tests.Contests;
+
+/// <summary>
+/// Exercises <see cref="OpposedSkillResolver"/> against Ch 5: System, "Opposed Skill Rolls"
+/// (BRP ORC Content Document, p.130-131): the highest-degree-wins rule, the degrade rule, the
+/// same-degree tiebreak, and the gamemaster-adjudication points the book leaves undefined.
+/// Every one of the 5x5 = 25 possible degree pairings is covered, not a sample -- 20 by
+/// direct/degraded win (this includes Failure beating Fumble, which the book resolves
+/// mechanically -- see <see cref="OpposedRollDecisionId.BothPartiesFailed"/>), 3 by the roll
+/// tiebreak, and 2 by both-parties-failed adjudication (only a tied Fumble-vs-Fumble or
+/// Failure-vs-Failure, where the book is genuinely silent).
+/// </summary>
+public class OpposedSkillResolverTests
+{
+    private static RollOutcome Roll(int roll, SuccessLevel level) =>
+        new(roll, Percent.Of(50), Percent.Of(50), Percent.Of(2), Percent.Of(10), Percent.Of(96), level);
+
+    /// <summary>
+    /// Every degree pairing where the book's plain highest-degree-wins rule decides it outright
+    /// (loser did not succeed, so no degrade applies) or where the degrade rule shifts the
+    /// winner's degree down by the loser's degrees above Failure.
+    /// </summary>
+    public static TheoryData<SuccessLevel, SuccessLevel, bool, SuccessLevel, int> DecisiveOrDegradedPairings() => new()
+    {
+        // levelA, levelB, aWins, expectedWinningLevel, expectedDegrade
+
+        // A fails outright (Fumble or Failure), B succeeds: B wins outright, no degrade.
+        { SuccessLevel.Fumble, SuccessLevel.Success, false, SuccessLevel.Success, 0 },
+        { SuccessLevel.Fumble, SuccessLevel.Special, false, SuccessLevel.Special, 0 },
+        { SuccessLevel.Fumble, SuccessLevel.Critical, false, SuccessLevel.Critical, 0 },
+        { SuccessLevel.Failure, SuccessLevel.Success, false, SuccessLevel.Success, 0 },
+        { SuccessLevel.Failure, SuccessLevel.Special, false, SuccessLevel.Special, 0 },
+        { SuccessLevel.Failure, SuccessLevel.Critical, false, SuccessLevel.Critical, 0 },
+
+        // Mirror image: B fails outright, A succeeds.
+        { SuccessLevel.Success, SuccessLevel.Fumble, true, SuccessLevel.Success, 0 },
+        { SuccessLevel.Special, SuccessLevel.Fumble, true, SuccessLevel.Special, 0 },
+        { SuccessLevel.Critical, SuccessLevel.Fumble, true, SuccessLevel.Critical, 0 },
+        { SuccessLevel.Success, SuccessLevel.Failure, true, SuccessLevel.Success, 0 },
+        { SuccessLevel.Special, SuccessLevel.Failure, true, SuccessLevel.Special, 0 },
+        { SuccessLevel.Critical, SuccessLevel.Failure, true, SuccessLevel.Critical, 0 },
+
+        // Both succeed, different degrees: winner's degree shifts down by the loser's degrees
+        // above Failure (Success = 1, Special = 2, Critical = 3).
+        { SuccessLevel.Success, SuccessLevel.Special, false, SuccessLevel.Success, 1 },
+        { SuccessLevel.Success, SuccessLevel.Critical, false, SuccessLevel.Special, 1 },
+        { SuccessLevel.Special, SuccessLevel.Success, true, SuccessLevel.Success, 1 },
+        { SuccessLevel.Special, SuccessLevel.Critical, false, SuccessLevel.Success, 2 },
+        { SuccessLevel.Critical, SuccessLevel.Success, true, SuccessLevel.Special, 1 },
+        { SuccessLevel.Critical, SuccessLevel.Special, true, SuccessLevel.Success, 2 },
+
+        // Different failing degrees: the book ranks Fumble below Failure on the same ladder it
+        // compares successes on (Ch 5, "Evaluating Success or Failure", p.127), and "highest
+        // degree wins" (p.130) does not carve out an exception for failing degrees. Failure
+        // mechanically beats Fumble, with no degrade (the loser never succeeded).
+        { SuccessLevel.Failure, SuccessLevel.Fumble, true, SuccessLevel.Failure, 0 },
+        { SuccessLevel.Fumble, SuccessLevel.Failure, false, SuccessLevel.Failure, 0 },
+    };
+
+    [Theory]
+    [MemberData(nameof(DecisiveOrDegradedPairings))]
+    public void Highest_degree_wins_with_the_degrade_rule_applied(
+        SuccessLevel levelA, SuccessLevel levelB, bool aWins, SuccessLevel expectedWinningLevel, int expectedDegrade)
+    {
+        // Roll values chosen arbitrarily but distinct; this theory is about degree, not roll.
+        var a = Roll(roll: 40, levelA);
+        var b = Roll(roll: 41, levelB);
+
+        var result = OpposedSkillResolver.Resolve(a, b);
+
+        Assert.Equal(
+            aWins ? OpposedRollOutcome.ParticipantAWins : OpposedRollOutcome.ParticipantBWins,
+            result.Outcome);
+        Assert.Equal(expectedWinningLevel, result.WinningLevel);
+        Assert.Equal(expectedDegrade, result.DegradeApplied);
+    }
+
+    [Theory]
+    [InlineData(SuccessLevel.Success)]
+    [InlineData(SuccessLevel.Special)]
+    [InlineData(SuccessLevel.Critical)]
+    public void Same_degree_is_broken_by_the_higher_die_roll(SuccessLevel level)
+    {
+        var higherRollWins = OpposedSkillResolver.Resolve(Roll(70, level), Roll(30, level));
+        Assert.Equal(OpposedRollOutcome.ParticipantAWins, higherRollWins.Outcome);
+        Assert.Equal(level, higherRollWins.WinningLevel);
+        Assert.Equal(0, higherRollWins.DegradeApplied);
+
+        var otherSideHigherRollWins = OpposedSkillResolver.Resolve(Roll(30, level), Roll(70, level));
+        Assert.Equal(OpposedRollOutcome.ParticipantBWins, otherSideHigherRollWins.Outcome);
+    }
+
+    /// <summary>
+    /// Only a tied failing degree is genuinely undefined by the book -- Fumble vs Fumble, or
+    /// Failure vs Failure. Failure vs Fumble (and its mirror) is mechanically decided by the
+    /// highest-degree-wins rule and is covered by <see cref="DecisiveOrDegradedPairings"/>
+    /// instead; see <see cref="OpposedRollDecisionId.BothPartiesFailed"/> for why.
+    /// </summary>
+    public static TheoryData<SuccessLevel, SuccessLevel> BothPartiesFailedPairings() => new()
+    {
+        { SuccessLevel.Fumble, SuccessLevel.Fumble },
+        { SuccessLevel.Failure, SuccessLevel.Failure },
+    };
+
+    [Theory]
+    [MemberData(nameof(BothPartiesFailedPairings))]
+    public void Both_parties_failing_is_routed_to_the_adjudicator_not_decided_silently(
+        SuccessLevel levelA, SuccessLevel levelB)
+    {
+        var spy = new SpyAdjudicator(OpposedRollOutcome.NoContest);
+
+        var result = OpposedSkillResolver.Resolve(Roll(97, levelA), Roll(98, levelB), spy);
+
+        Assert.Equal(OpposedRollDecisionId.BothPartiesFailed, Assert.Single(spy.Decisions));
+        Assert.Equal(OpposedRollOutcome.NoContest, result.Outcome);
+        Assert.Null(result.WinningLevel);
+        Assert.Equal(0, result.DegradeApplied);
+    }
+
+    [Fact]
+    public void Default_adjudicator_calls_both_parties_failed_no_contest()
+    {
+        // A genuine tie on a failing degree -- not Failure vs Fumble, which is now resolved
+        // mechanically (Failure wins) per the fix to OpposedRollDecisionId.BothPartiesFailed.
+        var result = OpposedSkillResolver.Resolve(
+            Roll(97, SuccessLevel.Failure), Roll(100, SuccessLevel.Failure));
+
+        Assert.Equal(OpposedRollOutcome.NoContest, result.Outcome);
+    }
+
+    [Fact]
+    public void A_supplied_adjudicator_can_override_the_both_failed_default()
+    {
+        var spy = new SpyAdjudicator(OpposedRollOutcome.ParticipantAWins);
+
+        var result = OpposedSkillResolver.Resolve(
+            Roll(97, SuccessLevel.Failure), Roll(98, SuccessLevel.Failure), spy);
+
+        Assert.Equal(OpposedRollOutcome.ParticipantAWins, result.Outcome);
+    }
+
+    [Fact]
+    public void Identical_degree_and_identical_roll_is_also_routed_to_the_adjudicator()
+    {
+        var spy = new SpyAdjudicator(OpposedRollOutcome.NoContest);
+
+        var result = OpposedSkillResolver.Resolve(
+            Roll(40, SuccessLevel.Success), Roll(40, SuccessLevel.Success), spy);
+
+        Assert.Equal(OpposedRollDecisionId.RollsIdenticalAfterTiebreak, Assert.Single(spy.Decisions));
+        Assert.Equal(OpposedRollOutcome.NoContest, result.Outcome);
+        Assert.Null(result.WinningLevel);
+    }
+
+    [Fact]
+    public void Entropy_overload_draws_both_rolls_and_resolves_through_SkillResolver()
+    {
+        // Participant A: chance 90, roll 50 -> Success (above the special band, at or below chance).
+        // Participant B: chance 20, roll 50 -> an ordinary Failure (above chance, below 96).
+        var entropy = new FixedEntropySource(50, 50);
+
+        var result = OpposedSkillResolver.Resolve(
+            Percent.Of(90), Percent.Of(90),
+            Percent.Of(20), Percent.Of(20),
+            entropy);
+
+        Assert.Equal(SuccessLevel.Success, result.ParticipantA.Level);
+        Assert.Equal(SuccessLevel.Failure, result.ParticipantB.Level);
+        Assert.Equal(OpposedRollOutcome.ParticipantAWins, result.Outcome);
+        Assert.Equal(2, entropy.DrawCount);
+    }
+
+    private sealed class SpyAdjudicator(OpposedRollOutcome toReturn) : IAdjudicator
+    {
+        public List<OpposedRollDecisionId> Decisions { get; } = [];
+
+        public OpposedRollOutcome Decide(
+            OpposedRollDecisionId decisionId, RollOutcome participantA, RollOutcome participantB)
+        {
+            Decisions.Add(decisionId);
+            return toReturn;
+        }
+    }
+}

--- a/tests/Brp.Core.Tests/Contests/ResistanceResolverTests.cs
+++ b/tests/Brp.Core.Tests/Contests/ResistanceResolverTests.cs
@@ -1,0 +1,108 @@
+using Brp.Core.Contests;
+
+namespace Brp.Core.Tests.Contests;
+
+/// <summary>
+/// Exercises <see cref="ResistanceResolver"/>'s automatic-success and automatic-failure rules
+/// (Ch 5: System, "Failure" and "Resistance Rolls", p.127 and p.129) and confirms it is not
+/// simply <c>Resolution.SkillResolver</c> under a different name -- see class remarks on
+/// <see cref="ResistanceResolver"/> and the carried-forward pinning test in
+/// <c>Resolution.ResolutionPolicyTests</c>.
+/// </summary>
+public class ResistanceResolverTests
+{
+    // active=20, passive=10: a 10-point active advantage -- the smallest difference that enters
+    // the automatic-success zone (chance would be 100%, one step past the last printed cell, 95).
+    private const int AutoSuccessActive = 20;
+    private const int AutoSuccessPassive = 10;
+
+    // active=10, passive=20: the mirror image, a 10-point passive advantage -- the smallest
+    // difference that enters the automatic-failure zone.
+    private const int AutoFailureActive = 10;
+    private const int AutoFailurePassive = 20;
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(95)]
+    [InlineData(96)]
+    [InlineData(99)]
+    public void Automatic_success_zone_succeeds_on_every_roll_except_00(int roll)
+    {
+        var outcome = ResistanceResolver.Resolve(AutoSuccessActive, AutoSuccessPassive, roll);
+
+        Assert.True(outcome.IsAutomaticSuccess);
+        Assert.False(outcome.IsAutomaticFailure);
+        Assert.True(outcome.Succeeded);
+    }
+
+    [Fact]
+    public void Automatic_success_zone_still_fails_on_a_roll_of_00()
+    {
+        // Ch 5, "Failure", p.127: "The exception are resistance rolls, where a difference of 10
+        // characteristic points is enough to make only a roll of 00 a failure." A printed roll
+        // of 00 is represented as 100 -- see Resolution.RollOutcome.
+        var outcome = ResistanceResolver.Resolve(AutoSuccessActive, AutoSuccessPassive, roll: 100);
+
+        Assert.True(outcome.IsAutomaticSuccess);
+        Assert.False(outcome.Succeeded);
+    }
+
+    /// <summary>
+    /// The concrete divergence from the skill kernel that motivated keeping resistance rolls off
+    /// <c>SkillResolver</c>: a 100%-equivalent skill roll of 96 fails
+    /// (<c>ResolutionPolicyTests.Skill_rolls_fail_at_96_even_at_full_chance_...</c>), but the
+    /// same roll against a resistance automatic-success zone succeeds.
+    /// </summary>
+    [Fact]
+    public void Diverges_from_SkillResolver_at_a_roll_of_96_in_the_automatic_success_zone()
+    {
+        var outcome = ResistanceResolver.Resolve(AutoSuccessActive, AutoSuccessPassive, roll: 96);
+
+        Assert.True(outcome.Succeeded);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(50)]
+    [InlineData(95)]
+    [InlineData(100)]
+    public void Automatic_failure_zone_fails_unconditionally(int roll)
+    {
+        // No default-rule exception is stated for this side (the book only offers a
+        // gamemaster-optional "may allow a roll of 01... to succeed", p.129, which is not
+        // implemented as the standing rule -- see ResistanceResolver remarks).
+        var outcome = ResistanceResolver.Resolve(AutoFailureActive, AutoFailurePassive, roll);
+
+        Assert.True(outcome.IsAutomaticFailure);
+        Assert.False(outcome.IsAutomaticSuccess);
+        Assert.False(outcome.Succeeded);
+    }
+
+    [Theory]
+    [InlineData(50, 50, true)]  // exactly at chance: succeeds
+    [InlineData(51, 50, false)] // one over chance: fails
+    public void Ordinary_zone_compares_roll_to_chance_directly(int roll, int expectedChance, bool expectedSucceeded)
+    {
+        // active=passive=1: parity, chance 50%, well inside the printed (non-automatic) range.
+        var outcome = ResistanceResolver.Resolve(active: 1, passive: 1, roll);
+
+        Assert.False(outcome.IsAutomaticSuccess);
+        Assert.False(outcome.IsAutomaticFailure);
+        Assert.Equal(expectedChance, outcome.Chance.Value);
+        Assert.Equal(expectedSucceeded, outcome.Succeeded);
+    }
+
+    [Fact]
+    public void Standard_policy_holds_the_printed_constants()
+    {
+        var policy = ResistancePolicy.Standard;
+
+        Assert.Equal(50, policy.ParityChance);
+        Assert.Equal(5, policy.PercentPerPointOfDifference);
+        Assert.Equal(5, policy.AutomaticFailureBelow);
+        Assert.Equal(95, policy.AutomaticSuccessAbove);
+        Assert.Equal(100, policy.MaximumRoll);
+    }
+}

--- a/tests/Brp.Core.Tests/Contests/ResistanceTableTests.cs
+++ b/tests/Brp.Core.Tests/Contests/ResistanceTableTests.cs
@@ -1,0 +1,183 @@
+using System.Globalization;
+using Brp.Core.Contests;
+
+namespace Brp.Core.Tests.Contests;
+
+/// <summary>
+/// Conformance fixture for the Resistance Table, Ch 5: System, "The Resistance Table" (BRP ORC
+/// Content Document, p.129). Transcribed directly from the printed grid -- all 24 rows and all
+/// 24 columns (576 cells) -- via the PDF's word bounding boxes (not a whitespace-sensitive text
+/// dump, which misaligns on a grid this wide), so a transcription error surfaces as a single
+/// named failing cell rather than hiding inside a loop.
+/// <para>
+/// The top axis is the active characteristic (1-24), the left axis is the passive characteristic
+/// (1-24); each row below is one passive value, left to right across active 1-24. <c>"-"</c>
+/// stands for either dash glyph the book prints for an automatic cell (both appear in the
+/// source; the distinction is a font artifact, not a rules difference).
+/// </para>
+/// </summary>
+public class ResistanceTableTests
+{
+    /// <summary>
+    /// Row <c>r</c> (0-indexed) is passive characteristic <c>r + 1</c>; each row lists active
+    /// characteristics 1 through 24 left to right, exactly as printed on p.129-130.
+    /// </summary>
+    public static readonly string[] PrintedRows =
+    {
+        "50 55 60 65 70 75 80 85 90 95 - - - - - - - - - - - - - -",
+        "45 50 55 60 65 70 75 80 85 90 95 - - - - - - - - - - - - -",
+        "40 45 50 55 60 65 70 75 80 85 90 95 - - - - - - - - - - - -",
+        "35 40 45 50 55 60 65 70 75 80 85 90 95 - - - - - - - - - - -",
+        "30 35 40 45 50 55 60 65 70 75 80 85 90 95 - - - - - - - - - -",
+        "25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 - - - - - - - - -",
+        "20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 - - - - - - - -",
+        "15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 - - - - - - -",
+        "10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 - - - - - -",
+        "05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 - - - - -",
+        "- 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 - - - -",
+        "- - 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 - - -",
+        "- - - 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 - -",
+        "- - - - 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95 -",
+
+        // Passive 15: the printed table's one departure from its own formula -- the last cell
+        // (active 24) prints 85, where every other diff-of-9 cell in the table (and the formula
+        // itself) gives 95. See Printed_table_disagrees_with_its_own_formula_at_exactly_one_cell.
+        "- - - - - 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 85",
+
+        "- - - - - - 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90",
+        "- - - - - - - 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85",
+        "- - - - - - - - 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80",
+        "- - - - - - - - - 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75",
+        "- - - - - - - - - - 05 10 15 20 25 30 35 40 45 50 55 60 65 70",
+        "- - - - - - - - - - - 05 10 15 20 25 30 35 40 45 50 55 60 65",
+        "- - - - - - - - - - - - 05 10 15 20 25 30 35 40 45 50 55 60",
+        "- - - - - - - - - - - - - 05 10 15 20 25 30 35 40 45 50 55",
+        "- - - - - - - - - - - - - - 05 10 15 20 25 30 35 40 45 50",
+    };
+
+    /// <summary>The one cell (passive 15, active 24) where the printed table disagrees with itself.</summary>
+    private static readonly (int Active, int Passive) KnownAnomaly = (24, 15);
+
+    [Fact]
+    public void Printed_table_has_24_rows_of_24_columns_576_cells_total()
+    {
+        Assert.Equal(24, PrintedRows.Length);
+        Assert.All(PrintedRows, row => Assert.Equal(24, row.Split(' ').Length));
+        Assert.Equal(576, PrintedRows.Sum(row => row.Split(' ').Length));
+    }
+
+    public static TheoryData<int, int, string> AllPrintedCells()
+    {
+        var data = new TheoryData<int, int, string>();
+        for (var passive = 1; passive <= 24; passive++)
+        {
+            var cells = PrintedRows[passive - 1].Split(' ');
+            for (var active = 1; active <= 24; active++)
+            {
+                data.Add(active, passive, cells[active - 1]);
+            }
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllPrintedCells))]
+    public void Closed_form_reproduces_every_printed_cell_except_the_one_documented_anomaly(
+        int active, int passive, string printed)
+    {
+        if ((active, passive) == KnownAnomaly)
+        {
+            return; // covered by its own dedicated test below.
+        }
+
+        var outcome = ResistanceResolver.Resolve(active, passive, roll: 1);
+
+        if (printed == "-")
+        {
+            // Direction matters, not just "some automatic flag is set" -- a resolver that had
+            // the two flags swapped would still pass a same-or check on every one of these 552
+            // cells. An active advantage (active > passive) must land in the automatic-success
+            // zone; a passive advantage must land in the automatic-failure zone.
+            if (active > passive)
+            {
+                Assert.True(outcome.IsAutomaticSuccess);
+                Assert.False(outcome.IsAutomaticFailure);
+            }
+            else
+            {
+                Assert.True(outcome.IsAutomaticFailure);
+                Assert.False(outcome.IsAutomaticSuccess);
+            }
+        }
+        else
+        {
+            Assert.False(outcome.IsAutomaticSuccess);
+            Assert.False(outcome.IsAutomaticFailure);
+            Assert.Equal(int.Parse(printed, CultureInfo.InvariantCulture), outcome.Chance.Value);
+        }
+    }
+
+    /// <summary>
+    /// Pins the one cell where the printed table disagrees with its own formula: passive 15,
+    /// active 24 (a 9-point active advantage) prints 85, but every other 9-point-advantage cell
+    /// in the table -- and the book's own prose ("Every point the active factor exceeds the
+    /// passive factor by modifies the chance of success by +5%") -- gives 95. This is almost
+    /// certainly a printing error: the formula, 575 of the table's own 576 cells, and the prose
+    /// all agree with each other and disagree only with this one cell.
+    /// <para>
+    /// The engine follows the formula (and the other 575 cells), not the anomalous cell -- an
+    /// unmotivated ±10 dip at a single grid position is not a plausible intentional rule, and
+    /// implementing the printed 85 would silently create a corresponding anomaly at whatever
+    /// row/column shares its active-minus-passive difference (24 - 15 = 9, same as every other
+    /// diff-9 cell), which would then disagree with 100% of the diff-9 cells that don't happen to
+    /// share this specific coordinate.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Printed_table_disagrees_with_its_own_formula_at_exactly_one_cell()
+    {
+        var (active, passive) = KnownAnomaly;
+        var printedValue = PrintedRows[passive - 1].Split(' ')[active - 1];
+        Assert.Equal("85", printedValue); // pins what the book actually prints here.
+
+        var outcome = ResistanceResolver.Resolve(active, passive, roll: 1);
+
+        Assert.False(outcome.IsAutomaticSuccess);
+        Assert.False(outcome.IsAutomaticFailure);
+        Assert.Equal(95, outcome.Chance.Value); // the formula's (and every sibling cell's) value.
+        Assert.NotEqual(int.Parse(printedValue, CultureInfo.InvariantCulture), outcome.Chance.Value);
+    }
+
+    [Theory]
+    [InlineData(1, 1, 50)]   // parity: "the active factor has a 50% chance of success" (p.129)
+    [InlineData(10, 1, 95)]  // largest printed active advantage before the automatic zone
+    [InlineData(1, 10, 5)]   // largest printed passive advantage before the automatic zone
+    public void Spot_checked_boundary_cells_match_the_book(int active, int passive, int expectedChance)
+    {
+        var outcome = ResistanceResolver.Resolve(active, passive, roll: 1);
+        Assert.Equal(expectedChance, outcome.Chance.Value);
+    }
+
+    /// <summary>
+    /// active 10 / passive 1 is a 9-point active advantage: chance 95, the last printed
+    /// (non-automatic) cell on that diagonal. This is the cell that actually distinguishes
+    /// "a 9-point advantage is an ordinary roll, compared to its chance like any other resistance
+    /// roll" from "a 10-point advantage ignores the roll entirely except for 00" -- the automatic
+    /// -success tests elsewhere in this suite exercise the 10-point side, but nothing previously
+    /// exercised the 9-point side landing on a plain, un-automatic 96 failing for the ordinary
+    /// reason (roll &gt; chance), not the skill kernel's unrelated 96+ rule.
+    /// </summary>
+    [Theory]
+    [InlineData(95, true)]
+    [InlineData(96, false)]
+    public void Ordinary_zone_upper_boundary_is_not_automatic(int roll, bool expectedSucceeded)
+    {
+        var outcome = ResistanceResolver.Resolve(active: 10, passive: 1, roll);
+
+        Assert.False(outcome.IsAutomaticSuccess);
+        Assert.False(outcome.IsAutomaticFailure);
+        Assert.Equal(95, outcome.Chance.Value);
+        Assert.Equal(expectedSucceeded, outcome.Succeeded);
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #12

## Exact behavioral claim

Characteristic-versus-characteristic contests and skill-versus-skill contests both
resolve correctly, and resistance rolls do so through a code path deliberately separate
from the skill kernel.

This completes Layer 0's contest half. Opposed rolls are the mechanical basis for the
framework's most-repeated interactions — tailing against noticing, interrogating against
stonewalling.

## Rules conformance

**576 of 576 table cells verified.** Transcribed independently twice by different
extraction methods and diffed against the fixture: zero mismatches. The closed form
`50 + 5×(active − passive)` reproduces every cell but one.

**That one is a misprint in the book.** The cell at passive 15 / active 24 prints `85`
where both the formula and the row's own progression give `95`. Two independent
monotonicity violations confirm it: the row decreases at its final column, and the
column breaks an otherwise perfect descent. The fifteen other cells sharing that
9-point difference all print 95. Verified at glyph level by bounding-box coordinates
and a 300 dpi render, so it is not an extraction artifact.

The test pins **both** the printed value and the engine's value and asserts they differ.
It therefore fails loudly if either the transcription is "corrected" or the engine
silently starts matching the misprint — and the next person to compare code against book
finds an explanation rather than a discrepancy.

**The two threshold sources agree.** For integer characteristics, the prose's "10 points
or more" and the caption's "below 05% / over 95%" are the same statement in different
units. Worth checking, because this book has contradicted itself before.

**Resistance results are binary.** Graded resistance results exist but as an explicit
gamemaster option, not the default.

**Opposed rolls confirmed against the book's own worked example**, including a detail
the implementation had justified only weakly: on a tied degree the winner keeps an
*undegraded* success. The code was right and the evidence is stronger than its comment
claimed.

## The trap held

`SkillResolver` applies the 96+ automatic-failure rule unconditionally, which is correct
for skill rolls and wrong for resistance — the book exempts resistance, where a
ten-point advantage means only 00 fails. Resistance runs through its own resolver, and
the pinning test carried over from #10 passes untouched.

## What review caught

**A misattribution (medium).** The code claimed the book never states what happens when
neither side succeeds. It does: the five degrees are ranked with Fumble below Failure,
and highest degree wins — so Failure beats Fumble. Two of the four both-failed pairings
were being routed to adjudication when the book answers them.

Now only genuinely tied failures adjudicate, and for the honest reason: the book's
tiebreak awards the higher die roll "giving the advantage to characters with higher skill
ratings," and that rationale inverts for two misses in a roll-under system. The port
design was right; the justification was false.

This is the third occurrence of the same defect class — a claim about what the source
says, written without checking.

**Five page citations off by one**, a sentence described as one-sided that is symmetric
in the book, an arithmetic slip in the very comment documenting the anomaly's coordinate,
and two coverage gaps — including one where a resolver that inverted automatic success
and automatic failure would still have passed all 552 dash assertions.

## Tests and evidence

```
dotnet build   -> Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test    -> Passed! Failed: 0, Passed: 886, Skipped: 0, Total: 886
dotnet format --verify-no-changes -> clean
```

`scope-warden`: **all seven items pass** — the first clean sweep. Item 6 failed on both
#10 and #11; this time the implementing agent built `ResistancePolicy` following the
established precedent without being told to.

I independently confirmed the misprint from the layout extraction before the gates ran.

## Known limitations

- The gamemaster-optional variant (allowing 01 to succeed or 00 to fail where results
  would otherwise be automatic) is documented but not implemented, consistent with
  `Standard` policies being the only supported configuration elsewhere.
- Tied mutual failure returns `NoContest` by default. That is a policy choice, not a book
  rule, and callers can supply their own adjudicator.

## Agent provenance

Implemented by `engine-dev` (Sonnet), gated by `scope-warden` (Haiku), verified by
`rules-conformance` (Opus).

The conformance pass separately confirmed the implementation did **not** inherit the
contaminated `engine-implementation-plan.md` — that document says ties go to the higher
skill rating, the book says higher die roll, and the code follows the book. Briefing
against the contamination worked.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).