### PR TITLE
Bind the 5% floor to the printed base, not the chain's rating (#27)

### DIFF
--- a/docs/decisions/0007-modifier-pipeline.md
+++ b/docs/decisions/0007-modifier-pipeline.md
@@ -130,5 +130,15 @@ happens to be true.
   depending on whether an impossible action was attempted.
 - The 5% floor from ADR 0006 keys on the *base* chance and survives arbitrary penalties.
   It is applied by the resolver, after this pipeline, not inside it.
+- **The chain does not own the printed base chance (#27).** `ModifierChain.BaseChance` is the
+  rating the chain started from — the character's current rating — not the skill's printed base.
+  For a trained character the two differ, and the 5% floor keys on the printed base. So
+  `ModifierChain.Resolve` takes the printed base chance as a **required argument**; it does not
+  read `BaseChance` for it. This keeps the chain arithmetic-only and makes the second number
+  impossible to forget, rather than silently conflating the two and wrongly rescuing a 01%-base
+  skill on 01–05. Where a `SkillDefinition` is in hand (Layer 2), `SkillRoll` supplies the printed
+  base from the skill's identity; the CLI passes it via `--base-chance`. **Sourced:** Ch 5: System,
+  "Skill Rolls", p.128 (the floor keys on base chance). **House shape:** making it a required
+  parameter of `Resolve` is an engineering choice, recorded here so the binding is not re-conflated.
 - The gamemaster's discretionary 1% on an Impossible action is not currently expressible,
   since gates short-circuit before overrides. Latent, not yet wrong.

--- a/src/Brp.Core/Modifiers/ModifierChain.cs
+++ b/src/Brp.Core/Modifiers/ModifierChain.cs
@@ -14,7 +14,13 @@ namespace Brp.Core.Modifiers;
 /// </summary>
 public sealed record ModifierChain
 {
-    /// <summary>The unmodified base chance the chain started from.</summary>
+    /// <summary>
+    /// The rating the chain started from -- the value handed to <see cref="ModifierPipeline"/>,
+    /// which is the character's current rating in the skill. This is <em>not</em> the skill's
+    /// printed base chance: for a trained character the two differ, and the 5% floor keys on the
+    /// printed base, not on this. Resolving a roll therefore takes the printed base as a separate
+    /// argument (see <see cref="Resolve"/>); the two must not be conflated (#27).
+    /// </summary>
     public required Percent BaseChance { get; init; }
 
     /// <summary>Non-null when a gate short-circuited the chain; no roll should be attempted.</summary>
@@ -58,13 +64,22 @@ public sealed record ModifierChain
     /// <summary>
     /// Draws a roll and resolves it via <see cref="SkillResolver"/>, or returns
     /// <see langword="null"/> without touching <paramref name="entropy"/> when
-    /// <see cref="IsGated"/> -- per ADR 0007, a gate consumes no entropy. The 5%-base-chance
-    /// floor is applied by <see cref="SkillResolver"/> itself, after this chain; it is not
-    /// duplicated here.
+    /// <see cref="IsGated"/> -- per ADR 0007, a gate consumes no entropy.
     /// </summary>
-    public RollOutcome? Resolve(IEntropySource entropy, ResolutionPolicy? policy = null)
+    /// <param name="printedBaseChance">
+    /// The skill's printed base chance -- what an untrained character rolls against. It is a
+    /// required argument, not <see cref="BaseChance"/>, because the two are different numbers: the
+    /// chain starts from the character's rating (<see cref="BaseChance"/>), while the 5%-base-chance
+    /// floor (Ch 5: System, "Skill Rolls", p.128) keys on the printed base. Passing it explicitly is
+    /// what stops a trained character in a 01%-base skill (Science, Strategy, Martial Arts) from
+    /// being wrongly rescued on 01--05 (#27). Where a <c>SkillDefinition</c> is in hand,
+    /// <c>SkillRoll</c> supplies this from the skill's identity instead.
+    /// </param>
+    /// <param name="entropy">The source the single percentile roll is drawn from, unless gated.</param>
+    /// <param name="policy">The resolution policy, or <see langword="null"/> for the default.</param>
+    public RollOutcome? Resolve(Percent printedBaseChance, IEntropySource entropy, ResolutionPolicy? policy = null)
     {
         ArgumentNullException.ThrowIfNull(entropy);
-        return IsGated ? null : SkillResolver.Resolve(BaseChance, EffectiveChance!.Value, entropy, policy);
+        return IsGated ? null : SkillResolver.Resolve(printedBaseChance, EffectiveChance!.Value, entropy, policy);
     }
 }

--- a/tests/Brp.Core.Tests/Modifiers/ModifierPipelineTests.cs
+++ b/tests/Brp.Core.Tests/Modifiers/ModifierPipelineTests.cs
@@ -269,7 +269,7 @@ public class ModifierPipelineTests
             Percent.Of(70), [new GateModifier("impassable obstacle", GateKind.Impossible)]);
         var entropy = new FixedEntropySource(50);
 
