### PR TITLE
brp roll: derive the printed base chance from a named skill (#38)

### DIFF
--- a/src/Brp.Core/Skills/BaseChanceExpression.cs
+++ b/src/Brp.Core/Skills/BaseChanceExpression.cs
@@ -18,4 +18,18 @@ public abstract record BaseChanceExpression
 {
     /// <summary>Evaluates this expression to a concrete base chance against a character's abilities.</summary>
     public abstract Percent Evaluate(AbilitySet abilities);
+
+    /// <summary>
+    /// Evaluates this expression when no <see cref="AbilitySet"/> is available, succeeding only
+    /// for a base chance that does not depend on one. A constant qualifies; an either/or pair
+    /// qualifies when the value it selects does. A characteristic formula and a weapon-derived
+    /// base do not -- they need data an abilities-less caller (such as <c>brp roll</c>, which has
+    /// no character sheet) cannot supply, and this returns <see langword="false"/> rather than
+    /// inventing it. The base implementation is the conservative default.
+    /// </summary>
+    public virtual bool TryEvaluateWithoutAbilities(out Percent value)
+    {
+        value = default;
+        return false;
+    }
 }

--- a/src/Brp.Core/Skills/ConstantBaseChance.cs
+++ b/src/Brp.Core/Skills/ConstantBaseChance.cs
@@ -11,4 +11,11 @@ public sealed record ConstantBaseChance(Percent Value) : BaseChanceExpression
 {
     /// <inheritdoc />
     public override Percent Evaluate(AbilitySet abilities) => Value;
+
+    /// <inheritdoc />
+    public override bool TryEvaluateWithoutAbilities(out Percent value)
+    {
+        value = Value;
+        return true;
+    }
 }

--- a/src/Brp.Core/Skills/EraConditionalBaseChance.cs
+++ b/src/Brp.Core/Skills/EraConditionalBaseChance.cs
@@ -24,4 +24,8 @@ public sealed record EraConditionalBaseChance(BaseChanceExpression Modern, BaseC
         ArgumentNullException.ThrowIfNull(abilities);
         return Modern.Evaluate(abilities);
     }
+
+    /// <inheritdoc />
+    public override bool TryEvaluateWithoutAbilities(out Percent value) =>
+        Modern.TryEvaluateWithoutAbilities(out value);
 }

