### PR TITLE
Layer 1 — abilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,13 +83,15 @@ If you discover unrelated work, file a separate Issue. Do not enlarge the curren
 
 `Brp.Core` holds Layer 0, complete: seeded dice (`Dice/`, `Randomness/`), the five-grade
 resolution kernel (`Resolution/`), the modifier pipeline (`Modifiers/`), and resistance
-and opposed rolls (`Contests/`). Roughly 930 tests, most of them printed tables
+and opposed rolls (`Contests/`). Layer 1 (`Abilities/`) adds data-defined
+characteristics, characteristic rolls, and live derived values. `Brp.Data` supplies
+the ability ruleset JSON. The solution has 1,573 tests, including printed tables
 reproduced cell by cell.
 
 `tools/Brp.Cli` is the `brp` command line over that kernel — one command, `roll`, which
 resolves a check and prints its whole derivation. It has its own `AGENTS.md`.
 
-Nothing above Layer 0 exists yet. See `engine-implementation-plan.md` §3 for the layer
+Nothing above Layer 1 exists yet. See `engine-implementation-plan.md` §3 for the layer
 map — the *structure* there is sound even though its formulas are not.
 
 ## Commands

--- a/NoiRPG.slnx
+++ b/NoiRPG.slnx
@@ -1,10 +1,12 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/Brp.Core/Brp.Core.csproj" />
+    <Project Path="src/Brp.Data/Brp.Data.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Brp.Cli.Tests/Brp.Cli.Tests.csproj" />
     <Project Path="tests/Brp.Core.Tests/Brp.Core.Tests.csproj" />
+    <Project Path="tests/Brp.Data.Tests/Brp.Data.Tests.csproj" />
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/Brp.Cli/Brp.Cli.csproj" />

--- a/docs/decisions/0008-abilities.md
+++ b/docs/decisions/0008-abilities.md
@@ -1,0 +1,46 @@
+# 0008 — Layer 1 abilities
+
+Status: Accepted
+
+Issue: #29. Approved by the project owner on 2026-08-29 before implementation.
+The owner also confirmed that the Phase 1 go/no-go gate has cleared for this work.
+
+## Characteristic rolls and the skill floor
+
+**Sourced interpretation:** Ch 5: System, "Skill Rolls" (p. 128), grants the
+01–05 success floor to skills with a printed base chance of at least 5%.
+"Characteristic Rolls" (p. 129) describes a separate kind of action roll.
+We do not extend the skill-only floor to characteristic rolls.
+
+The implementation composes the modifier pipeline with `SkillResolver` directly,
+passing zero as its floor-only base-chance argument. This zero is an adapter
+sentinel, not a claim that characteristics have a printed skill base chance.
+The actual chance remains characteristic value times multiplier, modified through
+the pipeline. This follows #27's existing interim approach without resolving its
+Layer 2 API question or changing `ModifierChain.Resolve`.
+
+**Sourced:** Ch 5, "Evaluating Success or Failure" and "Failure" (p. 127),
+apply the five grades and 96+ failure rule to these action rolls. They do not
+use the resistance-roll exception.
+
+## Rules data
+
+Create `src/Brp.Data/` in this issue. Characteristic definitions, the Damage
+Modifier Table, and other shipped rules values belong in JSON rather than C#
+constants, as required by AGENTS.md invariant 7. This is an architectural choice.
+The table's source is Ch 2: Characters, "Damage Modifier (STR+SIZ, see table)"
+(p. 13), including its open-ended continuation.
+
+## Experience checks
+
+**Sourced:** Ch 5: System, "Skill Improvement" (p. 138), explicitly excludes
+characteristic rolls from the skill experience-check mechanism. Ability resolution
+does not award an experience check. Characteristic improvement has separate rules
+("Increasing Characteristics" and "POW Increases", pp. 139–140), outside #29.
+The locked tick-on-use skill rule does not extend to characteristic rolls.
+
+## Verification
+
+The cited Chapter 5 passages and Chapter 2 damage table were checked against
+`BasicRoleplaying-ORC-Content-Document.pdf` on 2026-08-29. The implementation must
+reproduce every printed damage-table row and both sides of every band edge in tests.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -30,3 +30,4 @@ supersedes it — the original is not edited or deleted.
 | [0005](0005-target-framework.md) | Target net10.0, pinned via global.json | Accepted |
 | [0006](0006-skill-bonus-system.md) | Full Skill Category Bonuses, applied by subtraction | Accepted |
 | [0007](0007-modifier-pipeline.md) | Modifier ordering, and difficulty that does not stack | Accepted |
+| [0008](0008-abilities.md) | Layer 1 abilities: floor eligibility, rules data, and experience checks | Accepted |

--- a/src/Brp.Core/Abilities/AbilityResolver.cs
+++ b/src/Brp.Core/Abilities/AbilityResolver.cs
@@ -1,0 +1,35 @@
+using Brp.Core.Modifiers;
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+using Brp.Core.Resolution;
+
+namespace Brp.Core.Abilities;
+
+/// <summary>
+/// Resolves characteristic rolls through the normal modifier and action-roll paths. Ch 2,
+/// "Characteristic Rolls" (pp.11-12), and Ch 5, "Evaluating Success or Failure" (p.127),
+/// apply the five degrees and 96+ failure rule. Ch 5, "Skill Rolls" (p.128) limits the 01-05
+/// floor to skills, so this adapter passes the documented zero floor-only sentinel to
+/// <see cref="SkillResolver"/> (ADR 0008).
+/// </summary>
+public static class AbilityResolver
+{
+    /// <summary>Resolves a characteristic roll, or null when a gate makes the action impossible.</summary>
+    public static RollOutcome? Resolve(
+        AbilitySet abilities,
+        CharacteristicRoll roll,
+        IEnumerable<Modifier> modifiers,
+        IEntropySource entropy,
+        ResolutionPolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        ArgumentNullException.ThrowIfNull(modifiers);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var baseChance = roll.ChanceFor(abilities.ValueOf(roll.Characteristic));
+        var chain = ModifierPipeline.Evaluate(baseChance, modifiers);
+        return chain.IsGated
+            ? null
+            : SkillResolver.Resolve(Percent.Zero, chain.EffectiveChance!.Value, entropy, policy);
+    }
+}

