### PR TITLE
Drop Fate Points

### DIFF
--- a/docs/decisions/0009-drop-fate-points.md
+++ b/docs/decisions/0009-drop-fate-points.md
@@ -1,0 +1,72 @@
+# 0009. Drop Fate Points
+
+## Status
+
+Accepted — 2026-08-29. Resolves #5.
+
+## Context
+
+**Sourced:** Ch 5: System, "Fate Points" (pp. 133–134) defines Fate Points as
+uses of power points: rerolling percentile rolls, substituting a Difficult Luck
+roll, ignoring damage, shifting success levels, maximizing weapon damage, and
+introducing narrative elements. Each use spends power points at a printed or
+gamemaster-determined cost.
+
+**Sourced:** Ch 2: Characters, "Power Points (Max = POW)" (p. 15) defines power
+points as a spendable resource used to cast or resist spells.
+
+**Accepted project scope:** NoiRPG cuts that resource with Chapter 4; see ADR
+0002. The printed Fate Point option therefore has no currency in this ruleset.
+
+**Project design:** NoiRPG already addresses failed checks through authored
+failure branches and the Three Doors clue-routing rule. ADR 0003 and the locked
+roll-integrity decision make scene-entry results deterministic, so reloading is
+not an alternate reroll mechanism. The tick-on-use advancement rule can record
+meaningful skill use whether the check succeeds or fails.
+
+## Decision
+
+Fate Points are OFF. NoiRPG will not implement the printed power-point option and
+will not rebase it onto Composure, POW, or a new Luck currency.
+
+This is a **house scope decision**. The source book offers Fate Points as an
+option; it does not prescribe whether a setting must use them. Dropping the option
+preserves the established role of failure branches and avoids designing a second
+resource economy before Composure exists.
+
+## Consequences
+
+**Sourced option excluded:** Ch 5, "Fate Points" (pp. 133–134) supplies the
+reroll, Luck substitution, damage avoidance, grade shifting, maximum-damage, and
+narrative uses. Because the option is OFF, none enters NoiRPG.
+
+**Project-design consequences:**
+
+- Failed rolls and adverse combat results remain binding within the established
+  deterministic roll policy.
+- Case design must continue to turn consequential failure into a changed
+  situation rather than a blocked investigation. The Three Doors rule remains
+  the protection against a single failed clue check stopping a case.
+- Severe irreversible risks should be telegraphed and offer meaningful ways to
+  prepare or choose another approach. This is a content-design consequence, not
+  a replacement metacurrency.
+- Composure remains a measure of psychological and moral deterioration. It is not
+  consumed as tactical reroll fuel.
+- Adding a player-controlled outcome currency later would require a new decision
+  that supersedes this record and specifies its economy and interaction with
+  deterministic rolls.
+
+## Alternatives considered
+
+The following are **project-design judgments**, not claims sourced from BRP.
+
+**Rebase onto Composure.** Rejected. It would encourage treating psychological
+deterioration as tactical fuel and would constrain a subsystem deliberately
+deferred until the core loop is proven.
+
+**Create a separate Luck or POW-derived pool.** Rejected. It adds a resource whose
+main purpose overlaps authored failure handling and introduces balancing and
+hoarding pressure, especially around lethal combat.
+
+**Keep the decision deferred.** Rejected. Roll determinism is settled, and the
+remaining Composure dependency is avoided by deciding not to use it as currency.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -31,3 +31,4 @@ supersedes it — the original is not edited or deleted.
 | [0006](0006-skill-bonus-system.md) | Full Skill Category Bonuses, applied by subtraction | Accepted |
 | [0007](0007-modifier-pipeline.md) | Modifier ordering, and difficulty that does not stack | Accepted |
 | [0008](0008-abilities.md) | Layer 1 abilities: floor eligibility, rules data, and experience checks | Accepted |
+| [0009](0009-drop-fate-points.md) | Drop Fate Points instead of rebasing their power-point economy | Accepted |

--- a/orc-scope-filter.md
+++ b/orc-scope-filter.md
@@ -72,7 +72,7 @@ Nothing in this chapter enters the codebase: magic, sorcery, spells, divine/rune
 - `Projection` skill.
 - "Starting Equipment with Powers" (Ch 8).
 - Power-point reservoirs in items, enchanted gear, artifacts.
-- **Fate Points** — an optional rule that lets players spend power points to adjust dice. Interesting for a video game, but it's built on the power-point economy we're deleting, so it would need re-basing on a different currency. *Defer; don't cut on principle.*
+- **Fate Points** — an optional rule that spends power points to adjust dice and narrative results. **OFF:** drop rather than rebase onto Composure or a new currency. See `docs/decisions/0009-drop-fate-points.md` (Issue #5).
 - All power-related entries in the creature statblocks.
 
 Per the user's direction: no superheroes, no cyborgs, no galactic knights, no sorcerers. This chapter is where all four live.
@@ -164,9 +164,9 @@ Nonhuman Characters, Higher Starting Characteristics, Cultural Modifiers, Projec
 
 ### Decided since
 - **Skill Category Bonuses vs. Simpler Skill Bonuses** — **decided: full Skill Category Bonuses**, applied by subtraction. See `docs/decisions/0006-skill-bonus-system.md` (Issue #1). The two are mutually exclusive by the book's own statement, and this changes how every skill's effective rating is computed, so it had to land before Layer 2 — it has.
+- **Fate Points** — **decided: OFF.** Do not rebase the power-point option onto Composure, POW, or a new Luck currency. Failure branches and the Three Doors rule carry the gameplay burden instead. See `docs/decisions/0009-drop-fate-points.md` (Issue #5).
 
 ### Undecided — needs a call
-- **Fate Points** — needs re-basing off power points (see Ch 4 cut).
 - **Acting Without Skill** — a minor chance at untrained skills. Interacts directly with the framework's clue rule; the book warns it can break plausibility.
 
 ---


### PR DESCRIPTION
## Linked Issue

Closes #5

## Exact behavioral claim

Fate Points are explicitly OFF for NoiRPG. The game will not implement the BRP option or rebase its power-point costs onto Composure, POW, or a new Luck currency.

## Scope

Adds ADR 0009 and updates the binding scope filter and ADR index. No rules code, ruleset data, Composure design, or other optional-rule decision changes.

## Rules conformance

The excluded option was verified against `BasicRoleplaying-ORC-Content-Document.pdf`, Ch 5: System, “Fate Points” (pp. 133–134), and Ch 2: Characters, “Power Points (Max = POW)” (p. 15). This PR makes a house scope decision about an optional rule; it does not implement mechanics from those sections.

## Tests and evidence

- `git diff --check`: passed.
- Luna/low read-only scope gate: passed after sourced-vs-project labels were tightened.
- No build or test run: documentation-only decision; no executable files changed.

## Decisions and tradeoffs

Failure branches, Three Doors clue routing, and deterministic scene-entry rolls remain the intended gameplay model. Composure retains its psychological/moral role instead of becoming reroll fuel.

## Known limitations

This decision does not design Composure or combat encounter balance. A later player-controlled outcome currency would require a superseding ADR.

## Agent provenance

Decision: project owner. Documentation: gpt-5.6-sol. Scope review: gpt-5.6-luna, low effort, read-only.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