--- a/tests/Brp.Cli.Tests/RollSkillNameTests.cs
+++ b/tests/Brp.Cli.Tests/RollSkillNameTests.cs
@@ -1,0 +1,116 @@
+namespace Brp.Cli.Tests;
+
+/// <summary>
+/// The <c>--skill-name</c> option (#38): the printed base chance is looked up from the shipped
+/// ruleset so the 5% floor cannot be mis-applied to a 01%-base skill just because the caller
+/// forgot <c>--base-chance</c>. The engine binding is correct as of #27; this closes the one
+/// player-facing gap that remained, at the CLI's input.
+/// </summary>
+public class RollSkillNameTests
+{
+    /// <summary>
+    /// The reason the option exists, pinned as exact output. Science (Forensics) is printed at
+    /// 01% (Ch 3: Skills, p.49). Rolled Difficult with a -18 penalty the effective chance is 2%,
+    /// and because the printed base is below 5% the floor must NOT rescue 01-05: the bands show
+    /// 03 onward as Failure and there is no floor note. The base-chance line records where the
+    /// number came from. The companion test below shows the same line, base-defaulted to the
+    /// rating, wrongly rescuing -- which is exactly what naming the skill prevents.
+    /// </summary>
+    [Fact]
+    public void A_named_sub_5_percent_skill_is_not_rescued_on_01_to_05()
+    {
+        var result = CliHarness.Run(
+            "roll", "--skill", "40", "--skill-name", "Science (Forensics)",
+            "--difficulty", "difficult", "--modifier", "-18 no-lab", "--seed", "3");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.Error);
+        Assert.Equal(
+            """
+            brp roll  (seed 3)
+
+            Chance
+              base rating                                        40%
+              difficult ÷2                                       20%
+              no-lab -18% [situational]                           2%
+              effective chance                                    2%
+
+            Outcome bands  (effective 2%, base chance 1% from "Science (Forensics)")
+              01      Critical success
+              02      Success
+              03-95   Failure
+              96-100  Fumble
+
+            Roll  09  →  Failure
+
+            """,
+            result.Output);
+    }
+
+    /// <summary>
+    /// The same command without <c>--skill-name</c> defaults the base to the rating (40%), and the
+    /// floor then wrongly rescues 03-05 -- the bug #38 lets a caller avoid by naming the skill.
+    /// Pinned so the contrast is a test, not a comment.
+    /// </summary>
+    [Fact]
+    public void Without_a_skill_name_the_base_defaults_to_the_rating_and_the_floor_rescues()
+    {
+        var result = CliHarness.Run(
+            "roll", "--skill", "40",
+            "--difficulty", "difficult", "--modifier", "-18 no-lab", "--seed", "3");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("base chance 40%)", result.Output);
+        Assert.Contains("02-05   Success", result.Output);
+        Assert.Contains("note: 03-05 succeed on the base-chance floor (5% or more)", result.Output);
+    }
+
+    [Fact]
+    public void A_named_constant_skill_resolves_its_base_and_records_the_source()
+    {
+        // Spot is printed at 25% (Ch 3, p.50). No --base-chance needed.
+        var result = CliHarness.Run("roll", "--skill", "60", "--skill-name", "Spot", "--seed", "1");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("base chance 25% from \"Spot\"", result.Output);
+    }
+
+    [Fact]
+    public void An_unknown_skill_name_is_a_usage_error()
+    {
+        var result = CliHarness.Run("roll", "--skill", "50", "--skill-name", "Nonesuch", "--seed", "1");
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.Contains("unknown skill 'Nonesuch'", result.Error);
+    }
+
+    [Fact]
+    public void A_formula_based_skill_named_without_a_base_chance_is_refused_not_guessed()
+    {
+        // Dodge is DEX×2 (Ch 3, p.37): the CLI has no characteristics, so it must refuse rather
+        // than invent a base chance.
+        var result = CliHarness.Run("roll", "--skill", "50", "--skill-name", "Dodge", "--seed", "1");
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.Contains("cannot compute on its own", result.Error);
+    }
+
+    [Fact]
+    public void A_weapon_derived_skill_named_without_a_base_chance_is_refused()
+    {
+        var result = CliHarness.Run("roll", "--skill", "50", "--skill-name", "Firearms (Handgun)", "--seed", "1");
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.Contains("cannot compute on its own", result.Error);
+    }
+
+    [Fact]
+    public void Giving_both_a_skill_name_and_a_base_chance_is_rejected()
+    {
+        var result = CliHarness.Run(
+            "roll", "--skill", "50", "--skill-name", "Spot", "--base-chance", "25", "--seed", "1");
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.Contains("not both", result.Error);
+    }
+}

--- a/tests/Brp.Core.Tests/Skills/BaseChanceExpressionTests.cs
+++ b/tests/Brp.Core.Tests/Skills/BaseChanceExpressionTests.cs
@@ -89,6 +89,49 @@ public class BaseChanceExpressionTests
         Assert.Throws<InvalidOperationException>(() => firearm.Evaluate(Create()));
     }
 
