### PR TITLE
Include EDU in Mental skill bonuses

### DIFF
--- a/docs/decisions/0006-skill-bonus-system.md
+++ b/docs/decisions/0006-skill-bonus-system.md
@@ -41,12 +41,28 @@ derived:
 base = effective - category_bonus
 ```
 
-Characteristics come from the source's point-based creation at Normal power level:
-every characteristic starts at 10, 24 points to spend, DEX/INT/POW cost 3 per point,
-STR/CON/SIZ/CHA cost 1, reductions refund at the same rate.
+The seven main characteristics come from the source's point-based creation at Normal
+power level: each starts at 10, there are 24 points to spend, DEX/INT/POW cost 3 per
+point, STR/CON/SIZ/CHA cost 1, and reductions refund at the same rate. **Sourced:**
+Ch 2, “Point-Based Character Creation (Option)” (p. 10).
+
+EDU is an optional eighth characteristic, not one of the seven named by that
+24-point pool. The source says the GM assigns EDU from a character's age and
+background; a player may then modify it using pool points at 3 per EDU point.
+The audited background packages therefore record explicit neutral EDU 10 values while
+their existing seven-characteristic 24-point totals remain intact. **Sourced:** Ch 2,
+“Education (Option)” (p. 10). EDU 10 is an owner-approved audit fixture, not a
+character-creation assignment; Layer 3 will assign EDU from age and background.
+
+For the Mental category, INT is primary and POW **and EDU** are secondary. Each
+secondary contributes +1% per 2 points above 10 or −1% per 2 points below 10,
+rounding the magnitude down. **Sourced:** Ch 2, “Skill Category Bonuses (Option),”
+the “Skill Category Modifiers” and “Skill Bonus Table” (pp. 18–19).
 
 `tools/skill_bonus.py` holds the characteristic sets, the category mapping, and the
-formulas. `--check` asserts the point-buy totals are exact and that base plus bonus
+formulas. `--check` asserts the seven-characteristic point-buy totals are exact,
+reproduces all 21 numbered secondary rows through the Mental/EDU path, checks the
+table's continuation rule at EDU 22, 23, and 40, and verifies that base plus bonus
 reproduces every authored rating.
 
 ### Skill categories for the canonical 18

--- a/tools/skill_bonus.py
+++ b/tools/skill_bonus.py
@@ -25,23 +25,28 @@ from __future__ import annotations
 import argparse
 import math
 
-# --- Point-buy (source: point-based character creation, Normal power level) --------
-# Every characteristic starts at 10. 24 points to spend. DEX/INT/POW cost 3 per
-# point; STR/CON/SIZ/CHA cost 1. Reducing below 10 refunds at the same rate.
-# Range 3-21.
+# --- Point-buy (source: Ch 2, "Point-Based Character Creation (Option)", p. 10) --
+# The seven listed characteristics start at 10. 24 points to spend. DEX/INT/POW
+# cost 3 per point; STR/CON/SIZ/CHA cost 1. Reducing below 10 refunds at the same
+# rate. Range 3-21.
+#
+# EDU is not part of that seven-characteristic pool. Ch 2, "Education (Option)",
+# p. 10 says the GM assigns it from age and background; players may modify that
+# assigned value at 3 pool points per EDU point. These authored packages record only
+# their GM-assigned EDU values, so their 24-point validation deliberately excludes it.
 POINT_BUDGET = 24
 COSTS = {"STR": 1, "CON": 1, "SIZ": 1, "CHA": 1, "DEX": 3, "INT": 3, "POW": 3}
+POINT_BUY_CHARACTERISTICS = frozenset(COSTS)
 
-# --- Category formulas (source: Skill Category Modifiers) -------------------------
+# --- Category formulas (source: Ch 2, "Skill Category Bonuses (Option)", pp. 18-19)
 # primary: +/-1 per point from 10
 # secondary: +/-1 per 2 points from 10, magnitude rounded down
 # negative: inverted primary
-# EDU is not used in NoiRPG, so Mental has POW as its only secondary.
 CATEGORIES = {
     "Combat": {"primary": "DEX", "secondary": ["INT", "STR"], "negative": []},
     "Communication": {"primary": "INT", "secondary": ["POW", "CHA"], "negative": []},
     "Manipulation": {"primary": "DEX", "secondary": ["INT", "STR"], "negative": []},
-    "Mental": {"primary": "INT", "secondary": ["POW"], "negative": []},
+    "Mental": {"primary": "INT", "secondary": ["POW", "EDU"], "negative": []},
     "Perception": {"primary": "INT", "secondary": ["POW", "CON"], "negative": []},
     "Physical": {"primary": "DEX", "secondary": ["STR", "CON"], "negative": ["SIZ"]},
 }
@@ -72,14 +77,30 @@ SKILL_CATEGORY = {
 }
 
 # --- Background packages ----------------------------------------------------------
-# Each spends exactly POINT_BUDGET. Shapes chosen to match the packages' fiction:
-# the cop is a rounded generalist, the accountant trades physicality for INT/POW,
-# the soldier trades INT/CHA for DEX/STR/CON.
+# Each spends exactly POINT_BUDGET on the seven point-buy characteristics. EDU is a
+# separate GM-assigned value (Ch 2, "Education (Option)", p. 10). Until Layer 3
+# character creation assigns it from age and background, these audit fixtures use the
+# neutral value 10 so existing package bonuses and derived base ratings stay intact.
+# Shapes otherwise match the packages' fiction: the cop is a rounded generalist, the
+# accountant trades physicality for INT/POW, and the soldier trades INT/CHA for
+# DEX/STR/CON.
 CHARACTERISTICS = {
-    "ex-cop": {"STR": 12, "CON": 13, "SIZ": 12, "INT": 13, "POW": 10, "DEX": 12, "CHA": 12},
-    "ex-accountant": {"STR": 8, "CON": 12, "SIZ": 11, "INT": 15, "POW": 12, "DEX": 10, "CHA": 12},
-    "ex-soldier": {"STR": 14, "CON": 14, "SIZ": 12, "INT": 10, "POW": 11, "DEX": 14, "CHA": 9},
+    "ex-cop": {"STR": 12, "CON": 13, "SIZ": 12, "INT": 13, "POW": 10, "DEX": 12, "CHA": 12, "EDU": 10},
+    "ex-accountant": {"STR": 8, "CON": 12, "SIZ": 11, "INT": 15, "POW": 12, "DEX": 10, "CHA": 12, "EDU": 10},
+    "ex-soldier": {"STR": 14, "CON": 14, "SIZ": 12, "INT": 10, "POW": 11, "DEX": 14, "CHA": 9, "EDU": 10},
 }
+
+# Ch 2, "Skill Bonus Table", pp. 18-19. Each numbered secondary column entry is a
+# falsification row for the Mental formula below, with INT and POW held at 10.
+PRINTED_SECONDARY_BONUS_ROWS = {
+    1: -4, 2: -4, 3: -3, 4: -3, 5: -2, 6: -2, 7: -1, 8: -1, 9: 0, 10: 0,
+    11: 0, 12: 1, 13: 1, 14: 2, 15: 2, 16: 3, 17: 3, 18: 4, 19: 4, 20: 5,
+    21: 5,
+}
+
+# The table's continuation row reads "+1%/2 points" after its numbered 1-21 rows.
+# These cases pin the immediate parity boundary and a farther value beyond that range.
+SECONDARY_BONUS_CONTINUATION_CASES = {22: 6, 23: 6, 40: 15}
 
 # Authored effective ratings. Must stay in sync with BUILDS in case_validator.py.
 EFFECTIVE = {
@@ -96,7 +117,8 @@ EFFECTIVE = {
 
 
 def point_cost(chars: dict[str, int]) -> int:
-    return sum((value - 10) * COSTS[name] for name, value in chars.items())
+    """Return the seven-characteristic pool cost, excluding GM-assigned EDU."""
+    return sum((chars[name] - 10) * COSTS[name] for name in POINT_BUY_CHARACTERISTICS)
 
 
 def signed_half(delta: int) -> int:
@@ -147,6 +169,8 @@ def check() -> int:
     """Base + bonus must reproduce the authored effective ratings exactly."""
     failures = []
     for build in CHARACTERISTICS:
+        if set(CHARACTERISTICS[build]) != POINT_BUY_CHARACTERISTICS | {"EDU"}:
+            failures.append(f"{build}: must define the seven point-buy characteristics and EDU")
         cost = point_cost(CHARACTERISTICS[build])
         if cost != POINT_BUDGET:
             failures.append(f"{build}: spends {cost}, budget is {POINT_BUDGET}")
@@ -159,12 +183,22 @@ def check() -> int:
     for skill in EFFECTIVE["ex-cop"] | EFFECTIVE["ex-accountant"] | EFFECTIVE["ex-soldier"]:
         if skill not in SKILL_CATEGORY:
             failures.append(f"{skill} has no category")
+    for edu, expected in PRINTED_SECONDARY_BONUS_ROWS.items():
+        got = category_bonus({"INT": 10, "POW": 10, "EDU": edu}, "Mental")
+        if got != expected:
+            failures.append(f"Mental/EDU {edu}: {got:+d} != printed secondary bonus {expected:+d}")
+    for edu, expected in SECONDARY_BONUS_CONTINUATION_CASES.items():
+        got = category_bonus({"INT": 10, "POW": 10, "EDU": edu}, "Mental")
+        if got != expected:
+            failures.append(f"Mental/EDU {edu}: {got:+d} != continuation secondary bonus {expected:+d}")
     if failures:
         print("FAIL")
         for line in failures:
             print("  " + line)
         return 1
-    print("OK: point-buy totals correct; base + bonus reproduces every authored rating")
+    print("OK: seven-characteristic point-buy totals correct; Mental reproduces all 21 numbered EDU secondary rows")
+    print("    -> Mental also passes EDU continuation checks at 22, 23, and 40")
+    print("    -> base + bonus reproduces every authored rating")
     print("    -> door coverage in audited cases is unchanged by construction")
     return 0
 


### PR DESCRIPTION
## Linked Issue

Closes #32

## Exact behavioral claim

Mental skill category bonuses now include EDU as the second secondary characteristic. The audit pins every printed secondary row and the open continuation, while neutral EDU 10 fixtures preserve every existing package rating and case route.

## Scope

Corrects ADR 0006 and `tools/skill_bonus.py`. It does not implement Layer 2, assign differentiated EDU during character creation, reopen the full-category/subtraction decisions, or rebalance authored ratings.

## Rules conformance

Source: `BasicRoleplaying-ORC-Content-Document.pdf`, Ch 2: Characters, “Point-Based Character Creation (Option)” and “Education (Option)” (p. 10), plus “Skill Category Bonuses (Option),” the Skill Category Modifiers table, and Skill Bonus Table (pp. 18–19). Mental uses INT primary, POW and EDU secondary, no negative; secondary magnitude changes by 1% per two characteristic points.

## Tests and evidence

- `python3 tools/skill_bonus.py --check`: passed; 21/21 numbered secondary rows, continuation at EDU 22/23/40, 29/29 authored ratings.
- `python3 tools/case_validator.py`: passed; prior Three Doors coverage unchanged.
- `git diff --check`: passed.
- Luna/low read-only scope gate: passed all seven checks.
- Sol/high read-only conformance: first pass confirmed mechanics and found citation/continuation audit defects; both fixed; second pass CONFIRMED with no defects.

No .NET build was run because this narrow change touches Python audit tooling and documentation only.

## Decisions and tradeoffs

The owner approved EDU 10 for all three audit packages as a neutral fixture. Layer 3 remains responsible for assigning EDU from age and background.

## Known limitations

Differentiated background EDU and general character creation are deferred to Layer 3.

## Agent provenance

Implementation: gpt-5.6-terra, medium. Scope: gpt-5.6-luna, low, read-only. Rules conformance: gpt-5.6-sol, high, read-only.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented.
