### PR TITLE
Add brp roll CLI with full provenance output (#13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,11 @@ If you discover unrelated work, file a separate Issue. Do not enlarge the curren
 
 `Brp.Core` holds Layer 0, complete: seeded dice (`Dice/`, `Randomness/`), the five-grade
 resolution kernel (`Resolution/`), the modifier pipeline (`Modifiers/`), and resistance
-and opposed rolls (`Contests/`). Roughly 890 tests, most of them printed tables
+and opposed rolls (`Contests/`). Roughly 930 tests, most of them printed tables
 reproduced cell by cell.
+
+`tools/Brp.Cli` is the `brp` command line over that kernel — one command, `roll`, which
+resolves a check and prints its whole derivation. It has its own `AGENTS.md`.
 
 Nothing above Layer 0 exists yet. See `engine-implementation-plan.md` §3 for the layer
 map — the *structure* there is sound even though its formulas are not.

--- a/NoiRPG.slnx
+++ b/NoiRPG.slnx
@@ -3,6 +3,10 @@
     <Project Path="src/Brp.Core/Brp.Core.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Brp.Cli.Tests/Brp.Cli.Tests.csproj" />
     <Project Path="tests/Brp.Core.Tests/Brp.Core.Tests.csproj" />
+  </Folder>
+  <Folder Name="/tools/">
+    <Project Path="tools/Brp.Cli/Brp.Cli.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A modern-day noir action/mystery RPG — no magic, no unrealistic technology, pr
 | [tools/case_validator.py](tools/case_validator.py) | Case validator — enforces the Three Doors and junction-point rules, audits build coverage. |
 | [interrogation-cards-overpass.md](interrogation-cards-overpass.md) | Statement card decks for all four Overpass suspects — the interrogation paper-prototype materials. |
 | [paper-kit/overpass-cards.html](paper-kit/overpass-cards.html) | Print-ready paper test kit — open in a browser and print: statement decks, suspect dossiers with trackers, evidence cards, reference cards, build sheets. |
+| [tools/Brp.Cli/](tools/Brp.Cli/) | The `brp` command line — `brp roll` resolves a check and prints the full modifier chain, the outcome bands, and the grade. |
 | [docs/decisions/](docs/decisions/) | Architecture decision records. |
 | [docs/agent-team.md](docs/agent-team.md) | Agent roster and routing rules — which model does what, and why. |
 | [docs/source-handling.md](docs/source-handling.md) | How to extract from the source book, the verification discipline, and known errata in it. |

--- a/tests/Brp.Cli.Tests/Brp.Cli.Tests.csproj
+++ b/tests/Brp.Cli.Tests/Brp.Cli.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Brp.Core\Brp.Core.csproj" />
+    <ProjectReference Include="..\..\tools\Brp.Cli\Brp.Cli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Brp.Cli.Tests/CliHarness.cs
+++ b/tests/Brp.Cli.Tests/CliHarness.cs
@@ -1,0 +1,20 @@
+namespace Brp.Cli.Tests;
+
+/// <summary>
+/// Runs the command line in-process against string writers. Every test goes through
+/// <see cref="Program.Run"/> -- the same entry point the executable uses -- so what is asserted
+/// on is the real rendering path, not a reimplementation of it.
+/// </summary>
+internal static class CliHarness
+{
+    public static CliResult Run(params string[] args)
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var exitCode = Program.Run(args, output, error);
+        return new CliResult(exitCode, output.ToString(), error.ToString());
+    }
+
+    /// <summary>The three things a command line produces: what it printed, where, and its exit code.</summary>
+    public sealed record CliResult(int ExitCode, string Output, string Error);
+}