+    // ---- TryEvaluateWithoutAbilities: the abilities-less path used by brp roll (#38) --------
+
+    [Fact]
+    public void A_constant_base_chance_evaluates_without_abilities()
+    {
+        var spot = new ConstantBaseChance(Percent.Of(25));
+
+        Assert.True(spot.TryEvaluateWithoutAbilities(out var value));
+        Assert.Equal(Percent.Of(25), value);
+    }
+
+    [Fact]
+    public void An_era_conditional_over_constants_evaluates_without_abilities_to_its_modern_value()
+    {
+        // Drive: modern 20% / historical 01% (Ch 3, p.37). Both sides constant, so the modern
+        // value resolves with no character sheet -- which is what lets `brp roll --skill-name`
+        // price it.
+        var drive = new EraConditionalBaseChance(
+            new ConstantBaseChance(Percent.Of(20)), new ConstantBaseChance(Percent.Of(1)));
+
+        Assert.True(drive.TryEvaluateWithoutAbilities(out var value));
+        Assert.Equal(Percent.Of(20), value);
+    }
+
+    [Fact]
+    public void A_characteristic_formula_cannot_evaluate_without_abilities()
+    {
+        // Dodge DEX×2 (Ch 3, p.37): needs a characteristic, so an abilities-less caller must be
+        // told it cannot, not handed a wrong number.
+        var dodge = new CharacteristicFormulaBaseChance(new CharacteristicTerm(new CharacteristicId("DEX"), 2));
+
+        Assert.False(dodge.TryEvaluateWithoutAbilities(out var value));
+        Assert.Equal(Percent.Zero, value);
+    }
+
+    [Fact]
+    public void A_weapon_derived_base_chance_cannot_evaluate_without_abilities()
+    {
+        var firearm = new WeaponDerivedBaseChance();
+
+        Assert.False(firearm.TryEvaluateWithoutAbilities(out _));
+    }
+
     private static AbilitySet Create(int dexterity = 12, int intelligence = 12, int power = 12)
     {
         var ruleset = NoirAbilityRuleset.Load();

--- a/tools/Brp.Cli/Brp.Cli.csproj
+++ b/tools/Brp.Cli/Brp.Cli.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Brp.Core\Brp.Core.csproj" />
+    <ProjectReference Include="..\..\src\Brp.Data\Brp.Data.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Brp.Cli/RollCommand.cs
+++ b/tools/Brp.Cli/RollCommand.cs
@@ -3,6 +3,8 @@ using System.Globalization;
 using Brp.Core.Modifiers;
 using Brp.Core.Primitives;
 using Brp.Core.Randomness;
+using Brp.Core.Skills;
+using Brp.Data;
 
 namespace Brp.Cli;
 
@@ -18,7 +20,7 @@ namespace Brp.Cli;
 internal static class RollCommand
 {
     private static readonly HashSet<string> KnownOptions =
-        ["--skill", "--base-chance", "--seed", "--difficulty", "--modifier", "--permanent-modifier"];
+        ["--skill", "--skill-name", "--base-chance", "--seed", "--difficulty", "--modifier", "--permanent-modifier"];
 
     internal static int Run(IReadOnlyList<string> args, TextWriter output, TextWriter error)
     {
@@ -57,7 +59,7 @@ internal static class RollCommand
             ?? throw new InvalidOperationException(
                 "The chain was gated, but the roll command exposes no gate modifiers.");
 
-        output.Write(RollReport.Render(options.Seed, chain, outcome));
+        output.Write(RollReport.Render(options.Seed, chain, outcome, options.BaseChanceSkillName));
         return ExitCode.Ok;
     }
 
@@ -71,6 +73,7 @@ internal static class RollCommand
 
         int? skill = null;
         int? baseChance = null;
+        string? skillName = null;
         ulong? seed = null;
         DifficultyModifier? difficulty = null;
         var seenDifficulty = false;
@@ -158,6 +161,22 @@ internal static class RollCommand
                     baseChance = printed;
                     break;
 
+                case "--skill-name":
+                    if (skillName is not null)
+                    {
+                        error = "'--skill-name' was given more than once.";
+                        return false;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        error = "'--skill-name' needs a skill name, e.g. \"Science (Forensics)\".";
+                        return false;
+                    }
+
+                    skillName = value.Trim();
+                    break;
+
                 case "--seed":
                     if (seed is not null)
                     {
@@ -236,19 +255,82 @@ internal static class RollCommand
             modifiers.Add(difficulty);
         }
 
+        if (!TryResolveBaseChance(baseChance, skillName, skill.Value, out var resolvedBase, out var source, out error))
+        {
+            return false;
+        }
+
         options = new RollOptions
         {
             Skill = Percent.Of(skill.Value),
-
-            // Defaulting the printed base chance to the character's rating is right whenever the
-            // skill's printed base is 5% or higher, because the floor rule only asks which side
-            // of 5% that base falls on. It is wrong for the handful of in-scope skills printed
-            // at 01% -- Science, Strategy, Martial Arts -- where a trained character's rating is
-            // above the floor and the skill's base chance is not. Hence the option.
-            BaseChance = Percent.Of(baseChance ?? skill.Value),
+            BaseChance = resolvedBase,
+            BaseChanceSkillName = source,
             Seed = seed.Value,
             Modifiers = modifiers,
         };
+        return true;
+    }
+
+    /// <summary>
+    /// Settles the skill's printed base chance -- the only number the 5% floor reads -- from at
+    /// most one of two sources, or defaults it to the rating. <c>--base-chance</c> is the explicit
+    /// value for an ad-hoc action the skill list does not name; <c>--skill-name</c> looks the value
+    /// up in the shipped ruleset so the caller need not remember it. They are mutually exclusive:
+    /// naming a skill and also overriding its base would make one of the two silently ignored, which
+    /// is the kind of invisible step this command exists to prevent. When neither is given the base
+    /// defaults to the rating -- correct for every skill printed at 5% or higher, since the floor
+    /// only asks which side of 5% the base falls on, and wrong only for the 01%-base skills the two
+    /// options exist to serve.
+    /// </summary>
+    private static bool TryResolveBaseChance(
+        int? baseChance,
+        string? skillName,
+        int rating,
+        out Percent resolved,
+        out string? source,
+        [NotNullWhen(false)] out string? error)
+    {
+        resolved = default;
+        source = null;
+        error = null;
+
+        if (baseChance is not null && skillName is not null)
+        {
+            error = "give either '--skill-name' or '--base-chance', not both — '--base-chance' is "
+                + "for an ad-hoc action the skill list does not name.";
+            return false;
+        }
+
+        if (baseChance is not null)
+        {
+            resolved = Percent.Of(baseChance.Value);
+            return true;
+        }
+
+        if (skillName is not null)
+        {
+            var registry = NoirSkillRuleset.Load();
+            if (!registry.TryGetSkill(new SkillId(skillName), out var definition) || definition is null)
+            {
+                error = $"unknown skill '{skillName}'. Use a framework skill name, e.g. "
+                    + "\"Science (Forensics)\" or \"Spot\", or pass '--base-chance' for an ad-hoc action.";
+                return false;
+            }
+
+            if (!definition.BaseChance.TryEvaluateWithoutAbilities(out resolved))
+            {
+                // Formula- and weapon-derived bases need a character sheet or weapon data this
+                // command has no way to supply; refusing beats guessing a wrong floor.
+                error = $"the skill '{skillName}' has a base chance this command cannot compute on its "
+                    + "own (it depends on characteristics or weapon data); pass '--base-chance' explicitly.";
+                return false;
+            }
+
+            source = definition.Name;
+            return true;
+        }
+
+        resolved = Percent.Of(rating);
         return true;
     }
 
@@ -316,12 +398,22 @@ internal static class RollCommand
                                  from the command line that made it.
 
         options:
+          --skill-name <name>    A framework skill name, e.g. "Science
+                                 (Forensics)" or "Spot". Looks up the skill's
+                                 printed base chance from the ruleset, so you
+                                 need not pass --base-chance for a known skill.
+                                 A skill whose base depends on characteristics
+                                 (e.g. Dodge) or weapons (e.g. Firearms) has no
+                                 standalone value here — pass --base-chance for
+                                 those. Cannot be combined with --base-chance.
           --base-chance <n>      The skill's printed base chance — what an
                                  untrained character rolls against. Only the
-                                 5% floor reads it. Defaults to --skill, which
-                                 is right for every skill printed at 5% or
-                                 above; pass it for the ones printed at 01%,
-                                 such as Science, Strategy, or Martial Arts.
+                                 5% floor reads it. Use it for an ad-hoc action
+                                 the skill list does not name. When neither this
+                                 nor --skill-name is given, the base defaults to
+                                 --skill, which is right for every skill printed
+                                 at 5% or above; the 01%-base skills (Science,
+                                 Strategy, Martial Arts) need one of the two.
           --difficulty <grade>   easy, normal, or difficult. Default: normal.
                                  Doubles the rating or halves it, rounding up.
           --modifier "<n> <label>"
@@ -353,6 +445,14 @@ internal sealed class RollOptions
     /// nothing except the 5% floor (Ch 5: System, "Skill Rolls"). Defaults to <see cref="Skill"/>.
     /// </summary>
     public required Percent BaseChance { get; init; }
+
+    /// <summary>
+    /// The canonical name of the skill <see cref="BaseChance"/> was looked up from via
+    /// <c>--skill-name</c>, or <see langword="null"/> when the base was given with
+    /// <c>--base-chance</c> or defaulted to the rating. Carried only so the report can show where
+    /// the base chance came from.
+    /// </summary>
+    public string? BaseChanceSkillName { get; init; }
 
     /// <summary>The seed for the single draw this command makes.</summary>
     public required ulong Seed { get; init; }

--- a/tools/Brp.Cli/RollReport.cs
+++ b/tools/Brp.Cli/RollReport.cs
@@ -22,7 +22,7 @@ internal static class RollReport
 
     private const string Indent = "  ";
 
-    public static string Render(ulong seed, ModifierChain chain, RollOutcome outcome)
+    public static string Render(ulong seed, ModifierChain chain, RollOutcome outcome, string? baseChanceSkillName = null)
     {
         ArgumentNullException.ThrowIfNull(chain);
         ArgumentNullException.ThrowIfNull(outcome);
@@ -53,9 +53,15 @@ internal static class RollReport
 
         // "base chance", not "base rating": this is the skill's printed starting value, the only
         // thing the floor rule below reads. The rating the chain started from is the Chance
-        // section's first row, and the two are not always the same number.
+        // section's first row, and the two are not always the same number. When the base chance
+        // was looked up from a named skill (--skill-name), the source is shown so the report
+        // records where the number came from rather than leaving it a bare figure; when it was
+        // given with --base-chance or defaulted to the rating, the line is unchanged.
+        var baseChanceProvenance = baseChanceSkillName is null
+            ? string.Empty
+            : $" from \"{baseChanceSkillName}\"";
         report.Append(CultureInfo.InvariantCulture,
-            $"Outcome bands  (effective {outcome.EffectiveChance}, base chance {outcome.BaseChance})\n");
+            $"Outcome bands  (effective {outcome.EffectiveChance}, base chance {outcome.BaseChance}{baseChanceProvenance})\n");
         foreach (var band in bands)
         {
             report.Append(Indent)


### PR DESCRIPTION
## What

Adds `--skill-name` to `brp roll`, which looks up a skill's **printed base chance** from the shipped ruleset (`NoirSkillRuleset` / `SkillRegistry`, from #35) so the 5% floor can't be mis-applied to a 01%-base skill just because the caller forgot `--base-chance`.

## Why

The engine binding was fixed in #27, but `rules-conformance` flagged one player-facing gap that remained: the CLI defaulted the printed base to the character's rating, so rolling Science/Strategy/Martial Arts without `--base-chance 1` wrongly rescued 01–05. #35 gave the CLI a catalog to consult; this uses it.

## Behaviour

- **`--skill-name "Science (Forensics)"`** → base resolved from the ruleset (01%). Floor applies correctly.
- **`--base-chance`** stays the explicit override for ad-hoc actions the skill list doesn't name. The two are **mutually exclusive** (naming a skill and overriding its base would silently ignore one).
- **Neither given** → keeps the documented rating-default. This is the design choice the issue asked to settle: I kept it for backward-compatibility, so every existing invocation renders byte-identically and all prior CLI tests are unchanged.
- A skill whose base needs **characteristics** (Dodge) or **weapon data** (Firearms specialties) is **refused with a clear message**, never guessed — backed by a new `BaseChanceExpression.TryEvaluateWithoutAbilities` (resolves constants and era-conditional-over-constants like Drive without an `AbilitySet`; returns false otherwise).
- **Provenance:** the base-chance line shows its source (`base chance 1% from "Science (Forensics)"`) only when looked up by name; otherwise the output is unchanged.

## Acceptance criteria

- [x] Rolling a 01%-base skill by name, without `--base-chance`, applies the floor correctly (pinned test: Science → 02 Success, 03–95 Failure, no floor note; contrast test shows the default-to-rating case wrongly rescuing).
- [x] `--base-chance` still overrides and still serves ad-hoc actions.
- [x] A skill whose base needs data the CLI lacks fails loudly (Dodge, Firearms specialty tests).
- [x] Output provenance shows where the base chance came from.

## Verification

No new rules claims — base chances come from the registry `rules-conformance` verified in #35, and `SkillResolver`'s floor is unchanged (#27). Full suite green (1509 core / 124 data / 51 cli); `dotnet format` clean.

Resolves #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)