-        var outcome = chain.Resolve(entropy);
+        var outcome = chain.Resolve(Percent.Of(70), entropy);
 
         Assert.Null(outcome);
         Assert.Equal(0, entropy.DrawCount);
@@ -281,12 +281,47 @@ public class ModifierPipelineTests
         var chain = ModifierPipeline.Evaluate(Percent.Of(50), []);
         var entropy = new FixedEntropySource(20);
 
-        var outcome = chain.Resolve(entropy);
+        var outcome = chain.Resolve(Percent.Of(50), entropy);
 
         Assert.NotNull(outcome);
         Assert.Equal(20, outcome!.Roll);
         Assert.Equal(SuccessLevel.Success, outcome.Level);
         Assert.Equal(1, entropy.DrawCount);
+    }
+
+    // ---- The 5% floor keys on the passed printed base, not the chain's rating (#27) --------
+
+    // The worked example from #27: Science (Forensics) at 40%, rolled Difficult with no lab
+    // access (a -18 situational penalty). 40 halved is 20, less 18 is an effective 2%. Its
+    // printed base is 01%, below the floor, so a roll of 01-05 must NOT be rescued. Resolving
+    // the same chain against a printed base of 5% or higher WOULD be rescued on the same roll.
+    // The two assertions together prove the floor reads Resolve's printedBaseChance argument,
+    // not the chain's starting rating -- the exact conflation this method used to make.
+    [Fact]
+    public void Resolving_a_sub_5_percent_printed_base_is_not_rescued_on_01_to_05()
+    {
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(40),
+            [DifficultyModifier.Difficult("no lab access"), new AdditiveModifier("no lab access", -18)]);
+        Assert.Equal(Percent.Of(2), chain.EffectiveChance);
+
+        // Printed base 01% (Science is printed at 01%): a roll of 03, inside 01-05, still fails.
+        var unrescued = chain.Resolve(Percent.Of(1), new FixedEntropySource(3));
+        Assert.Equal(SuccessLevel.Failure, unrescued!.Level);
+    }
+
+    [Fact]
+    public void Resolving_a_5_percent_or_higher_printed_base_is_rescued_on_01_to_05()
+    {
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(40),
+            [DifficultyModifier.Difficult("no lab access"), new AdditiveModifier("no lab access", -18)]);
+        Assert.Equal(Percent.Of(2), chain.EffectiveChance);
+
+        // Same chain, same roll, but a printed base of 25% (>= the 5% floor): 03 is rescued to
+        // a Success by the floor, even though the effective chance is only 2%.
+        var rescued = chain.Resolve(Percent.Of(25), new FixedEntropySource(3));
+        Assert.Equal(SuccessLevel.Success, rescued!.Level);
     }
 
     // ---- Clamp floors at zero, but does not cap at 100 -------------------------------------
@@ -324,7 +359,7 @@ public class ModifierPipelineTests
         var chain = ModifierPipeline.Evaluate(Percent.Of(10), modifiers);
         Assert.Equal(Percent.Zero, chain.EffectiveChance);
 