--- a/tests/Brp.Cli.Tests/RollBandTests.cs
+++ b/tests/Brp.Cli.Tests/RollBandTests.cs
@@ -1,0 +1,196 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Brp.Core.Primitives;
+using Brp.Core.Resolution;
+
+namespace Brp.Cli.Tests;
+
+/// <summary>
+/// The outcome bands the report prints, checked against the resolution kernel and against the
+/// printed Skill Results Table, plus the layout constraint that the report stays readable in a
+/// narrow terminal.
+/// </summary>
+public class RollBandTests
+{
+    /// <summary>
+    /// Acceptance criterion: the thresholds shown match the kernel's for that rating. Swept
+    /// across the whole printed portion of the Skill Results Table rather than spot-checked,
+    /// per the rules-conformance rule in <c>AGENTS.md</c> -- the kernel's own conformance
+    /// fixture pins these values to the book, and this pins the display to the kernel.
+    /// </summary>
+    [Fact]
+    public void Rendered_bands_match_the_kernels_thresholds_at_every_rating_from_1_to_120()
+    {
+        for (var rating = 1; rating <= 120; rating++)
+        {
+            var chance = Percent.Of(rating);
+            var kernel = SkillResolver.Resolve(chance, chance, roll: 1);
+            var bands = BandsOf(CliHarness.Run("roll", "--skill", rating.ToString(CultureInfo.InvariantCulture), "--seed", "42"));
+
+            Assert.Equal(kernel.CriticalThreshold.Value, Last(bands, "Critical success", rating));
+            Assert.Equal(kernel.FumbleThreshold.Value, First(bands, "Fumble", rating));
+
+            // A special band only appears when it is wider than the critical band inside it;
+            // at a rating of 1 both thresholds are 1 and the critical result wins outright.
+            if (kernel.SpecialThreshold.Value > kernel.CriticalThreshold.Value)
+            {
+                Assert.Equal(kernel.SpecialThreshold.Value, Last(bands, "Special success", rating));
+            }
+            else
+            {
+                Assert.DoesNotContain(bands, b => b.Grade == "Special success");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The acceptance invocation resolves against an effective 13%, which is row <c>11-15</c> of
+    /// the printed Skill Results Table (Ch 5: System, BRP ORC Content Document, p.127-128):
+    /// critical <c>01</c>, special <c>01-03</c>, fumble <c>96-00</c>. Transcribed here from the
+    /// book so the demonstration this Issue delivers is checked against the source directly,
+    /// not only against the code that produced it.
+    /// </summary>
+    [Fact]
+    public void Bands_for_the_acceptance_rating_match_the_printed_skill_results_table_row()
+    {
+        var bands = BandsOf(CliHarness.Run(
+            "roll", "--skill", "65", "--difficulty", "difficult",
+            "--modifier", "-20 firing-into-combat", "--seed", "42"));
+
+        Assert.Equal(
+            [
+                (1, 1, "Critical success"),
+                (2, 3, "Special success"),
+                (4, 13, "Success"),
+                (14, 95, "Failure"),
+                (96, 100, "Fumble"),
+            ],
+            bands);
+    }
+
+    /// <summary>
+    /// Ch 5, "Skill Rolls": a skill whose <em>base</em> chance is 5% or higher always succeeds
+    /// on 01-05 however far modifiers push the effective chance down. Called out in the report
+    /// only when it actually widens the success band past the effective chance -- otherwise the
+    /// band would look like an arithmetic error.
+    /// </summary>
+    [Theory]
+    // 65 halved to 33, less 30, is 3 -- below the floor, and the base chance is above it.
+    [InlineData(new[] { "roll", "--skill", "65", "--difficulty", "difficult", "--modifier", "-30 pitch-dark", "--seed", "1" }, true)]
+    // Nothing pushes the effective chance below 5.
+    [InlineData(new[] { "roll", "--skill", "65", "--seed", "1" }, false)]
+    // Effective chance is below 5, but so is the base chance, so the floor does not apply.
+    [InlineData(new[] { "roll", "--skill", "3", "--seed", "1" }, false)]
+    public void The_base_chance_floor_is_named_only_when_it_widens_the_success_band(string[] args, bool expected)
+    {
+        var result = CliHarness.Run(args);
+
+        Assert.Equal(expected, result.Output.Contains("base-chance floor", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The floor is keyed on the skill's <em>printed base chance</em>, not on the character's
+    /// rating: Ch 5, "Skill Rolls" says "any skill which normally has a base chance of 5% or
+    /// higher... even if difficulty, conditional modifiers, or other factors reduce the skill
+    /// rating below 5%". Those are two different numbers, and several in-scope skills are
+    /// printed at 01% -- Science, Strategy and Martial Arts (Ch 3: Skills) -- so a trained
+    /// character can hold a rating well above the floor in a skill the floor does not cover.
+    /// <para>
+    /// Worked case: Science (Forensics) at 40%, rolled Difficult with no lab access. 40 halved
+    /// is 20, less 18 is an effective 2%. Rolls 03-05 are failures, because Science is printed
+    /// at 01%. Binding the rating into the base-chance slot would rescue them.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void The_floor_reads_the_printed_base_chance_not_the_characters_rating()
+    {
+        var args = new[]
+        {
+            "roll", "--skill", "40", "--difficulty", "difficult", "--modifier", "-18 no-lab-access", "--seed", "7",
+        };
+
+        var trained = CliHarness.Run([.. args, "--base-chance", "1"]);
+        Assert.Equal(
+            [(1, 1, "Critical success"), (2, 2, "Success"), (3, 95, "Failure"), (96, 100, "Fumble")],
+            BandsOf(trained));
+        Assert.DoesNotContain("floor", trained.Output, StringComparison.Ordinal);
+
+        // Without the option the printed base chance defaults to the rating, which is the right
+        // reading for every skill printed at 5% or above and the wrong one here. The option
+        // exists precisely so the difference is expressible; this pins the default.
+        var assumed = CliHarness.Run(args);
+        Assert.Equal(
+            [(1, 1, "Critical success"), (2, 5, "Success"), (6, 95, "Failure"), (96, 100, "Fumble")],
+            BandsOf(assumed));
+    }
+
+    /// <summary>
+    /// The note names only the rolls the floor actually rescues. At an effective 3% the success
+    /// band runs 02-05, but 02-03 succeed on the effective chance in the ordinary way and 01 is
+    /// a critical; only 04-05 are the floor's doing. Printing "01-05" there would contradict the
+    /// band list one line above it.
+    /// </summary>
+    [Fact]
+    public void The_floor_note_names_only_the_rolls_the_floor_rescues()
+    {
+        var result = CliHarness.Run(
+            "roll", "--skill", "65", "--difficulty", "difficult", "--modifier", "-30 pitch-dark", "--seed", "1");
+
+        Assert.Contains("note: 04-05 succeed on the base-chance floor", result.Output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Acceptance criterion: readable in a terminal without a wide window. 72 columns leaves
+    /// room for the quoting and indentation a diff or an Issue comment adds around it.
+    /// </summary>
+    [Theory]
+    // Arguments are separated by '|' because some of them contain spaces.
+    [InlineData("roll|--skill|65|--difficulty|difficult|--modifier|-20 firing-into-combat|--seed|42")]
+    [InlineData("roll|--skill|65|--difficulty|difficult|--modifier|-30 pitch-dark|--seed|1")]
+    [InlineData("roll|--skill|120|--difficulty|easy|--seed|9")]
+    [InlineData("roll|--skill|0|--seed|9")]
+    [InlineData("roll|--skill|65|--seed|42|--modifier|-5 a-source-label-long-enough-to-crowd-the-column")]
+    public void The_report_fits_a_terminal_seventy_two_columns_wide(string commandLine)
+    {
+        var overlong = CliHarness.Run(commandLine.Split('|')).Output
+            .Split('\n')
+            .Where(line => line.Length > 72)
+            .ToList();
+
+        Assert.Empty(overlong);
+    }
+
+    private static int Last(IReadOnlyList<(int Low, int High, string Grade)> bands, string grade, int rating)
+    {
+        var band = bands.LastOrDefault(b => b.Grade == grade);
+        Assert.True(band.Grade == grade, $"No '{grade}' band at rating {rating}.");
+        return band.High;
+    }
+
+    private static int First(IReadOnlyList<(int Low, int High, string Grade)> bands, string grade, int rating)
+    {
+        var band = bands.FirstOrDefault(b => b.Grade == grade);
+        Assert.True(band.Grade == grade, $"No '{grade}' band at rating {rating}.");
+        return band.Low;
+    }
+
+    /// <summary>
+    /// Reads the band table back out of the rendered report, which is the only thing a
+    /// gamemaster actually sees -- asserting against the rendering rather than against an
+    /// intermediate object is the point.
+    /// </summary>
+    private static List<(int Low, int High, string Grade)> BandsOf(CliHarness.CliResult result)
+    {
+        // A band covering a single roll is printed as one value, so the range half is optional.
+        var bands = Regex.Matches(result.Output, @"^  (\d{2,3})(?:-(\d{2,3}))?\s+(\S.*)$", RegexOptions.Multiline)
+            .Select(m => (
+                Low: int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture),
+                High: int.Parse(
+                    m.Groups[2].Success ? m.Groups[2].Value : m.Groups[1].Value, CultureInfo.InvariantCulture),
+                Grade: m.Groups[3].Value))
+            .ToList();
+
+        Assert.NotEmpty(bands);
+        return bands;
+    }
+}

--- a/tests/Brp.Cli.Tests/RollCommandTests.cs
+++ b/tests/Brp.Cli.Tests/RollCommandTests.cs
@@ -1,0 +1,221 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Brp.Cli.Tests;
+
+/// <summary>
+/// Behaviour of the <c>roll</c> command: the acceptance invocation from
+/// <c>engine-implementation-plan.md</c> §5, reproducibility, and what the tool does with a
+/// command line it cannot understand.
+/// </summary>
+public class RollCommandTests
+{
+    private static readonly string[] AcceptanceInvocation =
+    [
+        "roll", "--skill", "65", "--difficulty", "difficult",
+        "--modifier", "-20 firing-into-combat", "--seed", "42",
+    ];
+
+    /// <summary>
+    /// Acceptance criterion 5 of Milestone 1, verbatim: a rating, a named flat penalty, a
+    /// difficulty grade and a seed, printing the full modifier chain and the graded outcome.
+    /// Pinned as an exact string because the output <em>is</em> the deliverable here -- a
+    /// gamemaster reads it, and it gets pasted into Issues and diffed. A change to any line of
+    /// it is a change to the contract, and should have to be made deliberately.
+    /// </summary>
+    [Fact]
+    public void Acceptance_invocation_prints_the_whole_chain_and_the_graded_outcome()
+    {
+        var result = CliHarness.Run(AcceptanceInvocation);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.Error);
+        Assert.Equal(
+            """
+            brp roll  (seed 42)
+
+            Chance
+              base rating                                        65%
+              difficult ÷2                                       33%
+              firing-into-combat -20% [situational]              13%
+              effective chance                                   13%
+
+            Outcome bands  (effective 13%, base chance 65%)
+              01      Critical success
+              02-03   Special success
+              04-13   Success
+              14-95   Failure
+              96-100  Fumble
+
+            Roll  43  →  Failure
+
+            """,
+            result.Output);
+    }
+
+    [Fact]
+    public void Same_seed_produces_identical_output_across_runs()
+    {
+        var first = CliHarness.Run(AcceptanceInvocation);
+        var second = CliHarness.Run(AcceptanceInvocation);
+
+        Assert.Equal(first.Output, second.Output);
+        Assert.Equal(first.ExitCode, second.ExitCode);
+    }
+
+    /// <summary>
+    /// The companion to the reproducibility test: identical output across runs would also be
+    /// satisfied by a tool that ignored the seed entirely and always rolled the same number.
+    /// </summary>
+    [Fact]
+    public void Different_seeds_produce_different_rolls()
+    {
+        var rolls = Enumerable.Range(1, 20)
+            .Select(seed => RollOf(CliHarness.Run("roll", "--skill", "65", "--seed", seed.ToString(CultureInfo.InvariantCulture))))
+            .Distinct()
+            .ToList();
+
+        Assert.True(rolls.Count > 1, $"20 seeds produced only these rolls: {string.Join(", ", rolls)}");
+    }
+
+    [Fact]
+    public void Inline_and_separated_option_forms_are_equivalent()
+    {
+        var separated = CliHarness.Run(
+            "roll", "--skill", "65", "--difficulty", "difficult", "--modifier", "-20 firing-into-combat",
+            "--seed", "42");
+        var inline = CliHarness.Run(
+            "roll", "--skill=65", "--difficulty=difficult", "--modifier=-20 firing-into-combat", "--seed=42");
+
+        Assert.Equal(separated.Output, inline.Output);
+    }
+
+    /// <summary>
+    /// ADR 0007: a permanent modifier is figured into the rating before a Difficult grade halves
+    /// it; a situational one is applied after, so its stated weight is not itself halved. The
+    /// command has to make that visible, because a chain that hid it would hide the single most
+    /// error-prone step in the pipeline. 65 +10 = 75, halved = 38, −20 = 18 -- not 65 halved to
+    /// 33 with a net −10 applied, which would read 23.
+    /// </summary>
+    [Fact]
+    public void Permanent_modifiers_land_before_the_difficulty_grade_and_situational_ones_after()
+    {
+        var result = CliHarness.Run(
+            "roll", "--skill", "65",
+            "--permanent-modifier", "+10 specialist-training",
+            "--difficulty", "difficult",
+            "--modifier", "-20 firing-into-combat",
+            "--seed", "42");
+
+        var chance = ChanceLines(result.Output);
+        Assert.Equal(
+            [
+                "base rating|65%",
+                "specialist-training +10% [permanent]|75%",
+                "difficult ÷2|38%",
+                "firing-into-combat -20% [situational]|18%",
+                "effective chance|18%",
+            ],
+            chance);
+    }
+
+    /// <summary>
+    /// A failed or fumbled roll is a result, not a tool error, so every grade exits zero.
+    /// A script wrapping this command has to be able to tell "the dice went badly" from
+    /// "you typed it wrong", and the exit code is the only channel that carries that.
+    /// </summary>
+    [Theory]
+    [InlineData("32", "Critical success")]
+    [InlineData("3", "Special success")]
+    [InlineData("0", "Success")]
+    [InlineData("2", "Failure")]
+    [InlineData("8", "Fumble")]
+    public void Every_grade_exits_zero_because_a_bad_roll_is_a_result_not_an_error(string seed, string grade)
+    {
+        var result = CliHarness.Run("roll", "--skill", "65", "--seed", seed);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.Error);
+        Assert.EndsWith($"→  {grade}\n", result.Output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    // Missing required options -- a seed especially, because inventing one would make this the
+    // one place in the engine where a result cannot be reproduced from what was typed.
+    [InlineData(new[] { "roll", "--seed", "42" }, "--skill")]
+    [InlineData(new[] { "roll", "--skill", "65" }, "--seed")]
+    // Values that are not what the option takes.
+    [InlineData(new[] { "roll", "--skill", "sixty-five", "--seed", "42" }, "--skill")]
+    [InlineData(new[] { "roll", "--skill", "-5", "--seed", "42" }, "--skill")]
+    [InlineData(new[] { "roll", "--skill", "40", "--base-chance", "-1", "--seed", "42" }, "--base-chance")]
+    [InlineData(new[] { "roll", "--skill", "40", "--base-chance", "one", "--seed", "42" }, "--base-chance")]
+    [InlineData(new[] { "roll", "--skill", "65", "--seed", "-1" }, "--seed")]
+    [InlineData(new[] { "roll", "--skill", "65", "--seed", "42", "--difficulty", "tricky" }, "--difficulty")]
+    // A modifier with no source label defeats the purpose of the command.
+    [InlineData(new[] { "roll", "--skill", "65", "--seed", "42", "--modifier", "-20" }, "source label")]
+    [InlineData(new[] { "roll", "--skill", "65", "--seed", "42", "--modifier", "dark" }, "percentage adjustment")]
+    // Repeats are rejected rather than silently taking the last one.
+    [InlineData(new[] { "roll", "--skill", "65", "--skill", "40", "--seed", "42" }, "more than once")]
+    [InlineData(new[] { "roll", "--skill", "65", "--seed", "42", "--seed", "7" }, "more than once")]
+    [InlineData(new[] { "roll", "--skill", "65", "--base-chance", "5", "--base-chance", "1", "--seed", "42" }, "more than once")]
+    // Shapes the parser does not recognise.
+    [InlineData(new[] { "roll", "--skill", "65", "--seed", "42", "--bonus", "10" }, "unknown option")]
+    // A misspelled option reports itself rather than swallowing the next argument as its value.
+    [InlineData(new[] { "roll", "--skill", "65", "--seed", "42", "--bonus" }, "unknown option '--bonus'")]
+    [InlineData(new[] { "roll", "65", "--seed", "42" }, "unexpected argument")]
+    [InlineData(new[] { "roll", "--skill" }, "needs a value")]
+    public void A_command_line_that_cannot_be_understood_exits_two_and_says_why(string[] args, string expected)
+    {
+        var result = CliHarness.Run(args);
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.Contains(expected, result.Error, StringComparison.Ordinal);
+        // Nothing is rolled, so nothing goes to stdout: a caller piping this into a file gets
+        // an empty file rather than half a report.
+        Assert.Equal(string.Empty, result.Output);
+    }
+
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("-h")]
+    [InlineData("roll --help")]
+    public void Help_goes_to_stdout_and_exits_zero(string commandLine)
+    {
+        var result = CliHarness.Run(Words(commandLine));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.Error);
+        Assert.Contains("usage:", result.Output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("simulate")]
+    public void An_unusable_command_exits_two_with_the_usage_on_stderr(string commandLine)
+    {
+        var result = CliHarness.Run(Words(commandLine));
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.Equal(string.Empty, result.Output);
+        Assert.Contains("usage:", result.Error, StringComparison.Ordinal);
+    }
+
+    private static string[] Words(string commandLine) =>
+        commandLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+    private static int RollOf(CliHarness.CliResult result)
+    {
+        var match = Regex.Match(result.Output, @"^Roll\s+(\d+)\s", RegexOptions.Multiline);
+        Assert.True(match.Success, $"No roll line in:\n{result.Output}");
+        return int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Every line of the Chance section as <c>description|chance</c>.</summary>
+    private static List<string> ChanceLines(string output) =>
+        output.Split('\n')
+            .SkipWhile(line => line != "Chance")
+            .Skip(1)
+            .TakeWhile(line => line.Length > 0)
+            .Select(line => Regex.Replace(line.Trim(), @"\s{2,}", "|"))
+            .ToList();
+}

--- a/tools/Brp.Cli/AGENTS.md
+++ b/tools/Brp.Cli/AGENTS.md
@@ -1,0 +1,30 @@
+# `brp` — command-line tooling
+
+A gamemaster-facing shell over `Brp.Core`. Four rules govern it.
+
+**The rendered output is the contract.** It is read by a person, pasted into Issues, and
+diffed. `RollCommandTests.Acceptance_invocation_prints_the_whole_chain_and_the_graded_outcome`
+pins it as an exact string. Changing a line of the report means changing that test on
+purpose, which is the point — not an obstacle to route around.
+
+**The CLI computes no rules.** Every number it prints comes from the kernel: the derivation
+is read off `ModifierChain.Contributions`, and the outcome bands are produced by asking
+`SkillResolver` to grade all 100 possible rolls and collecting the runs. Re-deriving a
+threshold here would create a second implementation of the resolution table that no
+conformance fixture guards. If a value cannot be obtained from `Brp.Core`, that is a gap in
+`Brp.Core`.
+
+**A rating is not a base chance.** `--skill` is the character's rating, which the modifier
+chain starts from. `--base-chance` is the skill's printed starting value, and the only thing
+that reads it is the 5% floor (Ch 5: System, "Skill Rolls" — "any skill which normally has a
+base chance of 5% or higher... even if difficulty, conditional modifiers, or other factors
+reduce the skill rating below 5%"). They default to the same number, which is correct for
+every skill printed at 5% or above and wrong for the in-scope ones printed at 01% — Science,
+Strategy, Martial Arts. Do not collapse them back into one input.
+
+**No implicit seed, and no clock.** `--seed` is required. A tool whose whole purpose is
+showing how a result was produced cannot be the one place in the engine where a result
+cannot be reproduced from what was typed (AGENTS.md invariant 5, ADR 0003).
+
+**72 columns.** Enforced by `RollBandTests.The_report_fits_a_terminal_seventy_two_columns_wide`.
+It leaves room for the indentation a diff or an Issue comment wraps around the output.

--- a/tools/Brp.Cli/Brp.Cli.csproj
+++ b/tools/Brp.Cli/Brp.Cli.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- The invocation in engine-implementation-plan.md §5 is `brp roll ...`, so the
+         executable is named for the command, not for the project. -->
+    <AssemblyName>brp</AssemblyName>
+    <RootNamespace>Brp.Cli</RootNamespace>
+    <!-- Output must not vary with the machine's locale: ADR 0003's determinism promise is
+         about the roll, but a tool whose job is to be diffed and pasted into an Issue has
+         to render the same bytes everywhere too. -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Brp.Core\Brp.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Brp.Cli.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Brp.Cli/Program.cs
+++ b/tools/Brp.Cli/Program.cs
@@ -1,0 +1,100 @@
+using System.Text;
+
+namespace Brp.Cli;
+
+/// <summary>
+/// Entry point for <c>brp</c>, the gamemaster-facing command line over the rules kernel.
+/// <para>
+/// Deliberately thin: it owns the console and the exit code and nothing else. Everything a
+/// test needs to assert on is produced by <see cref="RollCommand"/> writing into a
+/// <see cref="TextWriter"/>, so the acceptance criterion "the same seed produces identical
+/// output" is checked against the real rendering path rather than a reimplementation of it.
+/// </para>
+/// </summary>
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        // The modifier chain renders with ÷ and × (Brp.Core's ModifierChain.Render uses the
+        // same glyphs), so a console left on a legacy code page would mangle the one thing
+        // this tool exists to show. Failure to set it is not worth aborting over.
+        try
+        {
+            Console.OutputEncoding = Encoding.UTF8;
+        }
+        catch (IOException)
+        {
+            // Redirected to a handle that will not take an encoding change. Carry on.
+        }
+
+        return Run(args, Console.Out, Console.Error);
+    }
+
+    /// <summary>
+    /// Dispatches one invocation. Returns <see cref="ExitCode.Ok"/> when a command ran to
+    /// completion -- including when the roll failed or fumbled, which is a result, not an error --
+    /// and <see cref="ExitCode.UsageError"/> when the command line could not be understood.
+    /// </summary>
+    internal static int Run(IReadOnlyList<string> args, TextWriter output, TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        if (args.Count == 0)
+        {
+            error.Write(Usage);
+            return ExitCode.UsageError;
+        }
+
+        var command = args[0];
+        var rest = args.Skip(1).ToList();
+
+        if (IsHelpFlag(command))
+        {
+            output.Write(Usage);
+            return ExitCode.Ok;
+        }
+
+        switch (command)
+        {
+            case "roll":
+                return RollCommand.Run(rest, output, error);
+
+            default:
+                error.Write($"brp: unknown command '{command}'.\n\n");
+                error.Write(Usage);
+                return ExitCode.UsageError;
+        }
+    }
+
+    internal static bool IsHelpFlag(string argument) =>
+        argument is "--help" or "-h" or "help";
+
+    internal const string Usage =
+        """
+        brp — Basic Roleplaying rules engine, from the command line.
+
+        usage:
+          brp roll --skill <n> --seed <n> [options]
+          brp --help
+
+        commands:
+          roll    Resolve one skill or action roll and show how the result was
+                  produced: the base rating, every modifier with its source, the
+                  effective chance, the outcome bands, the roll, and the grade.
+
+        Run `brp roll --help` for the options of the roll command.
+
+        """;
+}
+
+/// <summary>Process exit codes, named so a caller is not reading bare integers.</summary>
+internal static class ExitCode
+{
+    /// <summary>The command ran. A failed or fumbled roll still exits here -- it is a result.</summary>
+    public const int Ok = 0;
+
+    /// <summary>The command line could not be understood. Nothing was rolled.</summary>
+    public const int UsageError = 2;
+}

--- a/tools/Brp.Cli/RollCommand.cs
+++ b/tools/Brp.Cli/RollCommand.cs
@@ -1,0 +1,369 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Brp.Core.Modifiers;
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+using Brp.Core.Resolution;
+
+namespace Brp.Cli;
+
+/// <summary>
+/// The <c>roll</c> command: resolve one skill or action roll and print its whole derivation.
+/// <para>
+/// The command line is parsed by hand rather than by a parser library. The output of this tool
+/// is its contract -- it is meant to be pasted into an Issue and diffed -- so the fewer moving
+/// parts between the arguments and the rendering, the better, and a parser package would bring
+/// its own error text and its own help layout into that contract.
+/// </para>
+/// </summary>
+internal static class RollCommand
+{
+    private static readonly HashSet<string> KnownOptions =
+        ["--skill", "--base-chance", "--seed", "--difficulty", "--modifier", "--permanent-modifier"];
+
+    internal static int Run(IReadOnlyList<string> args, TextWriter output, TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        if (args.Any(Program.IsHelpFlag))
+        {
+            output.Write(Usage);
+            return ExitCode.Ok;
+        }
+
+        if (!TryParse(args, out var options, out var message))
+        {
+            error.Write($"brp roll: {message}\n\n");
+            error.Write(Usage);
+            return ExitCode.UsageError;
+        }
+
+        var chain = ModifierPipeline.Evaluate(options.Skill, options.Modifiers);
+
+        // One generator, seeded from the command line and drawn from exactly once. ADR 0003
+        // makes the save-scumming policy a configuration choice the game has yet to pick, so
+        // this is not a claim about how a scene is seeded -- only that the same seed and the
+        // same call sequence produce the same roll, which is the invariant the ADR does settle.
+        var entropy = new Xoshiro256StarStar(options.Seed);
+
+        // A gate short-circuits the chain and consumes no entropy, and no option on this command
+        // produces a GateModifier. Stated as a throw rather than a null-forgiving operator so
+        // that adding such an option later fails loudly instead of rendering a blank report.
+        if (chain.IsGated)
+        {
+            throw new InvalidOperationException(
+                "The chain was gated, but the roll command exposes no gate modifiers.");
+        }
+
+        // Resolved through SkillResolver rather than ModifierChain.Resolve because the chain
+        // passes the rating it started from as the resolver's base chance, and those are two
+        // different numbers: the chain starts from the character's rating, while the 5% floor
+        // keys on the skill's printed base chance (Ch 5: System, "Skill Rolls"). They coincide
+        // only when the caller does not distinguish them, which is what --base-chance is for.
+        var outcome = SkillResolver.Resolve(options.BaseChance, chain.EffectiveChance!.Value, entropy);
+
+        output.Write(RollReport.Render(options.Seed, chain, outcome));
+        return ExitCode.Ok;
+    }
+
+    private static bool TryParse(
+        IReadOnlyList<string> args,
+        [NotNullWhen(true)] out RollOptions? options,
+        [NotNullWhen(false)] out string? error)
+    {
+        options = null;
+        error = null;
+
+        int? skill = null;
+        int? baseChance = null;
+        ulong? seed = null;
+        DifficultyModifier? difficulty = null;
+        var seenDifficulty = false;
+        var modifiers = new List<Modifier>();
+
+        for (var i = 0; i < args.Count; i++)
+        {
+            var (name, inlineValue) = SplitOption(args[i]);
+
+            if (!name.StartsWith("--", StringComparison.Ordinal))
+            {
+                error = $"unexpected argument '{args[i]}'.";
+                return false;
+            }
+
+            if (!KnownOptions.Contains(name))
+            {
+                // Checked before the value is consumed, so a misspelled option reports itself
+                // rather than the missing value that consuming the next argument would produce.
+                error = $"unknown option '{name}'.";
+                return false;
+            }
+
+            // A modifier's value legitimately begins with '-' ("-20 firing-into-combat"), so the
+            // next argument is taken as the value whatever it looks like. Guessing from a
+            // leading dash would reject the command line this tool exists to serve.
+            string? value = inlineValue;
+            if (value is null)
+            {
+                if (i + 1 >= args.Count)
+                {
+                    error = $"option '{name}' needs a value.";
+                    return false;
+                }
+
+                value = args[++i];
+            }
+
+            switch (name)
+            {
+                case "--skill":
+                    if (skill is not null)
+                    {
+                        error = "'--skill' was given more than once.";
+                        return false;
+                    }
+
+                    if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rating))
+                    {
+                        error = $"'--skill' expects a whole number, got '{value}'.";
+                        return false;
+                    }
+
+                    if (rating < 0)
+                    {
+                        // Percent floors at zero. Flooring silently here would print a base
+                        // rating the caller never typed, which is exactly the kind of invisible
+                        // step this command exists to prevent.
+                        error = $"'--skill' cannot be negative, got {rating}.";
+                        return false;
+                    }
+
+                    skill = rating;
+                    break;
+
+                case "--base-chance":
+                    if (baseChance is not null)
+                    {
+                        error = "'--base-chance' was given more than once.";
+                        return false;
+                    }
+
+                    if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var printed))
+                    {
+                        error = $"'--base-chance' expects a whole number, got '{value}'.";
+                        return false;
+                    }
+
+                    if (printed < 0)
+                    {
+                        error = $"'--base-chance' cannot be negative, got {printed}.";
+                        return false;
+                    }
+
+                    baseChance = printed;
+                    break;
+
+                case "--seed":
+                    if (seed is not null)
+                    {
+                        error = "'--seed' was given more than once.";
+                        return false;
+                    }
+
+                    if (!ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedSeed))
+                    {
+                        error = $"'--seed' expects a whole number from 0 to {ulong.MaxValue}, got '{value}'.";
+                        return false;
+                    }
+
+                    seed = parsedSeed;
+                    break;
+
+                case "--difficulty":
+                    if (seenDifficulty)
+                    {
+                        error = "'--difficulty' was given more than once.";
+                        return false;
+                    }
+
+                    seenDifficulty = true;
+                    switch (value.ToLowerInvariant())
+                    {
+                        case "normal":
+                            difficulty = null;
+                            break;
+                        case "easy":
+                            difficulty = DifficultyModifier.Easy("easy");
+                            break;
+                        case "difficult":
+                            difficulty = DifficultyModifier.Difficult("difficult");
+                            break;
+                        default:
+                            error = $"'--difficulty' expects easy, normal, or difficult, got '{value}'.";
+                            return false;
+                    }
+
+                    break;
+
+                case "--modifier":
+                case "--permanent-modifier":
+                    var kind = name == "--modifier" ? AdditiveKind.Situational : AdditiveKind.Permanent;
+                    if (!TryParseModifier(value, kind, out var modifier, out error))
+                    {
+                        return false;
+                    }
+
+                    modifiers.Add(modifier);
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"'{name}' is listed in {nameof(KnownOptions)} but not handled.");
+            }
+        }
+
+        if (skill is null)
+        {
+            error = "'--skill' is required.";
+            return false;
+        }
+
+        if (seed is null)
+        {
+            // No default seed, and no clock-derived one. Every roll in this engine is seeded
+            // (AGENTS.md invariant 5); a tool that quietly invented a seed would be the one
+            // place in the system where a result could not be reproduced from what was typed.
+            error = "'--seed' is required — pick any number, and the same one always rolls the same result.";
+            return false;
+        }
+
+        if (difficulty is not null)
+        {
+            modifiers.Add(difficulty);
+        }
+
+        options = new RollOptions
+        {
+            Skill = Percent.Of(skill.Value),
+
+            // Defaulting the printed base chance to the character's rating is right whenever the
+            // skill's printed base is 5% or higher, because the floor rule only asks which side
+            // of 5% that base falls on. It is wrong for the handful of in-scope skills printed
+            // at 01% -- Science, Strategy, Martial Arts -- where a trained character's rating is
+            // above the floor and the skill's base chance is not. Hence the option.
+            BaseChance = Percent.Of(baseChance ?? skill.Value),
+            Seed = seed.Value,
+            Modifiers = modifiers,
+        };
+        return true;
+    }
+
+    /// <summary>
+    /// Splits <c>--name=value</c> into its parts. Returns a null value for the <c>--name value</c>
+    /// form, which the caller then reads from the next argument.
+    /// </summary>
+    private static (string Name, string? Value) SplitOption(string argument)
+    {
+        var equals = argument.IndexOf('=', StringComparison.Ordinal);
+        return equals < 0
+            ? (argument, null)
+            : (argument[..equals], argument[(equals + 1)..]);
+    }
+
+    private static bool TryParseModifier(
+        string raw,
+        AdditiveKind kind,
+        [NotNullWhen(true)] out AdditiveModifier? modifier,
+        [NotNullWhen(false)] out string? error)
+    {
+        modifier = null;
+        error = null;
+
+        var parts = raw.Trim().Split((char[]?)null, 2, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            error = "a modifier cannot be empty; expected \"<+/-n> <source label>\".";
+            return false;
+        }
+
+        var deltaText = parts[0].TrimEnd('%');
+        if (!int.TryParse(deltaText, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var delta))
+        {
+            error = $"'{parts[0]}' is not a percentage adjustment; expected \"<+/-n> <source label>\".";
+            return false;
+        }
+
+        var label = parts.Length > 1 ? parts[1].Trim() : string.Empty;
+        if (label.Length == 0)
+        {
+            // Every modifier carries a source label because that is the whole point of the
+            // command: an anonymous number in the chain cannot be traced back to the table it
+            // came from.
+            error = $"the modifier '{raw.Trim()}' needs a source label, e.g. \"-20 firing-into-combat\".";
+            return false;
+        }
+
+        modifier = new AdditiveModifier(label, delta, kind);
+        return true;
+    }
+
+    internal const string Usage =
+        """
+        brp roll — resolve one skill or action roll, showing every step.
+
+        usage:
+          brp roll --skill <n> --seed <n> [options]
+
+        required:
+          --skill <n>            The character's rating in the skill, as a
+                                 percentage.
+          --seed <n>             Any whole number. The same seed always produces
+                                 the same roll, so a result can be reproduced
+                                 from the command line that made it.
+
+        options:
+          --base-chance <n>      The skill's printed base chance — what an
+                                 untrained character rolls against. Only the
+                                 5% floor reads it. Defaults to --skill, which
+                                 is right for every skill printed at 5% or
+                                 above; pass it for the ones printed at 01%,
+                                 such as Science, Strategy, or Martial Arts.
+          --difficulty <grade>   easy, normal, or difficult. Default: normal.
+                                 Doubles the rating or halves it, rounding up.
+          --modifier "<n> <label>"
+                                 A flat adjustment describing the moment, e.g.
+                                 "-20 firing-into-combat". Applied after the
+                                 difficulty grade, so its stated weight is not
+                                 itself doubled or halved. Repeatable.
+          --permanent-modifier "<n> <label>"
+                                 A flat adjustment that is part of the rating
+                                 itself, e.g. "+10 specialist-training". Applied
+                                 before the difficulty grade. Repeatable.
+          --help                 This text.
+
+        example:
+          brp roll --skill 65 --difficulty difficult \
+                   --modifier "-20 firing-into-combat" --seed 42
+
+        """;
+}
+
+/// <summary>A parsed, validated <c>roll</c> command line.</summary>
+internal sealed class RollOptions
+{
+    /// <summary>The character's rating in the skill. The modifier chain starts from this.</summary>
+    public required Percent Skill { get; init; }
+
+    /// <summary>
+    /// The skill's printed base chance -- what an untrained character rolls against. Read by
+    /// nothing except the 5% floor (Ch 5: System, "Skill Rolls"). Defaults to <see cref="Skill"/>.
+    /// </summary>
+    public required Percent BaseChance { get; init; }
+
+    /// <summary>The seed for the single draw this command makes.</summary>
+    public required ulong Seed { get; init; }
+
+    /// <summary>Every modifier named on the command line, in the order given.</summary>
+    public required IReadOnlyList<Modifier> Modifiers { get; init; }
+}