--- a/src/Brp.Core/Abilities/AbilityRuleset.cs
+++ b/src/Brp.Core/Abilities/AbilityRuleset.cs
@@ -1,0 +1,93 @@
+namespace Brp.Core.Abilities;
+
+/// <summary>
+/// Ruleset data consumed by <see cref="AbilitySet"/>. All book values are supplied by a data
+/// project, per AGENTS.md; Ch 2: Characters supplies the characteristic definitions, damage
+/// modifier table, and MOV starting value (pp.10-15).
+/// </summary>
+public sealed class AbilityRuleset
+{
+    private readonly Dictionary<CharacteristicId, CharacteristicDefinition> _characteristics;
+
+    /// <summary>Creates an ability ruleset from data-defined values.</summary>
+    public AbilityRuleset(
+        IEnumerable<CharacteristicDefinition> characteristics,
+        DamageModifierTable damageModifierTable,
+        int startingMovement,
+        int minimumCharacteristicRollMultiplier,
+        int maximumCharacteristicRollMultiplier,
+        int standardCharacteristicRollMultiplier,
+        int hitPointDivisor,
+        int majorWoundDivisor,
+        int experienceBonusDivisor)
+    {
+        ArgumentNullException.ThrowIfNull(characteristics);
+        ArgumentNullException.ThrowIfNull(damageModifierTable);
+        _characteristics = characteristics.ToDictionary(c => c.Id);
+        if (_characteristics.Count == 0)
+        {
+            throw new ArgumentException("At least one characteristic definition is required.", nameof(characteristics));
+        }
+
+        DamageModifierTable = damageModifierTable;
+        StartingMovement = startingMovement;
+        MinimumCharacteristicRollMultiplier = minimumCharacteristicRollMultiplier;
+        MaximumCharacteristicRollMultiplier = maximumCharacteristicRollMultiplier;
+        StandardCharacteristicRollMultiplier = standardCharacteristicRollMultiplier;
+        HitPointDivisor = hitPointDivisor;
+        MajorWoundDivisor = majorWoundDivisor;
+        ExperienceBonusDivisor = experienceBonusDivisor;
+    }
+
+    /// <summary>The loaded characteristic definitions.</summary>
+    public IReadOnlyDictionary<CharacteristicId, CharacteristicDefinition> Characteristics => _characteristics;
+
+    /// <summary>Ch 2's data-backed damage modifier table.</summary>
+    public DamageModifierTable DamageModifierTable { get; }
+
+    /// <summary>Ch 2: Characters, "Movement (MOV)" (p.15) flat human starting value.</summary>
+    public int StartingMovement { get; }
+
+    /// <summary>Ch 2 p.12's lowest supported characteristic-roll multiplier.</summary>
+    public int MinimumCharacteristicRollMultiplier { get; }
+
+    /// <summary>Ch 5, "Difficulty Modifiers" (p.132)'s Easy x10 ceiling.</summary>
+    public int MaximumCharacteristicRollMultiplier { get; }
+
+    /// <summary>Ch 2 p.12's standard characteristic-roll multiplier.</summary>
+    public int StandardCharacteristicRollMultiplier { get; }
+
+    /// <summary>Ch 2 p.14 divisor for maximum hit points.</summary>
+    public int HitPointDivisor { get; }
+
+    /// <summary>Ch 2 p.14 divisor for major wounds.</summary>
+    public int MajorWoundDivisor { get; }
+
+    /// <summary>Ch 2 p.13 divisor for experience bonus.</summary>
+    public int ExperienceBonusDivisor { get; }
+
+    /// <summary>Creates a supported roll for a characteristic defined by this ruleset.</summary>
+    public CharacteristicRoll CharacteristicRoll(CharacteristicId characteristic, int multiplier)
+    {
+        if (!Characteristics.TryGetValue(characteristic, out var definition))
+        {
+            throw new KeyNotFoundException($"Unknown characteristic '{characteristic}'.");
+        }
+
+        if (!definition.HasCharacteristicRoll)
+        {
+            throw new InvalidOperationException($"{definition.DisplayName} has no associated characteristic roll.");
+        }
+
+        if (multiplier < MinimumCharacteristicRollMultiplier || multiplier > MaximumCharacteristicRollMultiplier)
+        {
+            throw new ArgumentOutOfRangeException(nameof(multiplier));
+        }
+
+        return new CharacteristicRoll(characteristic, multiplier);
+    }
+
+    /// <summary>Creates Ch 2 pp.11-12's named standard x5 characteristic roll.</summary>
+    public CharacteristicRoll StandardCharacteristicRoll(CharacteristicId characteristic) =>
+        CharacteristicRoll(characteristic, StandardCharacteristicRollMultiplier);
+}

