### PR TITLE
Retire decisions that were still listed as open

### DIFF
--- a/engine-implementation-plan.md
+++ b/engine-implementation-plan.md
@@ -250,14 +250,23 @@ tools/
 
 **The live queue is GitHub Issues, not this list.** These are summarised for context only; each has an Issue, and the Issue is authoritative if they diverge.
 
-Already resolved: the source-text question and the Prohibited Content constraint (ADR 0001), the sub-5% ambiguity (§2.4), and — locked in framework v0.2, not open — the roll-integrity model (**pre-seeded at scene entry**) and advancement (**tick-on-use**).
+Already resolved: the source-text question and the Prohibited Content constraint (ADR 0001), the sub-5% ambiguity (§2.4), and advancement (**tick-on-use**, locked in framework v0.2).
 
-Still open:
+**Five of the seven questions this section originally posed have since been decided**, in most cases by a document that outranks this one. They are recorded below with what decided them; read the record rather than this summary, which is the shorter and the more likely to rot.
 
-1. **Skill Category Bonuses vs. Simpler Skill Bonuses** — mutually exclusive by the book's own statement, and this is the highest-priority call. It changes how *every* skill's effective rating is computed, so it must be settled before Layer 2 is written.
-2. **Difficulty stacking** — do two Difficult conditions compound, or floor at one step?
-3. **Modifier ordering** — confirm `Gate → Override → Additive → Multiplicative → Clamp`.
-4. **Hit locations on or off** — the framework's persistent visible injuries argue for on; it meaningfully enlarges Layer 4. Decide before combat is written.
-5. **Fate Points** — attractive for a video game, but built on the power-point economy the scope filter deletes. Needs re-basing on another currency or dropping.
-6. **Acting Without Skill** — interacts directly with the framework's clue rule; the book warns it can strain plausibility.
-7. ~~Roll-determinism policy~~ — **decided**: pre-seeded at scene entry (framework v0.2). The engine must implement this; it is no longer a question. ADR 0003's architecture supports it directly.
+| Question | Decision | Decided by | Issue |
+|---|---|---|---|
+| Skill Category Bonuses vs. Simpler Skill Bonuses | Full **Skill Category Bonuses**, applied by subtraction so that authored ratings stay final | `docs/decisions/0006-skill-bonus-system.md` | #1, closed |
+| Difficulty stacking | **Does not stack** — any number of Difficult sources produce one halving, and Easy and Difficult cancel. A house rule, marked as one in the record | `docs/decisions/0007-modifier-pipeline.md` | #2, closed |
+| Modifier ordering | `Gate → Override → PermanentAdditive → Multiplicative → SituationalAdditive → Clamp` — **not** the scheme guessed above; the book puts two additive stages either side of the multiplicative one | `docs/decisions/0007-modifier-pipeline.md` | #3, closed |
+| Hit locations on or off | **On**, with armor by hit location and Major Wounds. Total Hit Points is off, which is consistent with per-location HP | `orc-scope-filter.md`, "Optional rules — the toggle list" → *ON for NoiRPG* | #4, closed |
+| Roll-determinism policy | **Pre-seeded at scene entry** — reloading replays the same result | `noir-rpg-framework.md` v0.2, restated under *Locked decisions* in `AGENTS.md`; the engine mechanism that makes it implementable is `docs/decisions/0003-deterministic-rolls.md` | #7, closed |
+
+The hit-location row is worth dwelling on, because it was never this document's call to make. `orc-scope-filter.md` is binding (AGENTS.md invariant 3) and had already answered it. Listing it here as open was the defect, not the question — the same failure mode the banner at the top of this file describes.
+
+Still open — two, both of them genuine:
+
+1. **Fate Points** (#5) — attractive for a video game, but built on the power-point economy the scope filter deletes. Needs re-basing on another currency or dropping. The scope filter carries it as *defer; don't cut on principle*.
+2. **Acting Without Skill** (#6) — interacts directly with the framework's clue rule; the book warns it can strain plausibility.
+
+Both also sit under "Undecided — needs a call" in `orc-scope-filter.md`, and neither has an ADR.

--- a/orc-scope-filter.md
+++ b/orc-scope-filter.md
@@ -162,8 +162,10 @@ The book ships a checklist of every optional rule. This is architecturally impor
 ### OFF
 Nonhuman Characters, Higher Starting Characteristics, Cultural Modifiers, Projection, Allegiance (gods actively intervening — no), Fatigue Points *(defer — could serve noir exhaustion, but adds a tracked resource)*, Encumbrance, Miniatures/Maps/VTT, Dodging Missile Weapons, Attacks and Parries over 100%, Dying Blows *(defer — arguably good for a lethal noir climax)*, Aging and Inaction, Total Hit Points, Initiative Rolls.
 
+### Decided since
+- **Skill Category Bonuses vs. Simpler Skill Bonuses** — **decided: full Skill Category Bonuses**, applied by subtraction. See `docs/decisions/0006-skill-bonus-system.md` (Issue #1). The two are mutually exclusive by the book's own statement, and this changes how every skill's effective rating is computed, so it had to land before Layer 2 — it has.
+
 ### Undecided — needs a call
-- **Skill Category Bonuses vs. Simpler Skill Bonuses** — mutually exclusive; the book says so explicitly. Category bonuses add characteristic-derived modifiers per skill category. Pick one before Layer 2 is written, because it changes how a skill's effective rating is computed for every skill in the game.
 - **Fate Points** — needs re-basing off power points (see Ch 4 cut).
 - **Acting Without Skill** — a minor chance at untrained skills. Interacts directly with the framework's clue rule; the book warns it can break plausibility.
 


### PR DESCRIPTION
Handoff defect, found while checking whether a fresh agent could pick this repo up. It could not, cleanly: two planning documents still posed questions that had already been answered, one of them the binding one.

## What was stale

`engine-implementation-plan.md` §6 listed all seven of its original questions as open. Five were decided:

| Question | Decided by |
|---|---|
| Skill Category Bonuses vs. Simpler | ADR 0006 |
| Difficulty stacking | ADR 0007 |
| Modifier ordering | ADR 0007 |
| Hit locations on or off | `orc-scope-filter.md` (binding) |
| Roll-determinism policy | framework v0.2, restated in AGENTS.md |

Only Fate Points (#5) and Acting Without Skill (#6) are genuinely open. Both confirmed against the ADRs, the scope filter, and the Issue list rather than assumed.

## Two worth naming

**Hit locations were never the plan's call.** `orc-scope-filter.md` had already put Damage and Hit Locations, Armor by Hit Locations, and Major Wounds under *ON for NoiRPG* — with Total Hit Points off, consistent with per-location HP. It is binding per invariant 3 and outranks the plan. #4 asked a question the higher-authority document had answered, and is closed. This also unblocks the combat layer, which is what #21 waits on.

**The plan's modifier ordering was wrong, not merely unconfirmed.** §6 asked to "confirm `Gate → Override → Additive → Multiplicative → Clamp`". ADR 0007 found the book puts two additive stages either side of the multiplicative one — `Gate → Override → PermanentAdditive → Multiplicative → SituationalAdditive → Clamp`. That is a fourth instance of the failure mode the plan's own banner describes, so it is recorded in the table rather than left as an open question with a false premise.

## The one that mattered most

`orc-scope-filter.md` had gone stale the same way, which is worse because agents are told it is binding. It still listed **Skill Category Bonuses** under *Undecided — needs a call*, with an instruction to settle it before Layer 2 — after ADR 0006 settled it. An agent picking up Layer 2 would have stopped to make a decision that was already made. That entry now records the decision and points at the ADR; Fate Points and Acting Without Skill remain listed as undecided, because they are.

## Verification

Docs only — no code touched, so `dotnet build` / `test` / `format` are unaffected (all green on `main` at 930 tests). Every status was verified against the ADR that claims it, the Issue state, and the binding document, rather than against the summary being corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)