--- a/tools/Brp.Cli/RollReport.cs
+++ b/tools/Brp.Cli/RollReport.cs
@@ -1,0 +1,160 @@
+using System.Globalization;
+using System.Text;
+using Brp.Core.Modifiers;
+using Brp.Core.Resolution;
+
+namespace Brp.Cli;
+
+/// <summary>
+/// Renders a resolved roll as text. A pure function of its inputs -- no console, no clock, no
+/// culture -- so the rendering a test asserts on is byte-for-byte the rendering a gamemaster sees.
+/// <para>
+/// Line endings are written as <c>\n</c> explicitly rather than through
+/// <see cref="Environment.NewLine"/>: the output is meant to be pasted into an Issue and
+/// diffed, and a report that changes shape with the operating system is not reproducible in
+/// the sense the rest of this engine means the word.
+/// </para>
+/// </summary>
+internal static class RollReport
+{
+    /// <summary>Column the right-aligned percentages end at. Fits an 80-column terminal with room to spare.</summary>
+    private const int Width = 56;
+
+    private const string Indent = "  ";
+
+    public static string Render(ulong seed, ModifierChain chain, RollOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(chain);
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        var report = new StringBuilder();
+        report.Append(CultureInfo.InvariantCulture, $"brp roll  (seed {seed})\n\n");
+
+        // The derivation is read straight off the chain's own contributions rather than
+        // recomputed here. Each one already carries the source label and the running chance
+        // after that step, which is precisely the provenance this command exists to print --
+        // and it means the CLI cannot drift from the pipeline that produced the number.
+        report.Append("Chance\n");
+        report.Append(Row("base rating", chain.BaseChance.ToString()));
+        foreach (var step in chain.Contributions)
+        {
+            report.Append(Row(step.Description, step.ResultingChance.ToString()));
+        }
+
+        report.Append(Row("effective chance", outcome.EffectiveChance.ToString()));
+        report.Append('\n');
+
+        // Grades come from asking the kernel to judge all 100 possible rolls, not from
+        // re-deriving thresholds out of RollOutcome. What is shown is therefore what the
+        // resolver actually applies -- including the 5% floor, which is not a threshold on the
+        // outcome at all -- so the display cannot disagree with the conformance fixtures.
+        var levels = Grade(outcome);
+        var bands = Runs(levels);
+
+        // "base chance", not "base rating": this is the skill's printed starting value, the only
+        // thing the floor rule below reads. The rating the chain started from is the Chance
+        // section's first row, and the two are not always the same number.
+        report.Append(CultureInfo.InvariantCulture,
+            $"Outcome bands  (effective {outcome.EffectiveChance}, base chance {outcome.BaseChance})\n");
+        foreach (var band in bands)
+        {
+            report.Append(Indent)
+                .Append(Range(band.Low, band.High).PadRight(8))
+                .Append(Name(band.Level))
+                .Append('\n');
+        }
+
+        // Ch 5: System, "Skill Rolls" -- a skill whose printed base chance is 5% or higher
+        // always succeeds on 01-05 however far modifiers push the effective chance down. Named
+        // only for the rolls it actually rescues: at an effective 3% that is 04-05, and saying
+        // "01-05" there would overclaim against the band list printed immediately above, where
+        // 01 is a critical and 02-03 succeed on the effective chance in the ordinary way.
+        var policy = ResolutionPolicy.Standard;
+        var rescued = Enumerable.Range(1, policy.MinimumSuccessFloorRoll)
+            .Where(roll => roll > outcome.EffectiveChance.Value && levels[roll] == SuccessLevel.Success)
+            .ToList();
+        if (rescued.Count > 0)
+        {
+            report.Append(CultureInfo.InvariantCulture,
+                $"{Indent}note: {Range(rescued[0], rescued[^1])} succeed on the base-chance floor "
+                + $"({policy.MinimumSuccessFloorChance}% or more)\n");
+        }
+
+        report.Append('\n');
+        report.Append(CultureInfo.InvariantCulture, $"Roll  {Pip(outcome.Roll)}  →  {Name(outcome.Level)}\n");
+        return report.ToString();
+    }
+
+    /// <summary>One contiguous run of rolls that all grade the same way.</summary>
+    private readonly record struct Band(int Low, int High, SuccessLevel Level);
+
+    /// <summary>Every possible roll, graded by the kernel. Indexed by the roll itself, so index 0 is unused.</summary>
+    private static SuccessLevel[] Grade(RollOutcome outcome)
+    {
+        var levels = new SuccessLevel[ResolutionPolicy.MaximumRoll + 1];
+        for (var roll = 1; roll <= ResolutionPolicy.MaximumRoll; roll++)
+        {
+            levels[roll] = SkillResolver.Resolve(outcome.BaseChance, outcome.EffectiveChance, roll).Level;
+        }
+
+        return levels;
+    }
+
+    /// <summary>Collapses the graded rolls into contiguous runs of the same grade.</summary>
+    private static List<Band> Runs(SuccessLevel[] levels)
+    {
+        var bands = new List<Band>();
+        for (var roll = 1; roll < levels.Length; roll++)
+        {
+            if (bands.Count > 0 && bands[^1].Level == levels[roll])
+            {
+                bands[^1] = bands[^1] with { High = roll };
+            }
+            else
+            {
+                bands.Add(new Band(roll, roll, levels[roll]));
+            }
+        }
+
+        return bands;
+    }
+
+    /// <summary>
+    /// A label on the left, a percentage right-aligned at <see cref="Width"/>, and always at
+    /// least one space between them however long the label runs.
+    /// </summary>
+    private static string Row(string label, string value)
+    {
+        var left = Indent + label;
+        var gap = Math.Max(1, Width - left.Length - value.Length);
+        return left + new string(' ', gap) + value + "\n";
+    }
+
+    /// <summary>
+    /// A band of rolls, collapsed to a single value when it covers only one -- the printed Skill
+    /// Results Table writes a one-roll critical as <c>01</c>, not <c>01-01</c>, and the same
+    /// reading is what keeps a one-roll fumble band from rendering as <c>100-100</c>.
+    /// </summary>
+    private static string Range(int low, int high) =>
+        low == high ? Pip(low) : $"{Pip(low)}-{Pip(high)}";
+
+    /// <summary>
+    /// A percentile result as it is written on a die face pair: two digits, except 100, which
+    /// is printed in full. The book prints that result as <c>00</c>, but this report also
+    /// prints ranges, and <c>96-00</c> reads backwards on a screen.
+    /// </summary>
+    private static string Pip(int roll) =>
+        roll == ResolutionPolicy.MaximumRoll
+            ? roll.ToString(CultureInfo.InvariantCulture)
+            : roll.ToString("00", CultureInfo.InvariantCulture);
+
+    private static string Name(SuccessLevel level) => level switch
+    {
+        SuccessLevel.Critical => "Critical success",
+        SuccessLevel.Special => "Special success",
+        SuccessLevel.Success => "Success",
+        SuccessLevel.Failure => "Failure",
+        SuccessLevel.Fumble => "Fumble",
+        _ => throw new ArgumentOutOfRangeException(nameof(level), level, "Unknown success level."),
+    };
+}