-        var outcome = chain.Resolve(new FixedEntropySource(5));
+        var outcome = chain.Resolve(Percent.Of(10), new FixedEntropySource(5));
 
         Assert.NotNull(outcome);
         Assert.Equal(SuccessLevel.Success, outcome!.Level);

--- a/tools/Brp.Cli/RollCommand.cs
+++ b/tools/Brp.Cli/RollCommand.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using Brp.Core.Modifiers;
 using Brp.Core.Primitives;
 using Brp.Core.Randomness;
-using Brp.Core.Resolution;
 
 namespace Brp.Cli;
 
@@ -48,21 +47,15 @@ internal static class RollCommand
         // same call sequence produce the same roll, which is the invariant the ADR does settle.
         var entropy = new Xoshiro256StarStar(options.Seed);
 
-        // A gate short-circuits the chain and consumes no entropy, and no option on this command
-        // produces a GateModifier. Stated as a throw rather than a null-forgiving operator so
-        // that adding such an option later fails loudly instead of rendering a blank report.
-        if (chain.IsGated)
-        {
-            throw new InvalidOperationException(
+        // Resolved through ModifierChain.Resolve, passing the printed base chance explicitly:
+        // the chain starts from the character's rating, while the 5% floor keys on the skill's
+        // printed base chance (Ch 5: System, "Skill Rolls"), and those are two different numbers
+        // -- which is what --base-chance is for (#27). A gate short-circuits the chain to null
+        // without drawing; no option on this command produces a GateModifier, so a null here means
+        // an impossible state, and the throw makes it fail loudly rather than render a blank report.
+        var outcome = chain.Resolve(options.BaseChance, entropy)
+            ?? throw new InvalidOperationException(
                 "The chain was gated, but the roll command exposes no gate modifiers.");
-        }
-
-        // Resolved through SkillResolver rather than ModifierChain.Resolve because the chain
-        // passes the rating it started from as the resolver's base chance, and those are two
-        // different numbers: the chain starts from the character's rating, while the 5% floor
-        // keys on the skill's printed base chance (Ch 5: System, "Skill Rolls"). They coincide
-        // only when the caller does not distinguish them, which is what --base-chance is for.
-        var outcome = SkillResolver.Resolve(options.BaseChance, chain.EffectiveChance!.Value, entropy);
 
         output.Write(RollReport.Render(options.Seed, chain, outcome));
         return ExitCode.Ok;


### PR DESCRIPTION
## What

`ModifierChain.Resolve` conflated two different numbers: it passed the chain's **starting rating** (`BaseChance`) as `SkillResolver`'s **base-chance** argument, which the 5% floor keys on. For a trained character in a 01%-base skill (Science, Strategy, Martial Arts), that wrongly rescued rolls of 01–05 that the book leaves as failures.

## Fix

Per ADR 0007 (option 2 from the issue): `Resolve` now takes the **printed base chance as a required argument** and never reads `BaseChance` for it. The chain stays arithmetic-only, and the second number is impossible to forget. This is now unambiguous because #35 gave the printed base a real home:
- With a `SkillDefinition` in hand, `SkillRoll` (#35) supplies the printed base from the skill's identity.
- `tools/Brp.Cli` passes it via `--base-chance` and now **routes back through the fixed `Resolve`**, unwinding its workaround. CLI behaviour and tests are unchanged.

## Acceptance criteria

- [x] A skill with a printed base below 5% and a rating above it does not gain successes on 01–05, through the `ModifierChain` resolution path.
- [x] Two named pinning tests reproduce #27's worked example (Science 40% Difficult, no lab → effective 2%): a 01% printed base is **not** rescued on a roll of 03; a 25% base **is** — proving the floor reads the argument, not the chain's rating.
- [x] The chosen shape recorded in `docs/decisions/` (ADR 0007 gains the note it called for).
- [x] `tools/Brp.Cli` uses the fixed path; its tests pass unchanged.

## Verification

Full suite green (1505 core / 124 data / 44 cli); `dotnet format` clean. `rules-conformance` on the resolution path with the 01%-base case as falsification target: running as the merge gate.

Resolves #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)