--- a/src/Brp.Core/Abilities/AbilitySet.cs
+++ b/src/Brp.Core/Abilities/AbilitySet.cs
@@ -1,0 +1,106 @@
+using Brp.Core.Dice;
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Abilities;
+
+/// <summary>
+/// Mutable characteristic values and their live derived attributes. Ch 2: Characters,
+/// "Derived Characteristics" (p.13) requires each derived attribute to change immediately
+/// after a characteristic changes, so values here are calculated on read rather than cached.
+/// </summary>
+public sealed class AbilitySet
+{
+    private readonly Dictionary<CharacteristicId, int> _values;
+    private readonly CharacteristicId _constitution;
+    private readonly CharacteristicId _size;
+    private readonly CharacteristicId _intelligence;
+    private readonly CharacteristicId _strength;
+    private int _currentHitPoints;
+
+    /// <summary>Creates a complete characteristic set using its ruleset definitions.</summary>
+    public AbilitySet(AbilityRuleset ruleset, IReadOnlyDictionary<CharacteristicId, int> values)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(values);
+        Ruleset = ruleset;
+        _values = values.ToDictionary(pair => pair.Key, pair => pair.Value);
+
+        if (!_values.Keys.OrderBy(id => id.Value).SequenceEqual(ruleset.Characteristics.Keys.OrderBy(id => id.Value)))
+        {
+            throw new ArgumentException("Values must contain exactly the characteristics defined by the ruleset.", nameof(values));
+        }
+
+        foreach (var (id, value) in _values)
+        {
+            Validate(id, value);
+        }
+
+        _constitution = RequiredId("CON");
+        _size = RequiredId("SIZ");
+        _intelligence = RequiredId("INT");
+        _strength = RequiredId("STR");
+        _currentHitPoints = MaximumHitPoints;
+    }
+
+    /// <summary>The ruleset that defines these abilities.</summary>
+    public AbilityRuleset Ruleset { get; }
+
+    /// <summary>Ch 2: Characters, "Hit Points" (p.14), rounded up.</summary>
+    public int MaximumHitPoints => Rounding.Divide(
+        ValueOf(_constitution) + ValueOf(_size), Ruleset.HitPointDivisor, RoundingMode.Up);
+
+    /// <summary>Ch 2: Characters, "Major Wounds" (p.14), rounded up from current maximum HP.</summary>
+    public int MajorWoundLevel => Rounding.Divide(MaximumHitPoints, Ruleset.MajorWoundDivisor, RoundingMode.Up);
+
+    /// <summary>Ch 2: Characters, "Experience Bonus" (p.13), rounded up from INT.</summary>
+    public int ExperienceBonus => Rounding.Divide(ValueOf(_intelligence), Ruleset.ExperienceBonusDivisor, RoundingMode.Up);
+
+    /// <summary>Ch 2: Characters, "Damage Modifier Table" (p.13), including negative dice.</summary>
+    public DiceExpression? DamageModifier => Ruleset.DamageModifierTable.ForTotal(ValueOf(_strength) + ValueOf(_size));
+
+    /// <summary>Current HP. It may be negative; Ch 2 p.14 permits damage below zero.</summary>
+    public int CurrentHitPoints => _currentHitPoints;
+
+    /// <summary>Ch 2: Characters, "Movement (MOV)" (p.15), a flat value and not a formula.</summary>
+    public int Movement => Ruleset.StartingMovement;
+
+    /// <summary>Reads a characteristic's current value.</summary>
+    public int ValueOf(CharacteristicId characteristic) => _values.TryGetValue(characteristic, out var value)
+        ? value
+        : throw new KeyNotFoundException($"Unknown characteristic '{characteristic}'.");
+
+    /// <summary>
+    /// Changes one characteristic and immediately enforces Ch 2 p.13's reduced maximum-HP cap.
+    /// The cap is applied at mutation time so a later restoration cannot resurrect clamped HP.
+    /// </summary>
+    public void Set(CharacteristicId characteristic, int value)
+    {
+        Validate(characteristic, value);
+        _values[characteristic] = value;
+        _currentHitPoints = Math.Min(_currentHitPoints, MaximumHitPoints);
+    }
+
+    /// <summary>Sets current HP without adding a zero floor absent from Ch 2's damage rules.</summary>
+    public void SetCurrentHitPoints(int value) => _currentHitPoints = Math.Min(value, MaximumHitPoints);
+
+    private CharacteristicId RequiredId(string value)
+    {
+        var id = new CharacteristicId(value);
+        return Ruleset.Characteristics.ContainsKey(id)
+            ? id
+            : throw new ArgumentException($"Ruleset must define {value}.");
+    }
+
+    private void Validate(CharacteristicId id, int value)
+    {
+        if (!Ruleset.Characteristics.TryGetValue(id, out var definition))
+        {
+            throw new KeyNotFoundException($"Unknown characteristic '{id}'.");
+        }
+
+        if (value < definition.Minimum || (definition.Maximum is int maximum && value > maximum))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), value, $"{definition.DisplayName} must be within its ruleset bounds.");
+        }
+    }
+}

--- a/src/Brp.Core/Abilities/CharacteristicDefinition.cs
+++ b/src/Brp.Core/Abilities/CharacteristicDefinition.cs
@@ -1,0 +1,16 @@
+namespace Brp.Core.Abilities;
+
+/// <summary>
+/// A characteristic definition supplied by a ruleset. Bounds and roll names are data because
+/// Ch 2: Characters, "Characteristics" and "Characteristic Rolls" (pp.10-12) define them.
+/// </summary>
+public sealed record CharacteristicDefinition(
+    CharacteristicId Id,
+    string DisplayName,
+    int Minimum,
+    int? Maximum,
+    string? RollName)
+{
+    /// <summary>Whether Ch 2 associates a named characteristic roll with this value.</summary>
+    public bool HasCharacteristicRoll => RollName is not null;
+}

--- a/src/Brp.Core/Abilities/CharacteristicId.cs
+++ b/src/Brp.Core/Abilities/CharacteristicId.cs
@@ -1,0 +1,22 @@
+namespace Brp.Core.Abilities;
+
+/// <summary>A data-defined characteristic identifier, rather than a hardcoded enum.</summary>
+public readonly record struct CharacteristicId
+{
+    /// <summary>Creates an identifier from its ruleset id.</summary>
+    public CharacteristicId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Characteristic id must not be empty.", nameof(value));
+        }
+
+        Value = value;
+    }
+
+    /// <summary>The stable ruleset identifier.</summary>
+    public string Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}

--- a/src/Brp.Core/Abilities/CharacteristicRoll.cs
+++ b/src/Brp.Core/Abilities/CharacteristicRoll.cs
@@ -1,0 +1,27 @@
+using Brp.Core.Primitives;
+
+namespace Brp.Core.Abilities;
+
+/// <summary>
+/// A roll against one characteristic at a variable multiplier, per Ch 2: Characters,
+/// "Characteristic Rolls" (pp.11-12). Ch 7: Spot Rules, "Disease" (p.170) also varies a
+/// CON roll from x1 upward, so this type represents x1 through x10 rather than only x5.
+/// </summary>
+public readonly record struct CharacteristicRoll
+{
+    /// <summary>Creates a characteristic roll.</summary>
+    internal CharacteristicRoll(CharacteristicId characteristic, int multiplier)
+    {
+        Characteristic = characteristic;
+        Multiplier = multiplier;
+    }
+
+    /// <summary>The characteristic being tested.</summary>
+    public CharacteristicId Characteristic { get; }
+
+    /// <summary>The multiplier selected for this action.</summary>
+    public int Multiplier { get; }
+
+    /// <summary>Calculates the unmodified roll chance.</summary>
+    public Percent ChanceFor(int characteristicValue) => Percent.Of(checked(characteristicValue * Multiplier));
+}

--- a/src/Brp.Core/Abilities/DamageModifierBand.cs
+++ b/src/Brp.Core/Abilities/DamageModifierBand.cs
@@ -1,0 +1,25 @@
+using Brp.Core.Dice;
+
+namespace Brp.Core.Abilities;
+
+/// <summary>One row of Ch 2: Characters, "Damage Modifier Table" (p.13).</summary>
+public sealed record DamageModifierBand(
+    int Minimum,
+    int? Maximum,
+    DiceExpression? Modifier,
+    DamageModifierContinuation? Continuation = null)
+{
+    /// <summary>Whether this band contains a STR+SIZ total.</summary>
+    public bool Contains(int total) => total >= Minimum && (Maximum is null || total <= Maximum.Value);
+}
+
+/// <summary>Data for the open-ended "Each +16: Additional +1D6" row on Ch 2 p.13.</summary>
+public sealed record DamageModifierContinuation(int Step, int StartingDiceCount, int DiceSides, int DiceCountIncrease)
+{
+    /// <summary>Creates the expression for the given total within its owning band.</summary>
+    public DiceExpression ExpressionAt(int total, int bandMinimum)
+    {
+        var steps = (total - bandMinimum) / Step;
+        return DiceExpression.Parse($"{StartingDiceCount + (steps * DiceCountIncrease)}D{DiceSides}");
+    }
+}

--- a/src/Brp.Core/Abilities/DamageModifierTable.cs
+++ b/src/Brp.Core/Abilities/DamageModifierTable.cs
@@ -1,0 +1,35 @@
+using Brp.Core.Dice;
+
+namespace Brp.Core.Abilities;
+
+/// <summary>
+/// Data-backed lookup for Ch 2: Characters, "Damage Modifier Table" (p.13). The table's
+/// irregular lower bands and open-ended +16 continuation are represented as ruleset rows.
+/// </summary>
+public sealed class DamageModifierTable
+{
+    private readonly List<DamageModifierBand> _bands;
+
+    /// <summary>Creates a table from ordered ruleset rows.</summary>
+    public DamageModifierTable(IEnumerable<DamageModifierBand> bands)
+    {
+        ArgumentNullException.ThrowIfNull(bands);
+        _bands = bands.ToList();
+        if (_bands.Count == 0)
+        {
+            throw new ArgumentException("Damage modifier table must contain at least one band.", nameof(bands));
+        }
+    }
+
+    /// <summary>Returns the modifier for a STR+SIZ total, or null for the printed None row.</summary>
+    public DiceExpression? ForTotal(int strengthPlusSize)
+    {
+        var band = _bands.SingleOrDefault(b => b.Contains(strengthPlusSize));
+        if (band is null)
+        {
+            throw new ArgumentOutOfRangeException(nameof(strengthPlusSize));
+        }
+
+        return band.Continuation?.ExpressionAt(strengthPlusSize, band.Minimum) ?? band.Modifier;
+    }
+}

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Brp.Core\Brp.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="ability-ruleset.json" />
+  </ItemGroup>
+
+</Project>

--- a/src/Brp.Data/NoirAbilityRuleset.cs
+++ b/src/Brp.Data/NoirAbilityRuleset.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using Brp.Core.Abilities;
+using Brp.Core.Dice;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's Layer 1 rules values from embedded JSON. The source is Ch 2: Characters,
+/// "Characteristics", "Damage Modifier Table", and "Movement (MOV)" (pp.10-15).
+/// </summary>
+public static class NoirAbilityRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable ruleset view from the shipped data.</summary>
+    public static AbilityRuleset Load()
+    {
+        var assembly = typeof(NoirAbilityRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.ability-ruleset.json")
+            ?? throw new InvalidOperationException("The ability ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<AbilityRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The ability ruleset data is empty.");
+
+        var characteristics = data.Characteristics.Select(c => new CharacteristicDefinition(
+            new CharacteristicId(c.Id), c.DisplayName, c.Minimum, c.Maximum, c.RollName));
+        var bands = data.DamageModifierBands.Select(b => new DamageModifierBand(
+            b.Minimum,
+            b.Maximum,
+            b.Modifier is null ? null : DiceExpression.Parse(b.Modifier),
+            b.Continuation is null ? null : new DamageModifierContinuation(
+                b.Continuation.Step,
+                b.Continuation.StartingDiceCount,
+                b.Continuation.DiceSides,
+                b.Continuation.DiceCountIncrease)));
+        return new AbilityRuleset(
+            characteristics,
+            new DamageModifierTable(bands),
+            data.StartingMovement,
+            data.MinimumCharacteristicRollMultiplier,
+            data.MaximumCharacteristicRollMultiplier,
+            data.StandardCharacteristicRollMultiplier,
+            data.HitPointDivisor,
+            data.MajorWoundDivisor,
+            data.ExperienceBonusDivisor);
+    }
+
+    private sealed class AbilityRulesetData
+    {
+        public required List<CharacteristicData> Characteristics { get; init; }
+
+        public required List<DamageModifierBandData> DamageModifierBands { get; init; }
+
+        public required int StartingMovement { get; init; }
+
+        public required int MinimumCharacteristicRollMultiplier { get; init; }
+
+        public required int MaximumCharacteristicRollMultiplier { get; init; }
+
+        public required int StandardCharacteristicRollMultiplier { get; init; }
+
+        public required int HitPointDivisor { get; init; }
+
+        public required int MajorWoundDivisor { get; init; }
+
+        public required int ExperienceBonusDivisor { get; init; }
+    }
+
+    private sealed class CharacteristicData
+    {
+        public required string Id { get; init; }
+
+        public required string DisplayName { get; init; }
+
+        public required int Minimum { get; init; }
+
+        public int? Maximum { get; init; }
+
+        public string? RollName { get; init; }
+    }
+
+    private sealed class DamageModifierBandData
+    {
+        public required int Minimum { get; init; }
+
+        public int? Maximum { get; init; }
+
+        public string? Modifier { get; init; }
+
+        public DamageModifierContinuationData? Continuation { get; init; }
+    }
+
+    private sealed class DamageModifierContinuationData
+    {
+        public required int Step { get; init; }
+
+        public required int StartingDiceCount { get; init; }
+
+        public required int DiceSides { get; init; }
+
+        public required int DiceCountIncrease { get; init; }
+    }
+}

--- a/src/Brp.Data/ability-ruleset.json
+++ b/src/Brp.Data/ability-ruleset.json
@@ -1,0 +1,40 @@
+{
+  "characteristics": [
+    { "id": "STR", "displayName": "Strength", "minimum": 3, "maximum": 21, "rollName": "Effort" },
+    { "id": "CON", "displayName": "Constitution", "minimum": 3, "maximum": 21, "rollName": "Stamina" },
+    { "id": "SIZ", "displayName": "Size", "minimum": 8, "maximum": 21, "rollName": null },
+    { "id": "INT", "displayName": "Intelligence", "minimum": 8, "maximum": null, "rollName": "Idea" },
+    { "id": "POW", "displayName": "Power", "minimum": 3, "maximum": null, "rollName": "Luck" },
+    { "id": "DEX", "displayName": "Dexterity", "minimum": 3, "maximum": 21, "rollName": "Agility" },
+    { "id": "CHA", "displayName": "Charisma", "minimum": 3, "maximum": 21, "rollName": "Charm" },
+    { "id": "EDU", "displayName": "Education", "minimum": 3, "maximum": null, "rollName": "Know" }
+  ],
+  "damageModifierBands": [
+    { "minimum": 2, "maximum": 12, "modifier": "-1D6" },
+    { "minimum": 13, "maximum": 16, "modifier": "-1D4" },
+    { "minimum": 17, "maximum": 24, "modifier": null },
+    { "minimum": 25, "maximum": 32, "modifier": "1D4" },
+    { "minimum": 33, "maximum": 40, "modifier": "1D6" },
+    { "minimum": 41, "maximum": 56, "modifier": "2D6" },
+    { "minimum": 57, "maximum": 72, "modifier": "3D6" },
+    { "minimum": 73, "maximum": 88, "modifier": "4D6" },
+    { "minimum": 89, "maximum": 104, "modifier": "5D6" },
+    { "minimum": 105, "maximum": 120, "modifier": "6D6" },
+    { "minimum": 121, "maximum": 136, "modifier": "7D6" },
+    { "minimum": 137, "maximum": 152, "modifier": "8D6" },
+    { "minimum": 153, "maximum": 168, "modifier": "9D6" },
+    {
+      "minimum": 169,
+      "maximum": null,
+      "modifier": null,
+      "continuation": { "step": 16, "startingDiceCount": 10, "diceSides": 6, "diceCountIncrease": 1 }
+    }
+  ],
+  "startingMovement": 10,
+  "minimumCharacteristicRollMultiplier": 1,
+  "maximumCharacteristicRollMultiplier": 10,
+  "standardCharacteristicRollMultiplier": 5,
+  "hitPointDivisor": 2,
+  "majorWoundDivisor": 2,
+  "experienceBonusDivisor": 2
+}

--- a/tests/Brp.Core.Tests/Abilities/AbilityResolverTests.cs
+++ b/tests/Brp.Core.Tests/Abilities/AbilityResolverTests.cs
@@ -1,0 +1,131 @@
+using Brp.Core.Abilities;
+using Brp.Core.Modifiers;
+using Brp.Core.Resolution;
+using Brp.Core.Tests.Dice;
+using Brp.Data;
+
+namespace Brp.Core.Tests.Abilities;
+
+public class AbilityResolverTests
+{
+    [Theory]
+    [InlineData(1, SuccessLevel.Critical)]
+    [InlineData(5, SuccessLevel.Special)]
+    [InlineData(20, SuccessLevel.Success)]
+    [InlineData(90, SuccessLevel.Failure)]
+    [InlineData(100, SuccessLevel.Fumble)]
+    public void Characteristic_rolls_use_all_five_action_roll_grades(int result, SuccessLevel expected)
+    {
+        var abilities = Create(power: 10);
+        var roll = abilities.Ruleset.CharacteristicRoll(new CharacteristicId("POW"), 5);
+
+        var outcome = AbilityResolver.Resolve(abilities, roll, [], new FixedEntropySource(result));
+
+        Assert.Equal(expected, outcome?.Level);
+    }
+
+    [Fact]
+    public void Characteristic_rolls_fail_at_96_and_do_not_take_the_resistance_carve_out()
+    {
+        var abilities = Create(power: 21);
+        var roll = abilities.Ruleset.CharacteristicRoll(new CharacteristicId("POW"), 5);
+
+        var outcome = AbilityResolver.Resolve(abilities, roll, [], new FixedEntropySource(96));
+
+        Assert.Equal(SuccessLevel.Failure, outcome?.Level);
+    }
+
+    [Fact]
+    public void Difficulty_modifier_makes_easy_rolls_double_to_x10()
+    {
+        var abilities = Create(power: 10);
+        var roll = abilities.Ruleset.StandardCharacteristicRoll(new CharacteristicId("POW"));
+
+        var outcome = AbilityResolver.Resolve(
+            abilities,
+            roll,
+            [DifficultyModifier.Easy("easy")],
+            new FixedEntropySource(100));
+
+        Assert.Equal(100, outcome?.EffectiveChance.Value);
+    }
+
+    [Fact]
+    public void Difficulty_modifier_halves_difficult_characteristic_rolls_rounding_up()
+    {
+        var abilities = Create(power: 3);
+        var roll = abilities.Ruleset.CharacteristicRoll(new CharacteristicId("POW"), 1);
+
+        var outcome = AbilityResolver.Resolve(
+            abilities,
+            roll,
+            [DifficultyModifier.Difficult("difficult")],
+            new FixedEntropySource(2));
+
+        Assert.Equal(2, outcome?.EffectiveChance.Value);
+        Assert.Equal(SuccessLevel.Success, outcome?.Level);
+    }
+
+    [Fact]
+    public void Characteristic_rolls_do_not_inherit_the_skill_only_5_percent_floor()
+    {
+        // Ch 5, "Skill Rolls" (p.128) says the 01-05 floor is for skills. POW 3 x2 begins
+        // above the floor's 5% eligibility threshold, then Difficult reduces it to 3%; roll
+        // 4 must fail instead of being rescued by that skill-only floor.
+        var abilities = Create(power: 3);
+        var roll = abilities.Ruleset.CharacteristicRoll(new CharacteristicId("POW"), 2);
+
+        var outcome = AbilityResolver.Resolve(
+            abilities,
+            roll,
+            [DifficultyModifier.Difficult("difficult")],
+            new FixedEntropySource(4));
+
+        Assert.Equal(SuccessLevel.Failure, outcome?.Level);
+    }
+
+    [Theory]
+    [InlineData(1, 3)]
+    [InlineData(2, 6)]
+    [InlineData(3, 9)]
+    [InlineData(4, 12)]
+    [InlineData(5, 15)]
+    public void Disease_recovery_multipliers_are_representable_by_the_same_roll_type(int multiplier, int expectedChance)
+    {
+        var abilities = Create(constitution: 3);
+        var roll = abilities.Ruleset.CharacteristicRoll(new CharacteristicId("CON"), multiplier);
+
+        Assert.Equal(expectedChance, roll.ChanceFor(abilities.ValueOf(roll.Characteristic)).Value);
+    }
+
+    [Fact]
+    public void Standard_rolls_have_the_books_names_and_siz_has_no_roll()
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+
+        Assert.Equal("Charm", ruleset.Characteristics[new CharacteristicId("CHA")].RollName);
+        Assert.Equal(5, ruleset.StandardCharacteristicRoll(new CharacteristicId("CHA")).Multiplier);
+        Assert.Throws<InvalidOperationException>(
+            () => ruleset.StandardCharacteristicRoll(new CharacteristicId("SIZ")));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(11)]
+    public void Unsupported_characteristic_roll_multipliers_are_rejected(int multiplier)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ruleset.CharacteristicRoll(new CharacteristicId("CON"), multiplier));
+    }
+
+    private static AbilitySet Create(int constitution = 12, int power = 12)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 12);
+        values[new CharacteristicId("CON")] = constitution;
+        values[new CharacteristicId("POW")] = power;
+        return new AbilitySet(ruleset, values);
+    }
+}

--- a/tests/Brp.Core.Tests/Abilities/AbilitySetTests.cs
+++ b/tests/Brp.Core.Tests/Abilities/AbilitySetTests.cs
@@ -1,0 +1,209 @@
+using Brp.Core.Abilities;
+using Brp.Data;
+
+namespace Brp.Core.Tests.Abilities;
+
+public class AbilitySetTests
+{
+    public static IEnumerable<object[]> PlausibleConAndSize =>
+        from constitution in Enumerable.Range(3, 19)
+        from size in Enumerable.Range(8, 14)
+        select new object[] { constitution, size };
+
+    public static IEnumerable<object[]> PlausibleIntelligence =>
+        Enumerable.Range(8, 14).Select(value => new object[] { value });
+
+    [Theory]
+    [InlineData("STR", 2)]
+    [InlineData("CON", 22)]
+    [InlineData("SIZ", 7)]
+    [InlineData("INT", 7)]
+    [InlineData("DEX", 22)]
+    [InlineData("CHA", 2)]
+    public void Characteristic_bounds_are_enforced_from_the_ruleset_data(string id, int value)
+    {
+        var abilities = Create();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => abilities.Set(new CharacteristicId(id), value));
+    }
+
+    [Theory]
+    [InlineData("STR", 2)]
+    [InlineData("CON", 22)]
+    [InlineData("SIZ", 7)]
+    [InlineData("INT", 7)]
+    [InlineData("DEX", 22)]
+    [InlineData("CHA", 2)]
+    public void Initial_characteristic_values_are_checked_against_the_same_data_backed_bounds(string id, int value)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(characteristic => characteristic, _ => 12);
+        values[new CharacteristicId(id)] = value;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AbilitySet(ruleset, values));
+    }
+
+    [Theory]
+    [InlineData("INT", 500)]
+    [InlineData("POW", 500)]
+    [InlineData("EDU", 500)]
+    public void Mental_characteristics_have_no_maximum(string id, int value)
+    {
+        var abilities = Create();
+
+        abilities.Set(new CharacteristicId(id), value);
+
+        Assert.Equal(value, abilities.ValueOf(new CharacteristicId(id)));
+    }
+
+    [Theory]
+    [MemberData(nameof(PlausibleConAndSize))]
+    public void Hit_points_round_up_for_the_full_physical_characteristic_range(int constitution, int size)
+    {
+        var abilities = Create(constitution: constitution, size: size);
+
+        Assert.Equal((constitution + size + 1) / 2, abilities.MaximumHitPoints);
+    }
+
+    [Theory]
+    [MemberData(nameof(PlausibleIntelligence))]
+    public void Experience_bonus_rounds_up_for_the_full_plausible_intelligence_range(int intelligence)
+    {
+        var abilities = Create(intelligence: intelligence);
+
+        Assert.Equal((intelligence + 1) / 2, abilities.ExperienceBonus);
+    }
+
+    [Theory]
+    [MemberData(nameof(PlausibleConAndSize))]
+    public void Major_wound_level_rounds_up_for_each_hit_point_parity(int constitution, int size)
+    {
+        var abilities = Create(constitution: constitution, size: size);
+
+        Assert.Equal((abilities.MaximumHitPoints + 1) / 2, abilities.MajorWoundLevel);
+    }
+
+    [Fact]
+    public void Derived_values_update_immediately_for_the_books_poison_example()
+    {
+        var abilities = Create(constitution: 16, size: 14);
+        Assert.Equal(15, abilities.MaximumHitPoints);
+        Assert.Equal(8, abilities.MajorWoundLevel);
+
+        abilities.Set(new CharacteristicId("CON"), 10);
+
+        Assert.Equal(12, abilities.MaximumHitPoints);
+        Assert.Equal(6, abilities.MajorWoundLevel);
+    }
+
+    [Fact]
+    public void Current_hit_points_below_a_reduced_maximum_take_no_additional_damage()
+    {
+        var abilities = Create(constitution: 16, size: 14);
+        abilities.SetCurrentHitPoints(10);
+
+        abilities.Set(new CharacteristicId("CON"), 10);
+
+        Assert.Equal(10, abilities.CurrentHitPoints);
+    }
+
+    [Fact]
+    public void Current_hit_points_are_capped_on_change_and_do_not_resurrect_when_the_maximum_is_restored()
+    {
+        var abilities = Create(constitution: 16, size: 14);
+        abilities.SetCurrentHitPoints(15);
+        abilities.Set(new CharacteristicId("CON"), 10);
+        abilities.Set(new CharacteristicId("CON"), 16);
+
+        Assert.Equal(12, abilities.CurrentHitPoints);
+        Assert.Equal(15, abilities.MaximumHitPoints);
+    }
+
+    [Fact]
+    public void Current_hit_points_can_remain_negative_when_the_maximum_changes()
+    {
+        var abilities = Create(constitution: 16, size: 14);
+        abilities.SetCurrentHitPoints(-3);
+        abilities.Set(new CharacteristicId("CON"), 10);
+
+        Assert.Equal(-3, abilities.CurrentHitPoints);
+    }
+
+    [Theory]
+    [InlineData("STR", 10, "STR", 5)]
+    [InlineData("CON", 10, "CON", 5)]
+    [InlineData("INT", 10, "INT", 5)]
+    [InlineData("POW", 10, "POW", 5)]
+    [InlineData("DEX", 10, "DEX", 5)]
+    [InlineData("CHA", 10, "CHA", 5)]
+    public void Every_disease_drained_characteristic_changes_its_associated_live_roll(
+        string changedId, int changedValue, string rollId, int multiplier)
+    {
+        var abilities = Create();
+        var roll = abilities.Ruleset.CharacteristicRoll(new CharacteristicId(rollId), multiplier);
+
+        abilities.Set(new CharacteristicId(changedId), changedValue);
+
+        Assert.Equal(changedValue * multiplier, roll.ChanceFor(abilities.ValueOf(roll.Characteristic)).Value);
+    }
+
+    [Fact]
+    public void Strength_drain_updates_the_damage_modifier_at_a_table_boundary()
+    {
+        var abilities = Create(strength: 13, size: 12);
+        Assert.Equal("1D4", abilities.DamageModifier?.Notation);
+
+        abilities.Set(new CharacteristicId("STR"), 12);
+
+        Assert.Null(abilities.DamageModifier);
+    }
+
+    [Fact]
+    public void Intelligence_drain_updates_experience_bonus()
+    {
+        var abilities = Create(intelligence: 11);
+        Assert.Equal(6, abilities.ExperienceBonus);
+
+        abilities.Set(new CharacteristicId("INT"), 10);
+
+        Assert.Equal(5, abilities.ExperienceBonus);
+    }
+
+    [Theory]
+    [InlineData("POW")]
+    [InlineData("DEX")]
+    [InlineData("CHA")]
+    public void Disease_drains_without_a_chapter_2_derived_formula_leave_other_derived_values_unchanged(string id)
+    {
+        var abilities = Create();
+        var before = (abilities.MaximumHitPoints, abilities.MajorWoundLevel, abilities.ExperienceBonus, abilities.DamageModifier?.Notation);
+
+        abilities.Set(new CharacteristicId(id), 10);
+
+        Assert.Equal(before, (abilities.MaximumHitPoints, abilities.MajorWoundLevel, abilities.ExperienceBonus, abilities.DamageModifier?.Notation));
+    }
+
+    [Fact]
+    public void Movement_is_not_a_characteristic_formula()
+    {
+        var abilities = Create();
+        abilities.Set(new CharacteristicId("DEX"), 3);
+
+        Assert.Equal(10, abilities.Movement);
+    }
+
+    private static AbilitySet Create(
+        int constitution = 12,
+        int size = 12,
+        int intelligence = 12,
+        int strength = 12)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 12);
+        values[new CharacteristicId("CON")] = constitution;
+        values[new CharacteristicId("SIZ")] = size;
+        values[new CharacteristicId("INT")] = intelligence;
+        values[new CharacteristicId("STR")] = strength;
+        return new AbilitySet(ruleset, values);
+    }
+}

--- a/tests/Brp.Data.Tests/Brp.Data.Tests.csproj
+++ b/tests/Brp.Data.Tests/Brp.Data.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
@@ -19,7 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Brp.Core\Brp.Core.csproj" />
     <ProjectReference Include="..\..\src\Brp.Data\Brp.Data.csproj" />
   </ItemGroup>
 

--- a/tests/Brp.Data.Tests/NoirAbilityRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirAbilityRulesetTests.cs
@@ -1,0 +1,97 @@
+using Brp.Data;
+
+namespace Brp.Data.Tests;
+
+public class NoirAbilityRulesetTests
+{
+    public static TheoryData<int, int, string?> PrintedDamageModifierTable => new()
+    {
+        { 2, 12, "-1D6" }, { 13, 16, "-1D4" }, { 17, 24, null }, { 25, 32, "1D4" },
+        { 33, 40, "1D6" }, { 41, 56, "2D6" }, { 57, 72, "3D6" }, { 73, 88, "4D6" },
+        { 89, 104, "5D6" }, { 105, 120, "6D6" }, { 121, 136, "7D6" }, { 137, 152, "8D6" },
+        { 153, 168, "9D6" },
+    };
+
+    [Fact]
+    public void Characteristics_are_loaded_from_data_with_their_printed_bounds_and_roll_names()
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+
+        Assert.Collection(
+            ruleset.Characteristics.Values.OrderBy(c => c.Id.Value),
+            c => Assert.Equal(("CHA", "Charisma", 3, 21, "Charm"), (c.Id.Value, c.DisplayName, c.Minimum, c.Maximum, c.RollName)),
+            c => Assert.Equal(("CON", "Constitution", 3, 21, "Stamina"), (c.Id.Value, c.DisplayName, c.Minimum, c.Maximum, c.RollName)),
+            c => Assert.Equal(("DEX", "Dexterity", 3, 21, "Agility"), (c.Id.Value, c.DisplayName, c.Minimum, c.Maximum, c.RollName)),
+            c => Assert.Equal(("EDU", "Education", 3, (int?)null, "Know"), (c.Id.Value, c.DisplayName, c.Minimum, c.Maximum, c.RollName)),
+            c => Assert.Equal(("INT", "Intelligence", 8, (int?)null, "Idea"), (c.Id.Value, c.DisplayName, c.Minimum, c.Maximum, c.RollName)),
+            c => Assert.Equal(("POW", "Power", 3, (int?)null, "Luck"), (c.Id.Value, c.DisplayName, c.Minimum, c.Maximum, c.RollName)),
+            c => Assert.Equal(("SIZ", "Size", 8, 21, (string?)null), (c.Id.Value, c.DisplayName, c.Minimum, c.Maximum, c.RollName)),
+            c => Assert.Equal(("STR", "Strength", 3, 21, "Effort"), (c.Id.Value, c.DisplayName, c.Minimum, c.Maximum, c.RollName)));
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintedDamageModifierTable))]
+    public void Damage_modifier_table_reproduces_each_printed_row(int minimum, int maximum, string? expectedNotation)
+    {
+        // Ch 2: Characters, "Damage Modifier Table" (p.13). Each printed row is a test case;
+        // checking every cell in its printed interval catches middle-band holes as well as ends.
+        var table = NoirAbilityRuleset.Load().DamageModifierTable;
+
+        foreach (var total in Enumerable.Range(minimum, maximum - minimum + 1))
+        {
+            Assert.Equal(expectedNotation, table.ForTotal(total)?.Notation);
+        }
+    }
+
+    [Theory]
+    [InlineData(12, "-1D6")]
+    [InlineData(13, "-1D4")]
+    [InlineData(16, "-1D4")]
+    [InlineData(17, null)]
+    [InlineData(24, null)]
+    [InlineData(25, "1D4")]
+    [InlineData(32, "1D4")]
+    [InlineData(33, "1D6")]
+    [InlineData(40, "1D6")]
+    [InlineData(41, "2D6")]
+    [InlineData(56, "2D6")]
+    [InlineData(57, "3D6")]
+    [InlineData(72, "3D6")]
+    [InlineData(73, "4D6")]
+    [InlineData(88, "4D6")]
+    [InlineData(89, "5D6")]
+    [InlineData(104, "5D6")]
+    [InlineData(105, "6D6")]
+    [InlineData(120, "6D6")]
+    [InlineData(121, "7D6")]
+    [InlineData(136, "7D6")]
+    [InlineData(137, "8D6")]
+    [InlineData(152, "8D6")]
+    [InlineData(153, "9D6")]
+    [InlineData(168, "9D6")]
+    [InlineData(169, "10D6")]
+    public void Damage_modifier_table_asserts_both_sides_of_every_band_edge(int total, string? expectedNotation)
+    {
+        Assert.Equal(expectedNotation, NoirAbilityRuleset.Load().DamageModifierTable.ForTotal(total)?.Notation);
+    }
+
+    [Theory]
+    [InlineData(184, "10D6")]
+    [InlineData(185, "11D6")]
+    [InlineData(200, "11D6")]
+    [InlineData(201, "12D6")]
+    [InlineData(216, "12D6")]
+    [InlineData(217, "13D6")]
+    [InlineData(232, "13D6")]
+    [InlineData(233, "14D6")]
+    public void Damage_modifier_continuation_is_expressed_by_the_data_table(int total, string expectedNotation)
+    {
+        Assert.Equal(expectedNotation, NoirAbilityRuleset.Load().DamageModifierTable.ForTotal(total)?.Notation);
+    }
+
+    [Fact]
+    public void Movement_is_a_flat_data_value()
+    {
+        Assert.Equal(10, NoirAbilityRuleset.Load().StartingMovement);
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #29

## Exact behavioral claim

Layer 1 supplies data-backed characteristics, characteristic action rolls, and derived values that follow characteristic changes. Maximum-HP reductions cap current HP without dealing additional damage to an already-wounded character.

## Scope

Adds STR, CON, SIZ, INT, POW, DEX, CHA, EDU; named characteristic rolls; HP, major wound level, experience bonus, damage modifier; and flat starting MOV. Creates Brp.Data for shipped JSON rules values. Leaves skills, character creation, combat effects, and #27's Layer 2 API decision unchanged.

## Rules conformance

Source: BasicRoleplaying-ORC-Content-Document.pdf, Ch 2 Characters (Characteristics, Characteristic Rolls, Derived Characteristics, Damage Modifier Table, Movement); Ch 5 System (action-roll grades, Skill Rolls, Difficulty Modifiers, Skill Improvement); Ch 7 Disease (characteristic drains).

## Tests and evidence

- `DOTNET_ROOT=/usr/lib/dotnet dotnet build --no-restore -warnaserror`: passed, 0 warnings/errors.
- `DOTNET_ROOT=/usr/lib/dotnet dotnet test --no-build`: passed, 1,573 tests (Core 1,480; Data 49; CLI 44).
- `DOTNET_ROOT=/usr/lib/dotnet dotnet format --verify-no-changes --verbosity diagnostic`: passed, all project references/analyzers loaded, 0 of 80 files changed.
- `git diff --check`: passed.
- Scope gate: gpt-5.6-luna/low, read-only; all seven checks passed.
- Rules-conformance gate: gpt-5.6-sol/high confirmed all mechanics; two test-coverage defects found on first pass were fixed and rechecked.

The local DOTNET_ROOT inherited an older SDK path; pointing this process at the installed .NET 10 directory resolved misleading formatter reference warnings. No environment configuration files were changed.

## Decisions and tradeoffs

ADR 0008 records owner-approved decisions before implementation: no skill-only 5% floor for characteristic rolls, create Brp.Data now, and no experience checks from characteristic rolls. Owner confirmed the Phase 1 gate cleared. Ability resolution uses SkillResolver directly with explicit floor ineligibility, preserving #27's interim separation.

## Known limitations

The #27 ModifierChain convenience-method issue remains deferred to Layer 2; this new resolver must not use that path. Disease and poison procedures themselves remain outside this issue.

## Agent provenance

Implementation: gpt-5.6-terra, medium effort. Integration and source-table cross-check: gpt-5.6-sol. Scope review: gpt-5.6-luna, low effort, passed. Rules conformance: gpt-5.6-sol, high effort; confirmed after its two test-coverage findings were fixed. Both verifiers run with enforced read-only sandboxes. Models are selected explicitly at invocation, not inferred from agent TOML configuration. No agent roles or verifier write permissions changed.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see orc-scope-filter.md).