### PR DESCRIPTION
Closes #13

`tools/Brp.Cli` — the `brp` executable, one command — plus `tests/Brp.Cli.Tests`.

```
$ brp roll --skill 65 --difficulty difficult --modifier "-20 firing-into-combat" --seed 42

brp roll  (seed 42)

Chance
  base rating                                        65%
  difficult ÷2                                       33%
  firing-into-combat -20% [situational]              13%
  effective chance                                   13%

Outcome bands  (effective 13%, base chance 65%)
  01      Critical success
  02-03   Special success
  04-13   Success
  14-95   Failure
  96-100  Fumble

Roll  43  →  Failure
```

That is acceptance criterion 5 of Milestone 1 verbatim.

## Acceptance criteria

- [x] A rating with a named flat penalty and a difficulty produces output naming every step.
- [x] The same seed produces identical output across runs.
- [x] Thresholds shown match the kernel's conformance fixture for that rating.
- [x] Output is readable in a terminal without a wide window (72 columns, enforced by a test).

## Design

**The CLI computes no rules.** The derivation is read off `ModifierChain.Contributions`; the bands come from asking `SkillResolver` to grade all 100 possible rolls and collecting the runs. So the display cannot drift from the resolver — including the 5% floor, which is not a threshold on `RollOutcome` at all. Re-deriving a threshold here would be a second copy of the resolution table that no conformance fixture guards.

**`--seed` is required**, with no clock-derived default. A tool whose purpose is showing how a result was produced cannot be the one place in the engine where a result cannot be reproduced from what was typed (AGENTS.md invariant 5). ADR 0003 leaves the save-scumming policy a configuration choice, so nothing here claims to be "how a scene is seeded".

**Hand-rolled argument parsing.** The output is the contract; a parser package would bring its own error text and help layout into it.

## Two judgment calls worth review

**`--permanent-modifier` alongside `--modifier`.** The Issue says "arbitrary named modifiers", and the pipeline has two additive kinds. Without the second flag the report cannot show ADR 0007's ordering split, which is the most error-prone step in the pipeline and the thing the Issue's stated value ("makes the modifier chain visible") is about. `65 +10 permanent, Difficult, −20 situational` renders `65 → 75 → 38 → 18`, matching ADR 0007's worked example.

**`--base-chance`.** A rules defect found in review, fixed rather than deferred. Ch 5: System, "Skill Rolls" keys the 5% floor on what a skill *"normally has a base chance of"* — explicitly not on the rating that modifiers push below 5%. Several in-scope skills are printed at 01%: Science, Strategy, Martial Arts (Ch 3: Skills). A single `--skill` input bound the character's rating into the floor's base-chance slot, so Science (Forensics) at 40% rolled Difficult without lab access showed rolls 03–05 as successes and attributed them to a rule that does not cover that skill. `--base-chance` defaults to `--skill`, which is correct for every skill printed at 5% or above; the option makes the other case expressible. It is a second numeric input the Issue did not ask for — flagging it as scope worth a second opinion, though shipping a provenance tool that prints a wrong band seemed worse.

## Verification

- 44 new tests; 930 total, all green. `dotnet format --verify-no-changes` clean.
- Acceptance output pinned as an exact string.
- Rendered bands checked against the kernel's thresholds at every rating from 1 to 120, and against the printed Skill Results Table row `11-15` transcribed from the book for the demo rating.
- scope-warden: pass, no findings.
- rules-conformance: bands CONFIRMED against all 24 printed rows and a 1,048-invocation sweep; the four defects it raised are all fixed here (base-chance binding, an ADR 0003 misattribution, help text describing unreachable behaviour, and a floor footnote that overclaimed against the band list above it). Every citation in the new files was re-checked against the PDF directly.
- New `tools/Brp.Cli/AGENTS.md`; `AGENTS.md` state-of-code and README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)