### PR TITLE
Make the repo picked-up-able (#24)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Read this file, then the one Issue you are working. Do not read the whole repo.
 |---|---|
 | `BasicRoleplaying-ORC-Content-Document.pdf` | **The rules.** The only valid source for mechanics. |
 | `orc-scope-filter.md` | **What we implement and what we cut.** ~60% of the book is out of scope. |
-| `engine-implementation-plan.md` | Architecture, build layers, resolution kernel formulas. |
+| `docs/source-handling.md` | How to extract from the book, the verification discipline, and known errata in it. |
+| `engine-implementation-plan.md` | Historical design context and the build-layer map. **Not authoritative for mechanics** — see the warning below. |
 | `noir-rpg-framework.md` | Game design: setting, tone, structure, art direction. |
 | `design-review-notes.md` | Known open design risks. |
 | `docs/decisions/` | Durable architectural decisions. Linked from Issues, not copied. |
@@ -24,18 +25,24 @@ If two of these conflict, the higher row wins, and the conflict is a bug — fil
 1. **`BRP SRD 1.0.2.pdf` is not our source.** It is a different, superseded 2020
    document with a different resolution table and only four success grades. It is
    gitignored. If you find a copy, do not read it for mechanics.
-2. **The scope filter is binding.** No magic, sorcery, psychic powers, superpowers,
+2. **`engine-implementation-plan.md` is not authoritative for mechanics.** It predates
+   the source-text decision and has been found wrong on three separate topics — the
+   modifier ordering, the weapon range bands (wrong in every particular, including a
+   rule that does not exist), and resistance rolls (one line cites a section number from
+   the superseded book). Its architecture and build-layer material is still useful. Its
+   formulas are not. Take mechanics from the book.
+3. **The scope filter is binding.** No magic, sorcery, psychic powers, superpowers,
    mutations, fantasy weapons, spacecraft, or monsters. If an Issue seems to require
    out-of-scope content, stop and ask rather than implementing it.
-3. **Modern era baselines, not historical.** Several BRP skills carry two base
+4. **Modern era baselines, not historical.** Several BRP skills carry two base
    chances. Always take the modern value. See `orc-scope-filter.md`.
-4. **All randomness is injected and seeded.** No `System.Random` statics, no
+5. **All randomness is injected and seeded.** No `System.Random` statics, no
    `DateTime.Now` in the core. Same seed plus same call sequence must produce a
    byte-identical roll log. This is load-bearing for tests, replay, and balance
    simulation — not a style preference.
-5. **`Brp.Core` and `Brp.Rules` take no game-engine dependency.** No Unity, Godot,
+6. **`Brp.Core` and `Brp.Rules` take no game-engine dependency.** No Unity, Godot,
    or MonoGame references.
-6. **Rules values are data, not constants.** Numbers from the book belong in
+7. **Rules values are data, not constants.** Numbers from the book belong in
    ruleset JSON under `src/Brp.Data/`, not hardcoded in C#.
 
 ## Rules-conformance rule
@@ -43,7 +50,21 @@ If two of these conflict, the higher row wins, and the conflict is a bug — fil
 Any change implementing a mechanic must cite the chapter and section it comes from,
 and where the book prints a table, the test suite must reproduce that table exactly
 rather than spot-checking it. Derived formulas are verified against every printed
-row, not a sample.
+row, not a sample. `docs/source-handling.md` has the extraction recipe, the known
+errata, and the defect classes that keep recurring — read it before touching rules code.
+
+Two conventions you will meet and should follow:
+
+**Sourced or house rule.** Every mechanical claim in a decision record either cites the
+chapter it was verified against, or says plainly that the book is silent and the choice
+is ours. An unmarked assertion is a defect regardless of whether it happens to be true —
+two rewrites on #11 came from one sitting unnoticed beside verified claims.
+
+**Pinning tests.** A few tests deliberately assert behaviour that is correct in one
+context and wrong in another, and say so in their name and comment. The test *continuing
+to pass* is the alarm: it means someone reused the narrow thing somewhere it does not
+belong. `ResolutionPolicyTests.Skill_rolls_fail_at_96_even_at_full_chance_which_is_why_resistance_is_a_separate_path`
+is the worked example. Do not "fix" one of these; understand why it exists first.
 
 ## Work protocol
 
@@ -58,9 +79,17 @@ One concern, one Issue, one branch, one pull request.
 
 If you discover unrelated work, file a separate Issue. Do not enlarge the current one.
 
-## Commands
+## State of the code
 
-No solution exists yet — Issue #1 creates it. Once it does, these are the contract:
+`Brp.Core` holds Layer 0, complete: seeded dice (`Dice/`, `Randomness/`), the five-grade
+resolution kernel (`Resolution/`), the modifier pipeline (`Modifiers/`), and resistance
+and opposed rolls (`Contests/`). Roughly 890 tests, most of them printed tables
+reproduced cell by cell.
+
+Nothing above Layer 0 exists yet. See `engine-implementation-plan.md` §3 for the layer
+map — the *structure* there is sound even though its formulas are not.
+
+## Commands
 
 ```
 dotnet build

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A modern-day noir action/mystery RPG — no magic, no unrealistic technology, pr
 | [paper-kit/overpass-cards.html](paper-kit/overpass-cards.html) | Print-ready paper test kit — open in a browser and print: statement decks, suspect dossiers with trackers, evidence cards, reference cards, build sheets. |
 | [docs/decisions/](docs/decisions/) | Architecture decision records. |
 | [docs/agent-team.md](docs/agent-team.md) | Agent roster and routing rules — which model does what, and why. |
+| [docs/source-handling.md](docs/source-handling.md) | How to extract from the source book, the verification discipline, and known errata in it. |
 
 ## How work is tracked
 
@@ -39,7 +40,7 @@ in Issues. Neither is duplicated here.
 
 ## Status
 
-Early design phase (Phase 0 decisions locked; Phase 1 validation underway — see the development plan). Decisions made so far: modern-day era, player-created protagonist via point-buy with background packages, open city structured as map nodes with multiple concurrent intersecting cases, junction-only case decay, pre-seeded rolls, tick-on-use advancement, commercial release intent. Platform and engine undecided until the vertical slice.
+Phase 1 validation underway alongside engine Layer 0, which is complete (dice, resolution kernel, modifier pipeline, resistance and opposed rolls; ~890 tests). Phase 0 decisions locked — see the development plan). Decisions made so far: modern-day era, player-created protagonist via point-buy with background packages, open city structured as map nodes with multiple concurrent intersecting cases, junction-only case decay, pre-seeded rolls, tick-on-use advancement, commercial release intent. Platform and engine undecided until the vertical slice.
 
 ## Licensing
 

--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -56,6 +56,14 @@ agent will find them.
 **Verification agents get read-only tools.** An agent that can edit what it is checking
 will eventually make the check pass instead of making the code right.
 
+## What verification passes should look for
+
+`docs/source-handling.md` lists the defect classes that have actually bitten this
+project — unchecked assertions, misattributed citations, contaminated inheritance,
+implementing prose over a printed table, and silently matching a misprint. Every one has
+occurred at least once. Brief verification agents against that list rather than leaving
+them to invent their own.
+
 ## The pipeline for a rules-engine change
 
 ```

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -3,6 +3,20 @@
 Short records of durable choices. Link them from Issues and PRs rather than
 restating them.
 
+### The sourced / house-rule convention
+
+Every mechanical claim in a record must be marked one of two ways:
+
+- **Sourced** — cite the chapter it was verified against. Not "the book says", but which
+  chapter, checked when the record was written.
+- **House rule** — state plainly that the book is silent and the decision is ours, and
+  give the reasoning.
+
+An unmarked assertion is a defect even when it happens to be right. ADR 0007 was rewritten
+twice because unchecked claims sat beside verified ones with nothing on the page telling
+them apart; both failures are preserved in that record. ADR 0007 is the worked example of
+the convention.
+
 One file per decision, numbered. Status is `Proposed`, `Accepted`, or
 `Superseded by NNNN`. A decision that turns out wrong gets a new record that
 supersedes it — the original is not edited or deleted.

--- a/docs/source-handling.md
+++ b/docs/source-handling.md
@@ -1,0 +1,101 @@
+# Working with the source book
+
+Everything mechanical in this engine comes from one document. This file is how to get
+things out of it correctly, and what is already known to be wrong with it.
+
+## The one source, and the one forbidden one
+
+**Use:** `BasicRoleplaying-ORC-Content-Document.pdf` (repo root). 303 pages, ORC licensed.
+
+**Never use:** `BRP SRD 1.0.2.pdf`. It is a different, superseded 2020 document under a
+different licence. It has **four** degrees of success where ours has five, and different
+threshold rounding — half-up where ours is ceiling, which diverges at **54 of 120**
+possible chance values. Code derived from it looks entirely correct and is wrong more
+often than right. It is gitignored; if a copy appears, do not read it for mechanics.
+
+`orc-scope-filter.md` decides what we implement. Roughly 60% of the book is out of scope.
+
+## Extraction recipe
+
+```bash
+pdftotext BasicRoleplaying-ORC-Content-Document.pdf /tmp/orc.txt
+```
+
+**No `-layout` for body text.** The document is single-column and linear; `-layout`
+scrambles reading order.
+
+**Page breaks are form feeds (`\f`).** They silently break naive greps — a heading at
+the top of a page will not match `^Heading` because the line begins with `\f`. Strip or
+account for them.
+
+**Wide tables are the exception.** The Resistance Table is a 24×24 grid that the
+whitespace dump misaligns. For those, extract the single page with layout preserved:
+
+```bash
+pdftotext -layout -f 130 -l 130 BasicRoleplaying-ORC-Content-Document.pdf -
+```
+
+**For a disputed cell, go to coordinates.** `pdftotext -bbox` gives glyph positions, so
+a value can be assigned to a column by matching its x-position against the header row.
+This is how the resistance misprint below was confirmed to be a real printing error
+rather than an extraction artifact. Rendering the region at 300 dpi and reading it
+visually is the final check.
+
+## The discipline
+
+**Where the book prints a table, reproduce the whole table as test data.** One case per
+printed row or cell, data-driven, so a transcription error surfaces as a named failing
+row rather than hiding inside a loop. Never spot-check a table.
+
+**Derive closed forms, then try to falsify them.** Every closed form in this engine was
+checked against every value in the printed range, not against sample points. Report the
+count you actually verified.
+
+**The printed table beats the prose.** The book's descriptive sentences have contradicted
+its own tables twice (see below). Tables are normative; prose hedges.
+
+**Cite the chapter and section for every mechanic you implement.** A misattributed
+citation is a defect even when the behaviour is right — it is the audit trail the next
+verification pass will trust.
+
+## Known errata in the book
+
+Both were established at real cost. Neither is a transcription mistake on our side.
+
+### 1. The fumble prose contradicts the Skill Results Table
+
+Ch 5 describes the fumble chance as one twentieth of the chance of failure. Read
+literally that is one row too narrow at every multiple of 20, and at a 100% chance it
+yields no fumble range at all — despite the same paragraph stating that a roll of 00
+always fumbles.
+
+**The table is authoritative.** Its preamble is normative where the prose hedges with
+"usually", and the prose's literal reading self-contradicts. Implemented per the table;
+see `ResolutionPolicy` and ADR 0007.
+
+### 2. One resistance table cell is misprinted
+
+The cell at **passive 15, active 24** prints a value 10 lower than it should. Both the
+closed form and the row's own progression give the higher value, and the fifteen other
+cells sharing that difference all print it.
+
+Confirmed by two independent monotonicity violations — the row decreases at its final
+column, and the column breaks an otherwise perfect descent — plus bounding-box
+coordinates placing the glyph under the correct column header, plus a 300 dpi render.
+
+`ResistanceTableTests` pins **both** the printed value and the engine's value and asserts
+they differ. That test fails loudly if either the transcription is "corrected" to match
+the formula or the engine silently starts matching the misprint.
+
+## Recurring defect classes
+
+Every one of these has bitten this project at least once. They are what a verification
+pass should look for first.
+
+| Class | What it looks like |
+|---|---|
+| **Unchecked assertion** | A mechanical claim written from memory, sitting beside verified claims with nothing distinguishing them. Caused two full rewrites on #11. |
+| **Misattributed citation** | Behaviour is right, but the cited chapter or page does not say what is claimed. Found on #10, #11, and #12. |
+| **Contaminated inheritance** | A formula copied from a document derived from the superseded book. |
+| **Prose over table** | Implementing a descriptive sentence instead of the printed grid it describes. |
+| **Silent table match** | Matching a misprint without recording that it is one, so the next reader cannot tell code from book. |

--- a/engine-implementation-plan.md
+++ b/engine-implementation-plan.md
@@ -6,6 +6,31 @@
 
 ---
 
+> ## ⚠ Not authoritative for mechanics
+>
+> This document predates the source-text decision and **carries residue from the
+> superseded 2020 book**. It has been found wrong on three separate topics:
+>
+> | Topic | What happened |
+> |---|---|
+> | Modifier ordering (§1 D3) | Framed as an open binary; the book specifies a three-stage scheme neither option described. Cost two rewrites of ADR 0007. |
+> | Weapon range bands (§1 D3, §3 Layer 4) | Wrong multipliers, wrong thresholds, and a "beyond three times range is impossible" rule that does not exist. |
+> | Opposed-roll degrade (§3 Layer 1) | Cited a section number from the superseded book. The rules it described are not this book's rules. |
+>
+> **What is still good:** the architecture decisions (§1 D1–D7), the build-layer map (§3),
+> and the project layout (§4). Those are engineering judgments, not rules claims.
+>
+> **What §2 is:** its formulas were independently re-derived and verified against every
+> printed row during #10, and they hold. But take them from the tests, not from here —
+> `Brp.Core.Resolution` and its conformance fixture are the live record.
+>
+> **Rule of thumb:** if a line in this file states a game rule, verify it against the book
+> before acting on it. See `docs/source-handling.md`.
+
+---
+
+---
+
 ## 0. Source text — resolved
 
 The framework doc was right and my first pass was wrong. The repo now holds the **ORC Content Document** (BRP: Universal Game Engine, 2023), which is what `noir-rpg-framework.md` described all along. The 23-page `BRP SRD 1.0.2.pdf` is a different, much smaller 2020 document under a different license; it is not our source and should be treated as superseded reference only.
@@ -81,9 +106,11 @@ The SRD mixes four incompatible modifier kinds and never states an ordering:
 | Gate | Automatic (no roll, succeeds), Impossible (no roll, fails) |
 | Override | Shield parry vs missiles: flat 15% / 30% / 60% / 90% |
 | Additive | Armor `−20% to physical skills`, Firing into combat `−20%` |
-| Multiplicative | Easy `×2`, Difficult `×½`, range band 2× `×½`, range band 3× `×¼` |
+| Multiplicative | Easy `×2`, Difficult `×½`, and other rational factors |
 
-Note **`×¼` exists** (weapon range band 3), so `Difficulty` cannot be a closed enum — it must reduce to a rational multiplier. Canonical order must be a documented, configurable policy: `Gate → Override → Additive → Multiplicative → Clamp`. Also undefined by the SRD and therefore a policy decision: **do two Difficults stack to ×¼ or stay ×½?** (darkness + firing into combat, SRD 6.4 + 6.8).
+`Difficulty` cannot be a closed enum — factors outside the Easy/Difficult ladder exist, so it must reduce to a rational multiplier. The ordering must be a named, configurable policy rather than implicit in call order.
+
+**Both questions this section originally posed are now settled, and not as it guessed.** See `docs/decisions/0007-modifier-pipeline.md`: the book specifies the ordering (three stages, not two), and difficulty non-stacking is a house rule the book leaves open. The range-band claims that were here were wrong and have been removed; range bands are tracked in #21.
 
 **D4 — Determinism and a recorded roll log.**
 Seedable, serializable PRNG injected everywhere; no `Random` static, no `DateTime.Now`. Every roll appends to an event log with sequence number and context. This single decision buys four things at once:
@@ -153,7 +180,7 @@ Each layer depends only on the layers above it. Nothing in Layer *n* may referen
 - `CharacteristicRoll(characteristic, multiplier)` → `Percent`. Covers Effort/Stamina/Idea/Luck/Agility/Charisma at ×5 *and* the disease-recovery ladder at ×1..×5 with one type.
 - `DerivedCharacteristic` as recomputable formulas: `MOV`, `HP = RoundUp((CON+SIZ)/2)`, `PowerPoints = POW`, `DamageBonus = table(STR+SIZ)`. **Must recompute on characteristic loss** — disease and poison drain characteristics (SRD 6.5, 6.10), so these cannot be baked at creation.
 - `AbilityResolver` — *the single most-used API in the system.* `(ability, modifiers, entropy) → RollOutcome`.
-- `ResistanceRoll` and `OpposedRoll` (SRD 3.3 degrade rules: Special vs Special → two failures but experience checks still allowed; Special vs Success → Success vs Failure; ties → higher rating wins).
+- `ResistanceRoll` and `OpposedRoll`. **Built in #12; the rules originally described here came from the superseded book and were wrong** — ties resolve by the higher die roll, not the higher rating. See `src/Brp.Core/Contests/` and its tests.
 
 ### Layer 2 — Skills
 - `SkillDefinition`: id, name, base chance which may be a constant (`Spot 25`) **or a formula** (`Dodge DEX×2`, `Language(Own) INT×5`, `Gaming INT+POW`, `Fly DEX×½ | DEX×4`) **or era-conditional** (`First Aid 30 | INT×1`, `Drive 20 | 01`) **or weapon-derived** (`Firearm var`).
@@ -169,7 +196,7 @@ Each layer depends only on the layers above it. Nothing in Layer *n* may referen
   - The "nothing at stake" gate must be enforced mechanically — there is no gamemaster to adjudicate it.
 
 ### Layer 4 — Combat, gear, spot rules
-- Weapon/armor/shield definitions as data, including range bands (`≤R` normal, `≤2R` ×½, `≤3R` ×¼, `>3R` impossible) and armor's skill penalties by skill *category* (SRD names the physical and perception sets explicitly).
+- Weapon/armor/shield definitions as data, and armor's skill penalties by category. **Range bands are tracked in #21**; the values previously stated here were wrong in every particular and have been removed rather than corrected.
 - `CombatRound`: four phases (Intent → Movement → Actions → Resolution); DEX-rank ordering with the weapon-type tiebreak (missile → long → medium → short/unarmed); movement tiers (6–15 m = ½ DEX rank, 16–29 m = ¼ DEX rank); draw weapon = −5 DEX ranks.
 - `AttackDefenseMatrix` — the 7-row table as data, not an `if` chain.
 - Damage: armor subtraction, special success = `weaponMax + normalRoll + db`, unconscious at ≤2 HP, dead at 0 at end of round, negative HP tracked, knockout rule (Difficult attack, damage > ½ *total* HP).
@@ -200,7 +227,9 @@ tools/
 
 ---
 
-## 5. Milestone 1 — the first thing to build
+## 5. Milestone 1 — complete
+
+*Delivered across #8, #9, #10, #11, #12. Retained as a record of the acceptance criteria that were actually met.*
 
 **Scope:** `Brp.Core` Layer 0 + `AbilityResolver` + `ResistanceRoll` + `OpposedRoll`.
 


### PR DESCRIPTION
## Linked Issue

Closes #24

## Exact behavioral claim

A fresh agent starting from `AGENTS.md` is no longer misled, and does not have to
re-derive knowledge this project already paid for.

## Scope

**Changed:** `AGENTS.md`, `engine-implementation-plan.md`, `README.md`,
`docs/decisions/README.md`, `docs/agent-team.md`. **Added:** `docs/source-handling.md`.

**Deliberately unchanged:** no code, no rules decision, no ADR content beyond
documenting the convention ADR 0007 already follows.

## The landmine this fixes

`AGENTS.md` listed `engine-implementation-plan.md` as authoritative for **"resolution
kernel formulas."** That document has been found wrong on three separate topics:

| Topic | What happened |
|---|---|
| Modifier ordering | Framed as an open binary; the book specifies a three-stage scheme neither option described. Cost two rewrites of ADR 0007. |
| Weapon range bands | Wrong multipliers, wrong thresholds, and a "beyond three times range is impossible" rule that does not exist. |
| Opposed-roll degrade | Cited a section number from the superseded 2020 book. |

Every Issue briefed this session carried an explicit "do not trust this file" warning,
while `AGENTS.md` told a fresh agent the opposite. It now carries a status banner naming
what is wrong and what survives, and the wrong claims are **excised rather than
annotated** — an annotated wrong formula is still a formula someone can copy.

What survives is real: the architecture decisions and the build-layer map are engineering
judgments, not rules claims, and they held up.

## Also fixed

`AGENTS.md` claimed *"No solution exists yet — Issue #1 creates it."* Wrong twice: the
solution has existed since #8, and #1 was the skill-bonus decision.

## What is now captured

**`docs/source-handling.md`** — the extraction recipe I retyped into six briefs (no
`-layout` for body text, form feeds break naive greps, `-layout` per page for wide
tables, bounding boxes for disputed cells), the verification discipline, and the five
recurring defect classes.

**Both known book errata**, with how they were confirmed — the fumble prose that
contradicts its own table, and the misprinted resistance cell. Either would otherwise be
rediscovered at full cost by whoever hits it next.

**Two conventions**, documented where someone would look rather than only inside the one
record that uses them:

- *Sourced or house rule* — every mechanical claim in an ADR cites a chapter or states
  the book is silent. This is the direct fix for the defect that caused two rewrites.
- *Pinning tests* — where the test **continuing to pass** is the alarm, not the
  reassurance. Unusual enough to confuse someone who finds one cold.

## Tests and evidence

```
dotnet build   -> 0 Warning(s), 0 Error(s)
dotnet test    -> Passed! 886 total, 0 failed
dotnet format --verify-no-changes -> clean
```

Every factual claim added to `AGENTS.md` was checked against the repo — the five Layer 0
namespaces exist, `global.json` exists, the test count is real.

## Known limitations

- `AGENTS.md`'s "State of the code" section will go stale as layers land. It is short and
  in the file that changes with the work, which is the best available trade.
- The `.claude/agents/*.md` definitions load at session start, so they were not callable
  in the session that created them. A fresh session gets them; worth knowing, not worth
  a workaround.
- `engine-implementation-plan.md` is now half-trusted, which is an awkward state. Splitting
  the architecture material into its own document would be cleaner, and is deliberately
  left for whoever needs it rather than done speculatively.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented.