### PR TITLE
Layer 3 — Characters: aggregate, point-buy creation, tick-on-use experience (#40)

### DIFF
--- a/NoiRPG.slnx
+++ b/NoiRPG.slnx
@@ -2,11 +2,13 @@
   <Folder Name="/src/">
     <Project Path="src/Brp.Core/Brp.Core.csproj" />
     <Project Path="src/Brp.Data/Brp.Data.csproj" />
+    <Project Path="src/Brp.Rules/Brp.Rules.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Brp.Cli.Tests/Brp.Cli.Tests.csproj" />
     <Project Path="tests/Brp.Core.Tests/Brp.Core.Tests.csproj" />
     <Project Path="tests/Brp.Data.Tests/Brp.Data.Tests.csproj" />
+    <Project Path="tests/Brp.Rules.Tests/Brp.Rules.Tests.csproj" />
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/Brp.Cli/Brp.Cli.csproj" />

--- a/docs/decisions/0012-characters-and-advancement.md
+++ b/docs/decisions/0012-characters-and-advancement.md
@@ -200,24 +200,46 @@ are #40's stated follow-on work).
   its fumble band matches the book's general fumble rule exactly. A Success
   (or better — Ch 5 p.138 does not distinguish Special/Critical for
   teaching) grants `+1D6`, capped so training alone cannot carry the skill
-  past `trainingCapPercent` (75%, `Ch 5 p.138`: "No skill can be trained
-  above 75%, no matter how good the instructor. Any increase above this
-  must come through successful use of the skill"). **Corrected
-  2026-08-30:** the original implementation applied the die roll
-  uncapped, which could train a skill past 75% — a real defect, since that
-  cap is the book's explicit floor on what teaching alone can do. A plain
-  Failure grants nothing. A **fumble now applies the book's printed
-  penalty**: `CharacterSkill.Degrade` reduces the rating by `1D3`, floored
-  at zero (Ch 5 p.138: "a fumble is counterproductive, with the teacher
-  causing self-doubt and contradicting your character's prior learnings,
-  reducing the skill by -1D3"). This was previously left unmodeled with an
-  incorrect scope note calling it "a combat/injury effect, Layer 4" — a
-  teaching fumble is skill *degradation*, not a physical injury, and there
-  was no genuine scope reason to defer it. `Teach` returns the signed
-  change actually applied (positive for a capped gain, negative for a
-  floored fumble penalty, zero for a plain failure), not the raw uncapped
-  die roll, so a caller reading the return value never sees a number larger
-  than what the skill's rating actually moved by.
+  past a training cap (75% per Ch 5 p.139: "No skill can be trained above
+  75%, no matter how good the instructor. Any increase above this must come
+  through successful use of the skill"). **Corrected 2026-08-30:** the
+  original implementation applied the die roll uncapped, which could train a
+  skill past 75% — a real defect, since that cap is the book's explicit
+  floor on what teaching alone can do. A plain Failure grants nothing. A
+  **fumble now applies the book's printed penalty**: `CharacterSkill.Degrade`
+  reduces the rating by `1D3`, floored at zero (Ch 5 p.138: "a fumble is
+  counterproductive, with the teacher causing self-doubt and contradicting
+  your character's prior learnings, reducing the skill by -1D3"). This was
+  previously left unmodeled with an incorrect scope note calling it "a
+  combat/injury effect, Layer 4" — a teaching fumble is skill *degradation*,
+  not a physical injury, and there was no genuine scope reason to defer it.
+  `Teach` returns the signed change actually applied (positive for a capped
+  gain, negative for a floored fumble penalty, zero for a plain failure),
+  not the raw uncapped die roll, so a caller reading the return value never
+  sees a number larger than what the skill's rating actually moved by.
+- **Corrected 2026-08-30 (second conformance pass): the training cap is now
+  ruleset data, not a bare constant.** The first fix for the missing 75%
+  cap (above) initially landed it as a `Teach` method-parameter default
+  (`int trainingCapPercent = 75`) — itself a nick against invariant 7 (rules
+  values are data, not constants), just one step removed from the defect it
+  fixed. It now lives on a new `Brp.Rules.Advancement.ExperienceRuleset`
+  (one field, `TrainingCapPercent`), loaded from `Brp.Data`'s
+  `experience-ruleset.json` via `NoirExperienceRuleset.Load()`, following
+  the exact loader/JSON/validation pattern
+  `NoirCharacterCreationRuleset`/`character-creation-ruleset.json` already
+  established. `Teach` now takes an `ExperienceRuleset` as a required
+  parameter (no in-code default), so a caller must supply the sourced
+  value rather than silently getting one baked into the method signature.
+  **This is deliberately a separate ruleset field from
+  `Creation.CharacterCreationRuleset.StartingSkillCapPercent`, not a shared
+  read of the same number**, even though the book prints 75% for both at
+  Normal power level: one gates what a skill may start at during character
+  creation (Ch 2 p.8), the other gates what teaching alone may raise an
+  *existing* skill to during play (Ch 5 p.139) — two different rules the
+  book happens to pin at the same value, not one rule with two names. A test
+  proves the value is genuinely read from data by constructing an
+  `ExperienceRuleset` with a non-default cap (40) and confirming `Teach`
+  clamps to it instead of 75.
 
 Policy names (`TickOnUse`, `RawTickOnSuccess`), the mechanical gate
 (`CheckStakes`), and the improvement rule (`d100 > rating → +1D6`, with the
@@ -253,9 +275,9 @@ bonus an explicit opt-in parameter, documented on both sides.
 ## Consequences
 
 - `Brp.Rules` is the third tenant of `Brp.Data`'s loader pattern
-  (`NoirCharacterCreationRuleset`, `NoirBackgroundPackageRuleset`), mirroring
-  `NoirAbilityRuleset`/`NoirSkillRuleset`. `Brp.Data` now references
-  `Brp.Rules` in addition to `Brp.Core`.
+  (`NoirCharacterCreationRuleset`, `NoirBackgroundPackageRuleset`, and now
+  `NoirExperienceRuleset`), mirroring `NoirAbilityRuleset`/`NoirSkillRuleset`.
+  `Brp.Data` now references `Brp.Rules` in addition to `Brp.Core`.
 - Layer 5 can author the real noir background packages
   (`background-packages.json`) and the Composure/Vices/Passions layer
   directly against `Character`, `CharacterSkill`, and `BackgroundPackage`
@@ -281,3 +303,10 @@ bonus an explicit opt-in parameter, documented on both sides.
   tests (see the "Decision: `ExperienceSystem`" section above); a Teach
   fumble now applies the printed -1D3 skill degradation instead of being
   left unmodeled under an inaccurate Layer-4-injury scope note.
+- **Second post-implementation correction (2026-08-30, re-audit):** the
+  training-cap fix above initially landed as a hardcoded method-parameter
+  default rather than ruleset data — a smaller instance of the same
+  invariant-7 gap this ADR otherwise documents at length. Moved to
+  `ExperienceRuleset`/`experience-ruleset.json`, with a test proving a
+  non-default cap value changes `Teach`'s clamp. See the data-sourcing note
+  under "Teaching" above.

--- a/docs/decisions/0012-characters-and-advancement.md
+++ b/docs/decisions/0012-characters-and-advancement.md
@@ -1,0 +1,231 @@
+# 0012. Layer 3 — Character, CharacterBuilder, and ExperienceSystem shape
+
+## Status
+
+Accepted — 2026-08-30. Resolves #40.
+
+## Context
+
+Layers 0–2 (`Brp.Core`'s abilities and skills) supply the pieces a whole
+character needs, but nothing yet binds them into a `Character` aggregate, a
+creation path, or the locked tick-on-use advancement rule
+(`noir-rpg-framework.md` v0.2, `AGENTS.md`). `engine-implementation-plan.md`
+§3 lists "power points" on the Layer 3 `Character`; that is superseded by
+`orc-scope-filter.md`'s Chapter 4 cut (see ADR 0009) and is not built.
+
+## Decision: `Character` aggregate
+
+**Sourced:** Ch 2: Characters, "Derived Characteristics" (p.13) and "Hit
+Points" (p.14).
+
+`Brp.Rules.Characters.Character` binds an identity, a Layer 1 `AbilitySet`,
+and a dictionary of `CharacterSkill` instances keyed by `SkillId`. It exposes
+`CurrentHitPoints`/`MaximumHitPoints` as pass-through properties that read
+`AbilitySet` live on every access rather than caching a value computed at
+construction — `AbilitySet` already made HP a computed-on-read value (ADR
+0008); `Character` does not re-introduce a cache on top of it. Verified by a
+test that drops CON on an existing `Character` and observes
+`MaximumHitPoints` fall, with `CurrentHitPoints` clamped alongside it.
+
+`CharacterSkill` is Layer 2's "two-number contract"
+(`Brp.Core.Skills.SkillRoll`) made concrete per character: `Definition`
+supplies the printed base chance, `CurrentRating` is the character's own
+number, set by `CharacterBuilder` and moved afterward only by
+`ExperienceSystem`. `HasExperienceCheck` is the per-skill experience flag Ch
+5 p.138 requires ("the small box next to that skill").
+
+`WoundTrack` and `EquipmentList` are structure only: an ordered list of
+`Wound`/`EquipmentItem` records with add/remove, carrying no wound mechanics
+or gear stats. Layer 4 (#21) owns First Aid-per-wound, Major Wounds, hit
+locations, and weapon/armor data; this issue only guarantees `Character` has
+somewhere to put them.
+
+**Scope cut, enforced:** no spendable power-point pool, Fate Points, or PP
+reservoir exists on `Character`. POW remains a characteristic (it still
+drives the Luck roll, Ch 2 p.11, and POW-vs-POW resistance). A reflection
+test (`ArchitectureTests.Character_carries_no_spendable_power_point_pool`)
+guards against a future PR reintroducing one under a different name.
+
+## Decision: `CharacterBuilder` — point-buy creation
+
+**Sourced:** Ch 2: Characters, "Point-Based Character Creation (option)"
+(pp.9-10) for characteristics; "Step Seven: Profession and Skills" (p.8) for
+skill points; "Freeform Professions" checklist entry (p.229) for the
+background-package mechanism.
+
+### Characteristics
+
+`CharacteristicPointBuy.Allocate` reproduces the printed option exactly:
+
+| Parameter | Value | Source |
+|---|---|---|
+| Point pool | 24 | p.9, "You have 24 points to spend ... equivalent of the 'normal' power level" |
+| Starting value | 10 (all seven) | p.9, "All characteristics ... begin at 10" |
+| Cost: STR/CON/SIZ/CHA | 1/point, symmetric refund | p.9 |
+| Cost: DEX/INT/POW | 3/point, symmetric refund | p.9 |
+| Creation-time maximum | 21 (all seven, including INT/POW) | p.9, "No initial characteristic can be raised to higher than 21" |
+| Floor | 3 general; SIZ/INT floor at 8 | p.9-10; already encoded in `ability-ruleset.json`'s per-characteristic `Minimum` (ADR 0008) |
+
+The 21 creation-time ceiling is deliberately **not** the same value as
+`AbilityRuleset.Characteristics[id].Maximum`: that property is `null` for
+INT and POW because Ch 2 p.10 says mental characteristics "can usually be
+raised without limits" **during play**. `CharacterCreationRuleset
+.CharacteristicCreationMaximum` is a separate, creation-time-only cap, taken
+as `min(21, AbilityRuleset maximum)` per characteristic
+(`CharacteristicPointBuy.ValidateBounds`) — the two numbers do different
+jobs and neither one absorbs the other.
+
+**House rule — the ±3 shift.** After point-buy allocation,
+`CharacteristicPointBuy.ApplyShift` lets up to
+`CharacterCreationRuleset.FreeShiftPoints` (3) points move between
+characteristics, zero-sum. **This is not printed for the point-buy option.**
+Ch 2 p.8's "redistribute up to 3 points between your characteristics" belongs
+to the dice-rolled Step One (`3D6`/`2D6+6`), which point-buy replaces
+outright ("the following adjustments are made to Step One" — full
+substitution, no redistribution clause carried over). NoiRPG extends the
+same small fine-tuning allowance to the point-buy path so a build is not
+locked to whole-point-cost increments at the margins. It is bounded,
+optional (0 disables it via ruleset data), and it can never move a
+characteristic outside its bounds. If this combination proves confusing at
+the table or in tooling, it can be turned off by setting
+`freeShiftPoints: 0` in `character-creation-ruleset.json` without touching
+code.
+
+EDU is out of scope for the point-buy allocator: Ch 2 p.9 has the
+gamemaster assign it "based on your character's age and background," which
+is a game-layer decision this issue does not make. `CharacterBuilder`
+accepts an optional `Education` value on the creation request, defaulting to
+the ruleset's starting value (10) — the same neutral fixture ADR 0006
+already used for the audited background packages.
+
+### Skills
+
+| Parameter | Value | Source |
+|---|---|---|
+| Professional skill points (Normal power level) | 250 | p.8, "Allot 250 points to professional skills" |
+| Personal skill points (RAW) | INT×10 | p.8, "multiply your character's INT×10" |
+| Personal skill points (Increased option) | INT×15 | p.8, "Increased Personal Skill Points (Option)" |
+| Starting soft cap | 75% | p.8, "No skill should begin higher than 75%" |
+
+**House rule — which "Increased" tier NoiRPG uses.** The book's Increased
+Personal Skill Points option states INT×15/20/25 for heroic/epic/superhuman
+campaigns and is silent on a Normal-power-level increase; Normal only has
+the plain INT×10 baseline. NoiRPG runs at Normal power level throughout (250
+professional points, 75% cap — never adopting heroic's 325/90%) and borrows
+only the heroic tier's INT×15 personal multiplier, because the Noir entry
+recommends the option specifically so "characters are professionals with
+prior experience" (`orc-scope-filter.md`), which is a personal-skill-pool
+concern, not a campaign-power-level one. `CharacterCreationRuleset
+.IncreasedPersonalSkillPointsIntMultiplier` documents this explicitly so a
+future reader does not mistake it for a plain transcription of the printed
+heroic row.
+
+The 75% cap is enforced per skill as `max(cap, printedBase)` — reproducing
+p.8's own carve-out: "If a combination of bonuses increases the skill to
+more than 75% before this step, do not add any additional skill points."
+`CharacterBuilder` throws rather than silently clamping, so a caller
+reallocates the points instead of losing them.
+
+### Background packages (Freeform Professions)
+
+`BackgroundPackage` is a name plus a professional skill-point allocation,
+applied through the same professional-skill-point mechanic every printed
+profession uses (Ch 2, "Professions A Through Z," p.17 onward — "Your
+character will spend their professional skill points on these skills"). The
+book's own text for Freeform Professions is one checklist line ("Useful for
+customized, difficult-to-categorize player characters," p.229) with no
+further mechanic given, so reusing the ordinary professional-points path
+rather than inventing a new one is the natural reading. `background-packages
+.json` ships exactly one placeholder fixture package, explicitly labeled as
+a test fixture, not a Layer 5 noir package (ex-cop, ex-journalist, and so on
+are #40's stated follow-on work).
+
+## Decision: `ExperienceSystem` — tick-on-use, RAW toggle
+
+**Sourced:** Ch 5: System, "Skill Improvement," "Making an Experience Roll,"
+"Increasing Skills by Experience," and "Training and Study" (pp.138-140).
+
+- **Gate (mechanical, both policies):** `CheckStakes.Easy` or `.NoStakes`
+  never records a tick — Ch 5 p.138, "If a skill roll was Easy, no
+  experience check is allowed," extended mechanically (there is no
+  gamemaster) to the "nothing at stake" exemption from the same page.
+- **Once per case:** `CaseExperienceLedger` refuses a second tick for the
+  same skill within one case — Ch 5 p.138, "made only once per adventure, no
+  matter how many times the skill is successfully used."
+- **House rule — `ExperiencePolicy.TickOnUse` (the default):** a real-stakes
+  check ticks whether it succeeded or failed. This is the locked deviation
+  from BRP RAW (`noir-rpg-framework.md` v0.2, `AGENTS.md`), justified by
+  `tools/advancement_sim.py`'s 10,000-character simulation showing RAW ticks
+  are "nearly invisible at video-game length" and "starve low skills."
+- **Sourced — `ExperiencePolicy.RawTickOnSuccess`:** the toggle that
+  reproduces Ch 5 p.138 exactly ("If a skill is used successfully, you
+  almost always get an experience check"). This is the falsification target
+  `rules-conformance` should check: flipping the policy and nothing else
+  must make every previously-ticking failed check stop ticking, and change
+  nothing else about the gate or the improvement roll.
+- **Improvement roll:** `ExperienceSystem.ImprovementRoll` draws a d100 via
+  the injected `IEntropySource`, adds an optional `experienceBonus`, and
+  compares to the current rating: `roll > rating` grants `+1D6` (`Ch 5
+  p.138-139`). The experience check clears either way. **The experience
+  bonus (½INT rounded up, `AbilitySet.ExperienceBonus`, already built in
+  Layer 1) defaults to 0** rather than being applied unconditionally. Ch 5
+  p.138 prints it as part of the roll ("added to the die roll ... just to
+  the roll to see if there is improvement"), and passing
+  `character.Abilities.ExperienceBonus` reproduces that exactly — the
+  default of 0 exists only so the implementation's simplest call matches
+  `tools/advancement_sim.py`'s deliberately simplified model, which omits
+  the bonus term. This is a reconciliation with the simulation's scope, not
+  a claim that the book has no such bonus.
+- **Teaching:** `ExperienceSystem.Teach` retains the RAW teaching rule (a
+  Teach roll against the teacher's chance grants the student `+1D6` on
+  success, nothing on failure). The book's fumble consequence (self-injury)
+  is not modeled — that is a combat/injury effect, Layer 4.
+
+Policy names (`TickOnUse`, `RawTickOnSuccess`), the mechanical gate
+(`CheckStakes`), and the improvement rule (`d100 > rating → +1D6`) are
+written to match `tools/advancement_sim.py`'s two simulated variants ("B
+tick on use" / "A RAW (tick on success)") so the simulation remains a valid
+sanity check against this implementation, per the issue's explicit
+requirement.
+
+## Alternatives considered
+
+**Baking HP at construction time.** Rejected outright — Ch 2 p.13 requires
+derived values to change immediately, and `AbilitySet` (Layer 1) already
+solved this; re-caching it in `Character` would silently undo that work.
+
+**Applying the printed heroic power level wholesale (325 points, 90% cap)
+instead of borrowing only its personal-points multiplier.** Rejected: the
+framework and scope filter want a Normal-power-level game with one
+professional-competence knob turned up, not a heroic-tier campaign; adopting
+the whole tier would also raise combat lethality assumptions the framework
+explicitly rejects ("danger never retires").
+
+**Applying the RAW experience bonus unconditionally in `ImprovementRoll`.**
+Considered for exactness to Ch 5 p.138, but rejected as the default because
+it would silently diverge from `tools/advancement_sim.py`'s model that the
+issue requires this system to reconcile with. Solved instead by making the
+bonus an explicit opt-in parameter, documented on both sides.
+
+## Consequences
+
+- `Brp.Rules` is the third tenant of `Brp.Data`'s loader pattern
+  (`NoirCharacterCreationRuleset`, `NoirBackgroundPackageRuleset`), mirroring
+  `NoirAbilityRuleset`/`NoirSkillRuleset`. `Brp.Data` now references
+  `Brp.Rules` in addition to `Brp.Core`.
+- Layer 5 can author the real noir background packages
+  (`background-packages.json`) and the Composure/Vices/Passions layer
+  directly against `Character`, `CharacterSkill`, and `BackgroundPackage`
+  without further Layer 3 changes.
+- Layer 4 (#21) will add wound and equipment mechanics that populate
+  `WoundTrack`/`EquipmentList` — no rework of `Character` should be needed,
+  only additions.
+- **Known limitation:** weapon-derived skills (Firearms, Melee Weapon
+  variants) resolve to a printed base of 0% in `CharacterBuilder` because
+  their real base chance needs weapon data that does not exist until Layer
+  4 (`Brp.Core.Skills.WeaponDerivedBaseChance` already documents this gap).
+  A character built today can still be assigned professional/personal
+  points on those skills, but the resulting rating undercounts what the
+  book would show once a weapon is chosen. This is not a defect introduced
+  here; it is the same gap Layer 2 already recorded, now visible at
+  character-build time.

--- a/docs/decisions/0012-characters-and-advancement.md
+++ b/docs/decisions/0012-characters-and-advancement.md
@@ -165,28 +165,71 @@ are #40's stated follow-on work).
   nothing else about the gate or the improvement roll.
 - **Improvement roll:** `ExperienceSystem.ImprovementRoll` draws a d100 via
   the injected `IEntropySource`, adds an optional `experienceBonus`, and
-  compares to the current rating: `roll > rating` grants `+1D6` (`Ch 5
-  p.138-139`). The experience check clears either way. **The experience
-  bonus (½INT rounded up, `AbilitySet.ExperienceBonus`, already built in
-  Layer 1) defaults to 0** rather than being applied unconditionally. Ch 5
-  p.138 prints it as part of the roll ("added to the die roll ... just to
-  the roll to see if there is improvement"), and passing
-  `character.Abilities.ExperienceBonus` reproduces that exactly — the
-  default of 0 exists only so the implementation's simplest call matches
-  `tools/advancement_sim.py`'s deliberately simplified model, which omits
-  the bonus term. This is a reconciliation with the simulation's scope, not
-  a claim that the book has no such bonus.
-- **Teaching:** `ExperienceSystem.Teach` retains the RAW teaching rule (a
-  Teach roll against the teacher's chance grants the student `+1D6` on
-  success, nothing on failure). The book's fumble consequence (self-injury)
-  is not modeled — that is a combat/injury effect, Layer 4.
+  compares against a success threshold: `roll > rating` grants `+1D6` (Ch 5
+  p.138-139) below 100%. **Corrected 2026-08-30 (post-implementation
+  conformance review):** at or above 100%, the threshold is pinned at 100
+  rather than at the (possibly much higher) current rating — Ch 5 p.138,
+  "Exceeding 100% in a Skill": "No matter how much over 100% the skill has
+  risen, any roll of 100 or over earns a skill improvement." The original
+  implementation used `roll <= rating` unconditionally, which meant a skill
+  at or above 100% could **never** improve (the maximum possible roll of 100
+  always satisfies `100 <= rating` once `rating >= 100`) — a real defect,
+  since NoiRPG does not cut skills at 100% and tick-on-use can carry a
+  primary skill past it over a campaign. Fixed by comparing against
+  `min(rating, 100)`, with `roll >= 100` at that cap instead of `roll >
+  100` (an unmodified d100 tops out at 100, so "greater than" would make
+  the capped threshold unreachable without the experience bonus, which
+  contradicts the book's own "any roll of 100 or over" clause).
+  `tools/advancement_sim.py`'s `Skill.improvement_roll` was updated with the
+  identical cap in the same change, so the two stay reconciled — see that
+  file's docstring and inline comment.
+  The experience check clears either way. **The experience bonus (½INT
+  rounded up, `AbilitySet.ExperienceBonus`, already built in Layer 1)
+  defaults to 0** rather than being applied unconditionally. Ch 5 p.138
+  prints it as part of the roll ("added to the die roll ... just to the
+  roll to see if there is improvement"), and passing
+  `character.Abilities.ExperienceBonus` now reproduces Ch 5's printed rule
+  exactly, including the 100%-and-above case — the default of 0 exists only
+  so the implementation's simplest call matches `tools/advancement_sim.py`'s
+  deliberately simplified model, which omits the bonus term. This is a
+  reconciliation with the simulation's scope, not a claim that the book has
+  no such bonus.
+- **Teaching:** `ExperienceSystem.Teach` now resolves the teacher's Teach
+  roll through the same five-grade `Brp.Core.Resolution.SkillResolver` every
+  other skill roll uses, rather than a bespoke percent-threshold check, so
+  its fumble band matches the book's general fumble rule exactly. A Success
+  (or better — Ch 5 p.138 does not distinguish Special/Critical for
+  teaching) grants `+1D6`, capped so training alone cannot carry the skill
+  past `trainingCapPercent` (75%, `Ch 5 p.138`: "No skill can be trained
+  above 75%, no matter how good the instructor. Any increase above this
+  must come through successful use of the skill"). **Corrected
+  2026-08-30:** the original implementation applied the die roll
+  uncapped, which could train a skill past 75% — a real defect, since that
+  cap is the book's explicit floor on what teaching alone can do. A plain
+  Failure grants nothing. A **fumble now applies the book's printed
+  penalty**: `CharacterSkill.Degrade` reduces the rating by `1D3`, floored
+  at zero (Ch 5 p.138: "a fumble is counterproductive, with the teacher
+  causing self-doubt and contradicting your character's prior learnings,
+  reducing the skill by -1D3"). This was previously left unmodeled with an
+  incorrect scope note calling it "a combat/injury effect, Layer 4" — a
+  teaching fumble is skill *degradation*, not a physical injury, and there
+  was no genuine scope reason to defer it. `Teach` returns the signed
+  change actually applied (positive for a capped gain, negative for a
+  floored fumble penalty, zero for a plain failure), not the raw uncapped
+  die roll, so a caller reading the return value never sees a number larger
+  than what the skill's rating actually moved by.
 
 Policy names (`TickOnUse`, `RawTickOnSuccess`), the mechanical gate
-(`CheckStakes`), and the improvement rule (`d100 > rating → +1D6`) are
-written to match `tools/advancement_sim.py`'s two simulated variants ("B
-tick on use" / "A RAW (tick on success)") so the simulation remains a valid
-sanity check against this implementation, per the issue's explicit
-requirement.
+(`CheckStakes`), and the improvement rule (`d100 > rating → +1D6`, with the
+100%-and-above threshold correction above) are written to match
+`tools/advancement_sim.py`'s two simulated variants ("B tick on use" / "A RAW
+(tick on success)") so the simulation remains a valid sanity check against
+this implementation, per the issue's explicit requirement. The
+rules-conformance falsification target — flipping `ExperiencePolicy` and
+nothing else must reproduce BRP's tick-on-success behavior exactly, with no
+other divergence from the book's experience rule — is unaffected by either
+correction: both defects lived inside "no other divergence," not in the
+gate itself, and both are now closed.
 
 ## Alternatives considered
 
@@ -229,3 +272,12 @@ bonus an explicit opt-in parameter, documented on both sides.
   book would show once a weapon is chosen. This is not a defect introduced
   here; it is the same gap Layer 2 already recorded, now visible at
   character-build time.
+- **Post-implementation correction (2026-08-30, rules-conformance audit):**
+  the initial implementation had two real defects, both inside the
+  falsification target's "no other divergence from the book" zone rather
+  than in the gate: the improvement roll's `>=100%` threshold (skills at or
+  above 100% could never improve) and the Teach roll's missing 75% training
+  cap (training could push a skill past it). Both are fixed and covered by
+  tests (see the "Decision: `ExperienceSystem`" section above); a Teach
+  fumble now applies the printed -1D3 skill degradation instead of being
+  left unmodeled under an inaccurate Layer-4-injury scope note.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -34,3 +34,4 @@ supersedes it — the original is not edited or deleted.
 | [0009](0009-drop-fate-points.md) | Drop Fate Points instead of rebasing their power-point economy | Accepted |
 | [0010](0010-acting-without-skill.md) | Acting Without Skill is off for core clues; texture use deferred | Accepted |
 | [0011](0011-skill-definition.md) | SkillDefinition: base-chance shape, specialties, and the skill registry | Accepted |
+| [0012](0012-characters-and-advancement.md) | Layer 3 — Character, CharacterBuilder, and ExperienceSystem shape | Accepted |

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -16,6 +16,7 @@
     <EmbeddedResource Include="skill-ruleset.json" />
     <EmbeddedResource Include="character-creation-ruleset.json" />
     <EmbeddedResource Include="background-packages.json" />
+    <EmbeddedResource Include="experience-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -8,11 +8,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Brp.Core\Brp.Core.csproj" />
+    <ProjectReference Include="..\Brp.Rules\Brp.Rules.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="ability-ruleset.json" />
     <EmbeddedResource Include="skill-ruleset.json" />
+    <EmbeddedResource Include="character-creation-ruleset.json" />
+    <EmbeddedResource Include="background-packages.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirBackgroundPackageRuleset.cs
+++ b/src/Brp.Data/NoirBackgroundPackageRuleset.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using Brp.Core.Skills;
+using Brp.Rules.Creation;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads Freeform Profession background packages from embedded JSON (Ch 2, "Freeform
+/// Professions (Option)" checklist entry, p.229; see <see cref="BackgroundPackage"/> for the
+/// mechanic this data drives). Ships one placeholder/test fixture package -- the actual noir
+/// packages (ex-cop, ex-journalist, ex-lawyer, ex-soldier, ex-accountant) are Layer 5 content
+/// authored on top of this mechanism, not this issue's concern.
+/// </summary>
+public static class NoirBackgroundPackageRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads every background package shipped in data.</summary>
+    public static IReadOnlyList<BackgroundPackage> LoadAll()
+    {
+        var assembly = typeof(NoirBackgroundPackageRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.background-packages.json")
+            ?? throw new InvalidOperationException("The background package data resource is missing.");
+        var data = JsonSerializer.Deserialize<List<BackgroundPackageData>>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The background package data is empty.");
+
+        return data.Select(entry => new BackgroundPackage(
+            entry.Name,
+            entry.ProfessionalSkillPoints.ToDictionary(pair => new SkillId(pair.Key), pair => pair.Value)))
+            .ToList();
+    }
+
+    private sealed class BackgroundPackageData
+    {
+        public required string Name { get; init; }
+
+        public required Dictionary<string, int> ProfessionalSkillPoints { get; init; }
+    }
+}

--- a/src/Brp.Data/NoirCharacterCreationRuleset.cs
+++ b/src/Brp.Data/NoirCharacterCreationRuleset.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using Brp.Core.Abilities;
+using Brp.Rules.Creation;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's Layer 3 character-creation parameters from embedded JSON. The source is
+/// Ch 2: Characters, "Point-Based Character Creation (option)" (pp.9-10) and "Step Seven:
+/// Profession and Skills" (p.8) -- see <see cref="CharacterCreationRuleset"/>'s own members
+/// for the exact citation of each value.
+/// </summary>
+public static class NoirCharacterCreationRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable creation ruleset view from the shipped data.</summary>
+    public static CharacterCreationRuleset Load()
+    {
+        var assembly = typeof(NoirCharacterCreationRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.character-creation-ruleset.json")
+            ?? throw new InvalidOperationException("The character creation ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<CreationRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The character creation ruleset data is empty.");
+
+        var costs = data.CharacteristicCosts.ToDictionary(
+            pair => new CharacteristicId(pair.Key), pair => pair.Value);
+
+        return new CharacterCreationRuleset(
+            data.CharacteristicPointPool,
+            data.StartingCharacteristicValue,
+            data.CharacteristicCreationMaximum,
+            costs,
+            data.FreeShiftPoints,
+            data.ProfessionalSkillPoints,
+            data.PersonalSkillPointsIntMultiplier,
+            data.IncreasedPersonalSkillPointsIntMultiplier,
+            data.StartingSkillCapPercent);
+    }
+
+    private sealed class CreationRulesetData
+    {
+        public required int CharacteristicPointPool { get; init; }
+
+        public required int StartingCharacteristicValue { get; init; }
+
+        public required int CharacteristicCreationMaximum { get; init; }
+
+        public required Dictionary<string, int> CharacteristicCosts { get; init; }
+
+        public required int FreeShiftPoints { get; init; }
+
+        public required int ProfessionalSkillPoints { get; init; }
+
+        public required int PersonalSkillPointsIntMultiplier { get; init; }
+
+        public required int IncreasedPersonalSkillPointsIntMultiplier { get; init; }
+
+        public required int StartingSkillCapPercent { get; init; }
+    }
+}

--- a/src/Brp.Data/NoirExperienceRuleset.cs
+++ b/src/Brp.Data/NoirExperienceRuleset.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using Brp.Rules.Advancement;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's Layer 3 advancement parameters from embedded JSON. The source is
+/// Ch 5: System, "Skill Training" (p.139) -- see <see cref="ExperienceRuleset"/>'s own
+/// members for the exact citation of each value.
+/// </summary>
+public static class NoirExperienceRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable experience ruleset view from the shipped data.</summary>
+    public static ExperienceRuleset Load()
+    {
+        var assembly = typeof(NoirExperienceRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.experience-ruleset.json")
+            ?? throw new InvalidOperationException("The experience ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<ExperienceRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The experience ruleset data is empty.");
+
+        return new ExperienceRuleset(data.TrainingCapPercent);
+    }
+
+    private sealed class ExperienceRulesetData
+    {
+        public required int TrainingCapPercent { get; init; }
+    }
+}

--- a/src/Brp.Data/background-packages.json
+++ b/src/Brp.Data/background-packages.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "Placeholder Investigator (test fixture -- not a Layer 5 noir package)",
+    "professionalSkillPoints": {
+      "Research": 40,
+      "Streetwise": 30,
+      "Insight": 25,
+      "Spot": 20,
+      "First Aid": 20,
+      "Persuade": 15,
+      "Drive": 10,
+      "Locksmith": 10
+    }
+  }
+]

--- a/src/Brp.Data/character-creation-ruleset.json
+++ b/src/Brp.Data/character-creation-ruleset.json
@@ -1,0 +1,19 @@
+{
+  "characteristicPointPool": 24,
+  "startingCharacteristicValue": 10,
+  "characteristicCreationMaximum": 21,
+  "characteristicCosts": {
+    "STR": 1,
+    "CON": 1,
+    "SIZ": 1,
+    "CHA": 1,
+    "DEX": 3,
+    "INT": 3,
+    "POW": 3
+  },
+  "freeShiftPoints": 3,
+  "professionalSkillPoints": 250,
+  "personalSkillPointsIntMultiplier": 10,
+  "increasedPersonalSkillPointsIntMultiplier": 15,
+  "startingSkillCapPercent": 75
+}

--- a/src/Brp.Data/experience-ruleset.json
+++ b/src/Brp.Data/experience-ruleset.json
@@ -1,0 +1,3 @@
+{
+  "trainingCapPercent": 75
+}

--- a/src/Brp.Rules/Advancement/CaseExperienceLedger.cs
+++ b/src/Brp.Rules/Advancement/CaseExperienceLedger.cs
@@ -1,0 +1,24 @@
+using Brp.Core.Skills;
+
+namespace Brp.Rules.Advancement;
+
+/// <summary>
+/// Tracks which skills have already earned an experience check during the current case, so
+/// <see cref="ExperienceSystem.RecordUse"/> can enforce Ch 5: System, "Skill Improvement"
+/// (p.138): "An experience check for a particular skill is made only once per adventure, no
+/// matter how many times the skill is successfully used." One ledger is scoped to one case;
+/// create a fresh one when a new case opens.
+/// </summary>
+public sealed class CaseExperienceLedger
+{
+    private readonly HashSet<SkillId> _ticked = [];
+
+    /// <summary>Whether this skill has already recorded a tick this case.</summary>
+    public bool HasTicked(SkillId id) => _ticked.Contains(id);
+
+    /// <summary>
+    /// Records a tick for this skill if it has not already ticked this case.
+    /// Returns <see langword="true"/> if this call newly recorded the tick.
+    /// </summary>
+    public bool TryTick(SkillId id) => _ticked.Add(id);
+}

--- a/src/Brp.Rules/Advancement/CheckStakes.cs
+++ b/src/Brp.Rules/Advancement/CheckStakes.cs
@@ -1,0 +1,24 @@
+namespace Brp.Rules.Advancement;
+
+/// <summary>
+/// What a skill check was made under, for <see cref="ExperienceSystem"/>'s mechanical
+/// no-stakes gate. Ch 5: System, "Skill Improvement" (p.138): "If a skill roll was Easy, no
+/// experience check is allowed" and "[the gamemaster] should almost always allow experience
+/// checks whenever skills are successfully used in stressful situations. An attack against a
+/// helpless target is not a stressful situation and does not deserve an experience check."
+/// The book leaves that second judgment to a gamemaster; NoiRPG has none at runtime, so the
+/// scenario/resolution layer (not this type) is responsible for classifying every check
+/// before it reaches <see cref="ExperienceSystem"/> -- this enum only records the result of
+/// that classification.
+/// </summary>
+public enum CheckStakes
+{
+    /// <summary>Nothing consequential rode on this check -- never eligible for a tick.</summary>
+    NoStakes,
+
+    /// <summary>Ch 5 p.138's Easy exemption -- never eligible for a tick.</summary>
+    Easy,
+
+    /// <summary>A genuine, consequential check -- eligible for a tick per <see cref="ExperiencePolicy"/>.</summary>
+    RealStakes,
+}

--- a/src/Brp.Rules/Advancement/ExperiencePolicy.cs
+++ b/src/Brp.Rules/Advancement/ExperiencePolicy.cs
@@ -1,0 +1,26 @@
+namespace Brp.Rules.Advancement;
+
+/// <summary>
+/// Which gate <see cref="ExperienceSystem.RecordUse"/> applies to a real-stakes check. Names
+/// and behavior are kept in step with <c>tools/advancement_sim.py</c>'s two simulated
+/// variants ("A RAW (tick on success)" and "B tick on use") so the simulation stays a valid
+/// sanity check against this implementation.
+/// </summary>
+public enum ExperiencePolicy
+{
+    /// <summary>
+    /// NoiRPG's locked default (`noir-rpg-framework.md` v0.2, `AGENTS.md`): a real-stakes
+    /// check ticks whether it succeeded or failed. A deliberate house-rule deviation from
+    /// BRP RAW -- validated by <c>tools/advancement_sim.py</c> across 10,000 simulated
+    /// characters -- adopted because RAW ticks are "nearly invisible at video-game length"
+    /// and "starve low skills, which rarely succeed and so rarely tick."
+    /// </summary>
+    TickOnUse,
+
+    /// <summary>
+    /// Ch 5: System, "Skill Improvement" (p.138): "If a skill is used successfully, you
+    /// almost always get an experience check" -- a tick requires success. The RAW toggle,
+    /// kept so <c>tools/advancement_sim.py</c>'s "RAW" scenario stays reproducible.
+    /// </summary>
+    RawTickOnSuccess,
+}

--- a/src/Brp.Rules/Advancement/ExperienceRuleset.cs
+++ b/src/Brp.Rules/Advancement/ExperienceRuleset.cs
@@ -1,0 +1,31 @@
+namespace Brp.Rules.Advancement;
+
+/// <summary>
+/// Ruleset data <see cref="ExperienceSystem"/> reads for advancement parameters the book
+/// treats as campaign-tunable, loaded the same way <c>Creation.CharacterCreationRuleset</c>
+/// is (AGENTS.md invariant 7: rules values are data, not constants).
+/// </summary>
+public sealed class ExperienceRuleset
+{
+    /// <summary>Creates an experience ruleset from data-defined values.</summary>
+    public ExperienceRuleset(int trainingCapPercent)
+    {
+        TrainingCapPercent = trainingCapPercent;
+    }
+
+    /// <summary>
+    /// Ch 5: System, "Skill Training" (p.139): "No skill can be trained above 75%, no matter
+    /// how good the instructor. Any increase above this must come through successful use of
+    /// the skill." Read by <see cref="ExperienceSystem.Teach"/> to cap a training gain.
+    /// <para>
+    /// Deliberately a separate field from
+    /// <c>Creation.CharacterCreationRuleset.StartingSkillCapPercent</c> even though the book
+    /// prints 75% for both at Normal power level: that field gates what a skill may start at
+    /// during character creation (Ch 2 p.8); this one gates what teaching alone may raise an
+    /// existing skill to during play (Ch 5 p.139). They are two different rules that happen
+    /// to share a number, not one rule read from two places -- a campaign that changes power
+    /// level, for instance, can move one without moving the other.
+    /// </para>
+    /// </summary>
+    public int TrainingCapPercent { get; }
+}

--- a/src/Brp.Rules/Advancement/ExperienceSystem.cs
+++ b/src/Brp.Rules/Advancement/ExperienceSystem.cs
@@ -1,5 +1,6 @@
 using Brp.Core.Primitives;
 using Brp.Core.Randomness;
+using Brp.Core.Resolution;
 using Brp.Core.Skills;
 using Brp.Rules.Characters;
 
@@ -8,11 +9,11 @@ namespace Brp.Rules.Advancement;
 /// <summary>
 /// Tick-on-use experience: records a skill's use during a case, and resolves the improvement
 /// roll at case close. Sourced to Ch 5: System, "Skill Improvement", "Making an Experience
-/// Roll", "Increasing Skills by Experience", and "Training and Study" (pp.138-140), except
-/// where noted as the tick-on-use house rule (see <see cref="ExperiencePolicy.TickOnUse"/>
-/// and `noir-rpg-framework.md` v0.2). All randomness is drawn from the injected
-/// <see cref="IEntropySource"/> (AGENTS.md invariant 5) -- nothing here calls
-/// <c>System.Random</c> or reads the clock.
+/// Roll", "Increasing Skills by Experience", "Exceeding 100% in a Skill", and "Skill Training
+/// and Research" (pp.138-140), except where noted as the tick-on-use house rule (see
+/// <see cref="ExperiencePolicy.TickOnUse"/> and `noir-rpg-framework.md` v0.2). All randomness
+/// is drawn from the injected <see cref="IEntropySource"/> (AGENTS.md invariant 5) -- nothing
+/// here calls <c>System.Random</c> or reads the clock.
 /// </summary>
 public static class ExperienceSystem
 {
@@ -63,13 +64,25 @@ public static class ExperienceSystem
     /// Experience Roll"): a no-op if the skill carries no experience check; otherwise draws a
     /// d100, adds <paramref name="experienceBonus"/> to the roll (never to the gain -- "The
     /// experience bonus is not added to the actual skill points gained, just to the roll"),
-    /// and raises the rating by a further die roll if the result exceeds the current rating.
+    /// and raises the rating by a further die roll if the roll beats the success threshold.
     /// The experience check is cleared either way. Returns the points gained (0 if none).
     /// <para>
+    /// Ch 5 p.138, "Exceeding 100% in a Skill": once a skill is at or above 100%, an
+    /// unmodified d100 can never again roll "higher than your character's current skill
+    /// rating" -- the printed rating has outrun the die. The book replaces the ordinary
+    /// comparison with a fixed threshold at that point: "you must roll over 100 on D100 ...
+    /// which means the experience modifier is necessary [to get there] ... [but] no matter
+    /// how much over 100% the skill has risen, any roll of 100 or over earns a skill
+    /// improvement." A skill this high is reachable under tick-on-use over a campaign (the
+    /// book does not cut skills at 100%, and NoiRPG does not either), so the threshold is
+    /// capped at 100 rather than at the (possibly much higher) current rating.
+    /// </para>
+    /// <para>
     /// <paramref name="experienceBonus"/> defaults to 0, which is the form
-    /// <c>tools/advancement_sim.py</c> simulates. Passing a character's
+    /// <c>tools/advancement_sim.py</c> simulates (updated alongside this fix to share the
+    /// same 100%-cap rule, so the two stay reconciled). Passing a character's
     /// <see cref="Core.Abilities.AbilitySet.ExperienceBonus"/> reproduces Ch 5's printed rule
-    /// exactly.
+    /// exactly, including the 100%-and-above case.
     /// </para>
     /// </summary>
     public static int ImprovementRoll(
@@ -86,7 +99,13 @@ public static class ExperienceSystem
         var roll = entropy.NextD100() + experienceBonus;
         skill.ClearExperienceCheck();
 
-        if (roll <= skill.CurrentRating)
+        // Below 100%, the ordinary rule applies: strictly higher than the current rating.
+        // At or above 100%, the threshold is pinned at 100 -- a raw d100 (max 100, since a
+        // printed 00 reads as 100) can still just reach it, matching "any roll of 100 or
+        // over earns a skill improvement."
+        var cappedThreshold = Math.Min(skill.CurrentRating, 100);
+        var succeeded = cappedThreshold >= 100 ? roll >= 100 : roll > cappedThreshold;
+        if (!succeeded)
         {
             return 0;
         }
@@ -124,25 +143,57 @@ public static class ExperienceSystem
     }
 
     /// <summary>
-    /// Ch 5 p.138, "Training and Study": a teacher attempts a Teach roll against
-    /// <paramref name="teacherTeachChance"/>; on success the student's skill rises by a die
-    /// roll. A failed roll grants no benefit. The book's fumble consequence (the teacher
-    /// causing the student self-injury) is not modeled -- that is a combat/injury effect
-    /// (Layer 4, #21), out of scope here.
+    /// Ch 5 p.138, "Skill Training and Research" / "Skill Training": a teacher attempts an
+    /// ordinary skill roll against <paramref name="teacherTeachChance"/>, graded through the
+    /// same five-grade resolution every other skill roll uses (Ch 5: System, "Evaluating
+    /// Success or Failure", pp.127-128). A success (Success, Special, or Critical -- the book
+    /// does not distinguish between them for teaching) raises the student's skill by a die
+    /// roll, capped so training alone can never carry it above
+    /// <paramref name="trainingCapPercent"/>: "No skill can be trained above 75%, no matter
+    /// how good the instructor. Any increase above this must come through successful use of
+    /// the skill." A plain failure grants nothing. A fumble is counterproductive: "the
+    /// teacher caus[es] self-doubt and contradict[s] your character's prior learnings,
+    /// reducing the skill by -1D3."
+    /// <para>
+    /// Returns the signed change actually applied to the student's rating: positive for a
+    /// successful lesson (0 if the skill was already at or above the training cap), negative
+    /// for a fumble, 0 for a plain failure.
+    /// </para>
     /// </summary>
-    public static bool Teach(
-        CharacterSkill studentSkill, Percent teacherTeachChance, IEntropySource entropy, int gainDieSides = 6)
+    public static int Teach(
+        CharacterSkill studentSkill,
+        Percent teacherTeachChance,
+        IEntropySource entropy,
+        int gainDieSides = 6,
+        int trainingCapPercent = 75,
+        int fumbleDieSides = 3)
     {
         ArgumentNullException.ThrowIfNull(studentSkill);
         ArgumentNullException.ThrowIfNull(entropy);
 
         var roll = entropy.NextD100();
-        if (roll > teacherTeachChance.Value)
+        var outcome = SkillResolver.Resolve(teacherTeachChance, teacherTeachChance, roll);
+
+        if (outcome.Level == SuccessLevel.Fumble)
         {
-            return false;
+            var penalty = entropy.NextDie(fumbleDieSides);
+            var before = studentSkill.CurrentRating;
+            studentSkill.Degrade(penalty);
+            return studentSkill.CurrentRating - before;
         }
 
-        studentSkill.Improve(entropy.NextDie(gainDieSides));
-        return true;
+        if (!outcome.Succeeded)
+        {
+            return 0;
+        }
+
+        var die = entropy.NextDie(gainDieSides);
+        var gain = Math.Clamp(trainingCapPercent - studentSkill.CurrentRating, 0, die);
+        if (gain > 0)
+        {
+            studentSkill.Improve(gain);
+        }
+
+        return gain;
     }
 }

--- a/src/Brp.Rules/Advancement/ExperienceSystem.cs
+++ b/src/Brp.Rules/Advancement/ExperienceSystem.cs
@@ -143,17 +143,18 @@ public static class ExperienceSystem
     }
 
     /// <summary>
-    /// Ch 5 p.138, "Skill Training and Research" / "Skill Training": a teacher attempts an
-    /// ordinary skill roll against <paramref name="teacherTeachChance"/>, graded through the
-    /// same five-grade resolution every other skill roll uses (Ch 5: System, "Evaluating
+    /// Ch 5 p.138-139, "Skill Training and Research" / "Skill Training": a teacher attempts
+    /// an ordinary skill roll against <paramref name="teacherTeachChance"/>, graded through
+    /// the same five-grade resolution every other skill roll uses (Ch 5: System, "Evaluating
     /// Success or Failure", pp.127-128). A success (Success, Special, or Critical -- the book
     /// does not distinguish between them for teaching) raises the student's skill by a die
     /// roll, capped so training alone can never carry it above
-    /// <paramref name="trainingCapPercent"/>: "No skill can be trained above 75%, no matter
-    /// how good the instructor. Any increase above this must come through successful use of
-    /// the skill." A plain failure grants nothing. A fumble is counterproductive: "the
-    /// teacher caus[es] self-doubt and contradict[s] your character's prior learnings,
-    /// reducing the skill by -1D3."
+    /// <paramref name="ruleset"/>'s <see cref="ExperienceRuleset.TrainingCapPercent"/>
+    /// (75% per Ch 5 p.139 -- see that property for why this is a ruleset field and not the
+    /// same number as <c>Creation.CharacterCreationRuleset.StartingSkillCapPercent</c>). A
+    /// plain failure grants nothing. A fumble is counterproductive: "the teacher caus[es]
+    /// self-doubt and contradict[s] your character's prior learnings, reducing the skill by
+    /// -1D3."
     /// <para>
     /// Returns the signed change actually applied to the student's rating: positive for a
     /// successful lesson (0 if the skill was already at or above the training cap), negative
@@ -164,12 +165,13 @@ public static class ExperienceSystem
         CharacterSkill studentSkill,
         Percent teacherTeachChance,
         IEntropySource entropy,
+        ExperienceRuleset ruleset,
         int gainDieSides = 6,
-        int trainingCapPercent = 75,
         int fumbleDieSides = 3)
     {
         ArgumentNullException.ThrowIfNull(studentSkill);
         ArgumentNullException.ThrowIfNull(entropy);
+        ArgumentNullException.ThrowIfNull(ruleset);
 
         var roll = entropy.NextD100();
         var outcome = SkillResolver.Resolve(teacherTeachChance, teacherTeachChance, roll);
@@ -188,7 +190,7 @@ public static class ExperienceSystem
         }
 
         var die = entropy.NextDie(gainDieSides);
-        var gain = Math.Clamp(trainingCapPercent - studentSkill.CurrentRating, 0, die);
+        var gain = Math.Clamp(ruleset.TrainingCapPercent - studentSkill.CurrentRating, 0, die);
         if (gain > 0)
         {
             studentSkill.Improve(gain);

--- a/src/Brp.Rules/Advancement/ExperienceSystem.cs
+++ b/src/Brp.Rules/Advancement/ExperienceSystem.cs
@@ -1,0 +1,148 @@
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+using Brp.Core.Skills;
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Advancement;
+
+/// <summary>
+/// Tick-on-use experience: records a skill's use during a case, and resolves the improvement
+/// roll at case close. Sourced to Ch 5: System, "Skill Improvement", "Making an Experience
+/// Roll", "Increasing Skills by Experience", and "Training and Study" (pp.138-140), except
+/// where noted as the tick-on-use house rule (see <see cref="ExperiencePolicy.TickOnUse"/>
+/// and `noir-rpg-framework.md` v0.2). All randomness is drawn from the injected
+/// <see cref="IEntropySource"/> (AGENTS.md invariant 5) -- nothing here calls
+/// <c>System.Random</c> or reads the clock.
+/// </summary>
+public static class ExperienceSystem
+{
+    /// <summary>
+    /// Records one skill's use under <paramref name="stakes"/>, applying the mechanical gate:
+    /// an Easy or no-stakes check is never eligible (Ch 5 p.138), and under
+    /// <see cref="ExperiencePolicy.RawTickOnSuccess"/> an unsuccessful check is not eligible
+    /// either. Enforces "once per case" via <paramref name="ledger"/>. Returns
+    /// <see langword="true"/> only if this call newly recorded a tick.
+    /// </summary>
+    public static bool RecordUse(
+        CaseExperienceLedger ledger,
+        CharacterSkill skill,
+        CheckStakes stakes,
+        bool succeeded,
+        ExperiencePolicy policy = ExperiencePolicy.TickOnUse)
+    {
+        ArgumentNullException.ThrowIfNull(ledger);
+        ArgumentNullException.ThrowIfNull(skill);
+
+        // Ch 5 p.138: "If a skill roll was Easy, no experience check is allowed." The
+        // "nothing at stake" gate is the same mechanical refusal for a check the scenario
+        // layer classified as carrying no consequence -- there is no gamemaster here to
+        // adjudicate either exemption by hand, so both are refused unconditionally.
+        if (stakes != CheckStakes.RealStakes)
+        {
+            return false;
+        }
+
+        // The only difference between the two policies: RAW requires success, tick-on-use
+        // does not. Nothing else about the gate or the ledger changes between them.
+        if (policy == ExperiencePolicy.RawTickOnSuccess && !succeeded)
+        {
+            return false;
+        }
+
+        if (!ledger.TryTick(skill.Definition.Id))
+        {
+            return false;
+        }
+
+        skill.MarkExperienceCheck();
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves one skill's improvement roll at case close (Ch 5 p.138, "Making an
+    /// Experience Roll"): a no-op if the skill carries no experience check; otherwise draws a
+    /// d100, adds <paramref name="experienceBonus"/> to the roll (never to the gain -- "The
+    /// experience bonus is not added to the actual skill points gained, just to the roll"),
+    /// and raises the rating by a further die roll if the result exceeds the current rating.
+    /// The experience check is cleared either way. Returns the points gained (0 if none).
+    /// <para>
+    /// <paramref name="experienceBonus"/> defaults to 0, which is the form
+    /// <c>tools/advancement_sim.py</c> simulates. Passing a character's
+    /// <see cref="Core.Abilities.AbilitySet.ExperienceBonus"/> reproduces Ch 5's printed rule
+    /// exactly.
+    /// </para>
+    /// </summary>
+    public static int ImprovementRoll(
+        CharacterSkill skill, IEntropySource entropy, int gainDieSides = 6, int experienceBonus = 0)
+    {
+        ArgumentNullException.ThrowIfNull(skill);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        if (!skill.HasExperienceCheck)
+        {
+            return 0;
+        }
+
+        var roll = entropy.NextD100() + experienceBonus;
+        skill.ClearExperienceCheck();
+
+        if (roll <= skill.CurrentRating)
+        {
+            return 0;
+        }
+
+        var gain = entropy.NextDie(gainDieSides);
+        skill.Improve(gain);
+        return gain;
+    }
+
+    /// <summary>
+    /// Resolves the improvement roll for every skill on <paramref name="character"/> that
+    /// carries an experience check, in a stable order keyed by <see cref="SkillId"/> so the
+    /// draw sequence -- and therefore the resulting roll log -- is reproducible for a given
+    /// seed. Returns each ticked skill's gain (0 for a failed improvement roll).
+    /// </summary>
+    public static IReadOnlyDictionary<SkillId, int> CloseCase(
+        Character character, IEntropySource entropy, int gainDieSides = 6, bool includeExperienceBonus = false)
+    {
+        ArgumentNullException.ThrowIfNull(character);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var results = new Dictionary<SkillId, int>();
+        var bonus = includeExperienceBonus ? character.Abilities.ExperienceBonus : 0;
+        foreach (var (id, skill) in character.Skills.OrderBy(pair => pair.Key.Value, StringComparer.Ordinal))
+        {
+            if (!skill.HasExperienceCheck)
+            {
+                continue;
+            }
+
+            results[id] = ImprovementRoll(skill, entropy, gainDieSides, bonus);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Ch 5 p.138, "Training and Study": a teacher attempts a Teach roll against
+    /// <paramref name="teacherTeachChance"/>; on success the student's skill rises by a die
+    /// roll. A failed roll grants no benefit. The book's fumble consequence (the teacher
+    /// causing the student self-injury) is not modeled -- that is a combat/injury effect
+    /// (Layer 4, #21), out of scope here.
+    /// </summary>
+    public static bool Teach(
+        CharacterSkill studentSkill, Percent teacherTeachChance, IEntropySource entropy, int gainDieSides = 6)
+    {
+        ArgumentNullException.ThrowIfNull(studentSkill);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var roll = entropy.NextD100();
+        if (roll > teacherTeachChance.Value)
+        {
+            return false;
+        }
+
+        studentSkill.Improve(entropy.NextDie(gainDieSides));
+        return true;
+    }
+}

--- a/src/Brp.Rules/Brp.Rules.csproj
+++ b/src/Brp.Rules/Brp.Rules.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="../Brp.Core/BannedSymbols.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Brp.Core\Brp.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Brp.Rules/Characters/Character.cs
+++ b/src/Brp.Rules/Characters/Character.cs
@@ -1,0 +1,78 @@
+using Brp.Core.Abilities;
+using Brp.Core.Skills;
+
+namespace Brp.Rules.Characters;
+
+/// <summary>
+/// A whole character: identity, a Layer 1 <see cref="AbilitySet"/>, a set of Layer 2
+/// skill instances with their own current ratings and experience flags, a wound list, and
+/// equipment. Ch 2: Characters, "Derived Characteristics" (p.13) requires hit points to
+/// change immediately after a characteristic changes, so this type never caches HP -- it
+/// reads <see cref="AbilitySet.CurrentHitPoints"/> and <see cref="AbilitySet.MaximumHitPoints"/>
+/// live from <see cref="Abilities"/> on every access.
+/// <para>
+/// Deliberately absent: any spendable power-point pool, Fate Points, or PP reservoir.
+/// Ch 4: Powers is cut in full (<c>orc-scope-filter.md</c>); POW remains a characteristic
+/// (it still drives the Luck roll and POW-vs-POW resistance) but nothing here spends it.
+/// </para>
+/// </summary>
+public sealed class Character
+{
+    /// <summary>Creates a character from an already-built ability set and skill set.</summary>
+    public Character(
+        CharacterId id,
+        string name,
+        AbilitySet abilities,
+        IReadOnlyDictionary<SkillId, CharacterSkill> skills)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        ArgumentNullException.ThrowIfNull(skills);
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Character name must not be empty.", nameof(name));
+        }
+
+        Id = id;
+        Name = name;
+        Abilities = abilities;
+        Skills = skills;
+        Wounds = new WoundTrack();
+        Equipment = new EquipmentList();
+    }
+
+    /// <summary>This character's stable identifier.</summary>
+    public CharacterId Id { get; }
+
+    /// <summary>The character's name.</summary>
+    public string Name { get; }
+
+    /// <summary>The Layer 1 characteristic set this character's skills and HP are computed from.</summary>
+    public AbilitySet Abilities { get; }
+
+    /// <summary>Every skill instance this character has, keyed by its canonical <see cref="SkillId"/>.</summary>
+    public IReadOnlyDictionary<SkillId, CharacterSkill> Skills { get; }
+
+    /// <summary>Structural container for wounds (Layer 4 supplies the mechanics).</summary>
+    public WoundTrack Wounds { get; }
+
+    /// <summary>Reference-only container for carried equipment (Layer 4/8 supplies gear stats).</summary>
+    public EquipmentList Equipment { get; }
+
+    /// <summary>
+    /// Live current hit points, read from <see cref="Abilities"/> on every access so a
+    /// characteristic change (e.g. CON lost to poison) is reflected without this type doing
+    /// anything -- Ch 2 p.13's "changes immediately" requirement.
+    /// </summary>
+    public int CurrentHitPoints => Abilities.CurrentHitPoints;
+
+    /// <summary>Live maximum hit points, recomputed from <see cref="Abilities"/> on every access.</summary>
+    public int MaximumHitPoints => Abilities.MaximumHitPoints;
+
+    /// <summary>Looks up a skill instance by its canonical id, throwing if this character does not have it.</summary>
+    public CharacterSkill Skill(SkillId id) => Skills.TryGetValue(id, out var skill)
+        ? skill
+        : throw new KeyNotFoundException($"Character '{Name}' has no skill '{id}'.");
+
+    /// <summary>Whether this character has a given skill at all -- the "has / does not have" question (#6).</summary>
+    public bool HasSkill(SkillId id) => Skills.ContainsKey(id);
+}

--- a/src/Brp.Rules/Characters/CharacterId.cs
+++ b/src/Brp.Rules/Characters/CharacterId.cs
@@ -1,0 +1,27 @@
+namespace Brp.Rules.Characters;
+
+/// <summary>
+/// A stable identifier for a <see cref="Character"/>. Mirrors the identifier pattern used
+/// for <c>CharacteristicId</c> and <c>SkillId</c> in <c>Brp.Core</c>: a thin wrapper over a
+/// caller-supplied string rather than a database-generated key, since Layer 3 has no
+/// persistence concept of its own.
+/// </summary>
+public readonly record struct CharacterId
+{
+    /// <summary>Creates an identifier from a caller-chosen value.</summary>
+    public CharacterId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Character id must not be empty.", nameof(value));
+        }
+
+        Value = value;
+    }
+
+    /// <summary>The identifier's value.</summary>
+    public string Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}

--- a/src/Brp.Rules/Characters/CharacterSkill.cs
+++ b/src/Brp.Rules/Characters/CharacterSkill.cs
@@ -1,0 +1,58 @@
+using Brp.Core.Abilities;
+using Brp.Core.Primitives;
+using Brp.Core.Skills;
+
+namespace Brp.Rules.Characters;
+
+/// <summary>
+/// One skill instance belonging to a <see cref="Character"/>: a reference to its Layer 2
+/// <see cref="SkillDefinition"/>, its own mutable current rating, and a per-skill experience
+/// flag. This is Layer 2's "two-number contract" (<c>SkillRoll</c>) made concrete for a
+/// single character -- <see cref="Definition"/> supplies the printed base chance
+/// (<see cref="PrintedBaseChance"/>), while <see cref="CurrentRating"/> is the character's own,
+/// distinct number set by <see cref="Creation.CharacterBuilder"/> and moved afterward only by
+/// <see cref="Advancement.ExperienceSystem"/>.
+/// </summary>
+public sealed class CharacterSkill
+{
+    /// <summary>Creates a skill instance at a starting rating.</summary>
+    public CharacterSkill(SkillDefinition definition, int currentRating)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        Definition = definition;
+        CurrentRating = currentRating;
+    }
+
+    /// <summary>The Layer 2 skill this instance resolves against.</summary>
+    public SkillDefinition Definition { get; }
+
+    /// <summary>
+    /// The character's current rating -- distinct from <see cref="PrintedBaseChance"/>.
+    /// Set by creation, and moved only by an <see cref="Advancement.ExperienceSystem"/>
+    /// improvement roll or teaching, never directly.
+    /// </summary>
+    public int CurrentRating { get; private set; }
+
+    /// <summary>
+    /// Ch 5: System, "Skill Improvement" (p.138): whether this skill carries an experience
+    /// check awaiting an improvement roll at case close. Set by
+    /// <see cref="Advancement.ExperienceSystem"/>, mechanically gated -- there is no
+    /// gamemaster to award or withhold it by hand.
+    /// </summary>
+    public bool HasExperienceCheck { get; private set; }
+
+    /// <summary>This skill's printed base chance, evaluated against a character's abilities.</summary>
+    public Percent PrintedBaseChance(AbilitySet abilities) => Definition.BaseChanceFor(abilities);
+
+    /// <summary>Sets the current rating directly. Creation-time only; advancement uses <see cref="Improve"/>.</summary>
+    internal void SetRating(int rating) => CurrentRating = rating;
+
+    /// <summary>Marks this skill as carrying an unresolved experience check.</summary>
+    internal void MarkExperienceCheck() => HasExperienceCheck = true;
+
+    /// <summary>Clears the experience check, whether or not the improvement roll succeeded.</summary>
+    internal void ClearExperienceCheck() => HasExperienceCheck = false;
+
+    /// <summary>Raises the current rating by a gain from a successful improvement roll or teaching.</summary>
+    internal void Improve(int gain) => CurrentRating += Math.Max(0, gain);
+}

--- a/src/Brp.Rules/Characters/CharacterSkill.cs
+++ b/src/Brp.Rules/Characters/CharacterSkill.cs
@@ -55,4 +55,11 @@ public sealed class CharacterSkill
 
     /// <summary>Raises the current rating by a gain from a successful improvement roll or teaching.</summary>
     internal void Improve(int gain) => CurrentRating += Math.Max(0, gain);
+
+    /// <summary>
+    /// Lowers the current rating -- Ch 5: System, "Skill Training" (p.138): a teaching
+    /// fumble "reduc[es] the skill by -1D3." Floors at zero rather than letting a rating go
+    /// negative, which the book never contemplates.
+    /// </summary>
+    internal void Degrade(int amount) => CurrentRating = Math.Max(0, CurrentRating - Math.Max(0, amount));
 }

--- a/src/Brp.Rules/Characters/EquipmentItem.cs
+++ b/src/Brp.Rules/Characters/EquipmentItem.cs
@@ -1,0 +1,10 @@
+namespace Brp.Rules.Characters;
+
+/// <summary>
+/// A reference to an item a character carries. Deliberately name-only: gear stats (weapon
+/// damage, armor value, ranges) are Layer 4/8 (#21) and do not exist yet. This lets
+/// <see cref="Character"/> carry "what the player is holding" as a list of names without
+/// inventing a stats schema this issue was not asked to design.
+/// </summary>
+/// <param name="Name">A free-text label for the item, e.g. "revolver" or "flashlight".</param>
+public sealed record EquipmentItem(string Name);

--- a/src/Brp.Rules/Characters/EquipmentList.cs
+++ b/src/Brp.Rules/Characters/EquipmentList.cs
@@ -1,0 +1,23 @@
+namespace Brp.Rules.Characters;
+
+/// <summary>
+/// A character's equipment: a reference-only container of <see cref="EquipmentItem"/>
+/// entries, carrying no gear stats (see <see cref="EquipmentItem"/>).
+/// </summary>
+public sealed class EquipmentList
+{
+    private readonly List<EquipmentItem> _items = [];
+
+    /// <summary>Every item currently carried, in the order added.</summary>
+    public IReadOnlyList<EquipmentItem> Items => _items;
+
+    /// <summary>Adds an item.</summary>
+    public void Add(EquipmentItem item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        _items.Add(item);
+    }
+
+    /// <summary>Removes an item (e.g. lost, sold, confiscated).</summary>
+    public bool Remove(EquipmentItem item) => _items.Remove(item);
+}

--- a/src/Brp.Rules/Characters/Wound.cs
+++ b/src/Brp.Rules/Characters/Wound.cs
@@ -1,0 +1,10 @@
+namespace Brp.Rules.Characters;
+
+/// <summary>
+/// A single entry in a character's wound list. Structure only: this issue (#40) builds the
+/// container a <see cref="Character"/> carries, not the mechanics that populate or resolve it
+/// (First Aid per wound, Major Wounds, hit locations) -- those are Layer 4 (#21).
+/// Deliberately minimal so nothing here presumes a mechanic that has not been decided yet.
+/// </summary>
+/// <param name="Description">A free-text note of what happened, for the game layer to render.</param>
+public sealed record Wound(string Description);

--- a/src/Brp.Rules/Characters/WoundTrack.cs
+++ b/src/Brp.Rules/Characters/WoundTrack.cs
@@ -1,0 +1,25 @@
+namespace Brp.Rules.Characters;
+
+/// <summary>
+/// A character's wound list. A plain container -- add, read, remove -- carrying no wound
+/// mechanics of its own (see <see cref="Wound"/>). Layer 4 (#21) will decide what populates
+/// and resolves this list; Layer 3 only guarantees a <see cref="Character"/> has somewhere to
+/// keep it.
+/// </summary>
+public sealed class WoundTrack
+{
+    private readonly List<Wound> _wounds = [];
+
+    /// <summary>Every wound currently recorded, in the order added.</summary>
+    public IReadOnlyList<Wound> Wounds => _wounds;
+
+    /// <summary>Records a new wound.</summary>
+    public void Add(Wound wound)
+    {
+        ArgumentNullException.ThrowIfNull(wound);
+        _wounds.Add(wound);
+    }
+
+    /// <summary>Removes a previously recorded wound (e.g. once healed).</summary>
+    public bool Remove(Wound wound) => _wounds.Remove(wound);
+}

--- a/src/Brp.Rules/Creation/BackgroundPackage.cs
+++ b/src/Brp.Rules/Creation/BackgroundPackage.cs
@@ -1,0 +1,24 @@
+using Brp.Core.Skills;
+
+namespace Brp.Rules.Creation;
+
+/// <summary>
+/// A Freeform Profession package: a data-defined name plus a professional skill-point
+/// allocation, applied during creation exactly like the book's named professions
+/// ("Professions A Through Z", pp.17 onward -- "Your character will spend their professional
+/// skill points on these skills"), except the skill list and point spend are player/author
+/// -defined rather than one of the book's printed entries. Sourced: the "Freeform Professions
+/// (Option)" checklist entry (p.229): "Useful for customized, difficult-to-categorize player
+/// characters" -- the book gives no further mechanic beyond that description, so a freeform
+/// package reuses the ordinary professional-skill-point mechanic rather than inventing a new
+/// one. The actual noir packages (ex-cop, ex-journalist, etc.) are Layer 5 content authored
+/// against this mechanism; this type and its loaded data are the mechanism only.
+/// </summary>
+/// <param name="Name">The package's display name.</param>
+/// <param name="ProfessionalSkillPoints">
+/// Points from the professional skill-point pool pre-assigned to specific skills, keyed by
+/// canonical <see cref="SkillId"/>. Must not exceed the ruleset's professional skill-point
+/// total; <see cref="CharacterBuilder"/> enforces this at apply time, alongside the pool's
+/// remaining budget for any further profession points the builder allocates.
+/// </param>
+public sealed record BackgroundPackage(string Name, IReadOnlyDictionary<SkillId, int> ProfessionalSkillPoints);

--- a/src/Brp.Rules/Creation/CharacterBuilder.cs
+++ b/src/Brp.Rules/Creation/CharacterBuilder.cs
@@ -1,0 +1,135 @@
+using Brp.Core.Abilities;
+using Brp.Core.Primitives;
+using Brp.Core.Skills;
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Creation;
+
+/// <summary>
+/// Builds a <see cref="Character"/> by point-buy: characteristic point-buy (Ch 2 p.9-10),
+/// profession and personal skill-point allocation with Increased Personal Skill Points
+/// (Ch 2 p.8), and the 75% starting soft cap. Every numeric parameter comes from a
+/// <see cref="CharacterCreationRuleset"/> loaded as ruleset data (AGENTS.md invariant 7) --
+/// nothing here is a hardcoded book number.
+/// <para>
+/// This type builds only the point-buy path. BRP's rolled-characteristics path (Step One
+/// with 3D6/2D6+6 dice) is out of scope for this issue and is not built; nothing here
+/// prevents a future <c>RolledCharacterBuilder</c> (or an overload here) from producing the
+/// same <see cref="Character"/> shape by a different route.
+/// </para>
+/// </summary>
+public sealed class CharacterBuilder
+{
+    private readonly CharacterCreationRuleset _ruleset;
+    private readonly AbilityRuleset _abilityRuleset;
+    private readonly SkillRegistry _skillRegistry;
+
+    /// <summary>Creates a builder bound to a specific set of rulesets.</summary>
+    public CharacterBuilder(CharacterCreationRuleset ruleset, AbilityRuleset abilityRuleset, SkillRegistry skillRegistry)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(abilityRuleset);
+        ArgumentNullException.ThrowIfNull(skillRegistry);
+        _ruleset = ruleset;
+        _abilityRuleset = abilityRuleset;
+        _skillRegistry = skillRegistry;
+    }
+
+    /// <summary>Builds a complete, valid <see cref="Character"/> from a creation request.</summary>
+    public Character Build(CharacterCreationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var characteristics = CharacteristicPointBuy.Allocate(_ruleset, _abilityRuleset, request.CharacteristicDeltas);
+        if (request.CharacteristicShift.Count > 0)
+        {
+            characteristics = CharacteristicPointBuy.ApplyShift(_ruleset, _abilityRuleset, characteristics, request.CharacteristicShift);
+        }
+
+        var education = request.Education ?? _ruleset.StartingCharacteristicValue;
+        var eduId = new CharacteristicId("EDU");
+        if (_abilityRuleset.Characteristics.ContainsKey(eduId))
+        {
+            var withEdu = new Dictionary<CharacteristicId, int>(characteristics) { [eduId] = education };
+            characteristics = withEdu;
+        }
+
+        var abilities = new AbilitySet(_abilityRuleset, characteristics);
+
+        var professionalPoints = CombineSkillPoints(request.Package?.ProfessionalSkillPoints, request.AdditionalProfessionalSkillPoints);
+        ValidatePool(professionalPoints, _ruleset.ProfessionalSkillPoints, "professional");
+
+        var personalCap = abilities.ValueOf(new CharacteristicId("INT")) * (request.UseIncreasedPersonalSkillPoints
+            ? _ruleset.IncreasedPersonalSkillPointsIntMultiplier
+            : _ruleset.PersonalSkillPointsIntMultiplier);
+        ValidatePool(request.PersonalSkillPoints, personalCap, "personal");
+
+        var skills = new Dictionary<SkillId, CharacterSkill>();
+        foreach (var (id, definition) in _skillRegistry.Skills)
+        {
+            var baseChance = SafeBaseChance(definition, abilities);
+            var professional = professionalPoints.GetValueOrDefault(id);
+            var personal = request.PersonalSkillPoints.GetValueOrDefault(id);
+            var addedPoints = professional + personal;
+
+            var effectiveCap = Math.Max(_ruleset.StartingSkillCapPercent, baseChance.Value);
+            var total = baseChance.Value + addedPoints;
+            if (total > effectiveCap)
+            {
+                throw new ArgumentException(
+                    $"Skill '{definition.Name}' would start at {total}%, above the {_ruleset.StartingSkillCapPercent}% "
+                    + "starting soft cap (Ch 2 p.8) -- spend those points on another skill instead.",
+                    nameof(request));
+            }
+
+            skills[id] = new CharacterSkill(definition, total);
+        }
+
+        return new Character(request.Id, request.Name, abilities, skills);
+    }
+
+    private static Percent SafeBaseChance(SkillDefinition definition, AbilitySet abilities)
+    {
+        try
+        {
+            return definition.BaseChanceFor(abilities);
+        }
+        catch (InvalidOperationException)
+        {
+            // Weapon-derived base chances (Ch 3, "as per weapon specialty") have no
+            // standalone value until Layer 4 supplies weapon data (#21); treat as 0 rather
+            // than fail character creation over a skill this layer cannot resolve.
+            return Percent.Zero;
+        }
+    }
+
+    private static Dictionary<SkillId, int> CombineSkillPoints(
+        IReadOnlyDictionary<SkillId, int>? package, IReadOnlyDictionary<SkillId, int> additional)
+    {
+        var combined = new Dictionary<SkillId, int>();
+        if (package is not null)
+        {
+            foreach (var (id, points) in package)
+            {
+                combined[id] = combined.GetValueOrDefault(id) + points;
+            }
+        }
+
+        foreach (var (id, points) in additional)
+        {
+            combined[id] = combined.GetValueOrDefault(id) + points;
+        }
+
+        return combined;
+    }
+
+    private static void ValidatePool(IReadOnlyDictionary<SkillId, int> spend, int pool, string poolName)
+    {
+        var total = spend.Values.Sum();
+        if (total > pool)
+        {
+            throw new ArgumentException(
+                $"{poolName} skill points spent ({total}) exceed the pool of {pool}.", nameof(spend));
+        }
+    }
+}

--- a/src/Brp.Rules/Creation/CharacterCreationRequest.cs
+++ b/src/Brp.Rules/Creation/CharacterCreationRequest.cs
@@ -1,0 +1,63 @@
+using Brp.Core.Abilities;
+using Brp.Core.Skills;
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Creation;
+
+/// <summary>
+/// Everything <see cref="CharacterBuilder"/> needs to build one <see cref="Character"/> by
+/// point-buy. A plain data holder -- the builder does all the validation and derivation.
+/// </summary>
+public sealed class CharacterCreationRequest
+{
+    /// <summary>This character's stable identifier.</summary>
+    public required CharacterId Id { get; init; }
+
+    /// <summary>The character's name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Signed point-buy deltas from the ruleset's starting value, keyed by characteristic --
+    /// exactly the seven point-buy characteristics (STR, CON, SIZ, INT, POW, DEX, CHA).
+    /// </summary>
+    public required IReadOnlyDictionary<CharacteristicId, int> CharacteristicDeltas { get; init; }
+
+    /// <summary>
+    /// Optional zero-sum redistribution applied after <see cref="CharacteristicDeltas"/> --
+    /// see <see cref="CharacterCreationRuleset.FreeShiftPoints"/>. Empty by default.
+    /// </summary>
+    public IReadOnlyDictionary<CharacteristicId, int> CharacteristicShift { get; init; } =
+        new Dictionary<CharacteristicId, int>();
+
+    /// <summary>
+    /// EDU is assigned by the gamemaster from age and background (Ch 2 p.9, "Education
+    /// (Option)"), not spent from the 24-point pool; that assignment is out of this issue's
+    /// scope (see `docs/decisions/0006-skill-bonus-system.md`). Defaults to the ruleset's
+    /// starting value (10) as a neutral placeholder.
+    /// </summary>
+    public int? Education { get; init; }
+
+    /// <summary>The Freeform Profession package to apply, if any. See <see cref="BackgroundPackage"/>.</summary>
+    public BackgroundPackage? Package { get; init; }
+
+    /// <summary>
+    /// Professional skill points spent beyond the package's own allocation, keyed by skill.
+    /// Combined with the package's points, the total must not exceed
+    /// <see cref="CharacterCreationRuleset.ProfessionalSkillPoints"/>.
+    /// </summary>
+    public IReadOnlyDictionary<SkillId, int> AdditionalProfessionalSkillPoints { get; init; } =
+        new Dictionary<SkillId, int>();
+
+    /// <summary>
+    /// Personal skill points spent, keyed by skill. Total must not exceed INT times the
+    /// ruleset's personal skill-point multiplier (see <see cref="UseIncreasedPersonalSkillPoints"/>).
+    /// </summary>
+    public IReadOnlyDictionary<SkillId, int> PersonalSkillPoints { get; init; } =
+        new Dictionary<SkillId, int>();
+
+    /// <summary>
+    /// Whether to use the Increased Personal Skill Points option (`orc-scope-filter.md`: ON).
+    /// True by default -- NoiRPG's recommended Noir configuration.
+    /// </summary>
+    public bool UseIncreasedPersonalSkillPoints { get; init; } = true;
+}

--- a/src/Brp.Rules/Creation/CharacterCreationRuleset.cs
+++ b/src/Brp.Rules/Creation/CharacterCreationRuleset.cs
@@ -1,0 +1,102 @@
+using Brp.Core.Abilities;
+
+namespace Brp.Rules.Creation;
+
+/// <summary>
+/// Every numeric parameter <see cref="CharacterBuilder"/>'s point-buy path reads, kept as
+/// ruleset data rather than constants (AGENTS.md invariant 7). Sourced to Ch 2: Characters,
+/// "Point-Based Character Creation (option)" (p.9-10) for the characteristic pool, and
+/// "Step Seven: Profession and Skills" (p.8) for the skill-point figures.
+/// </summary>
+public sealed class CharacterCreationRuleset
+{
+    /// <summary>Creates a creation ruleset from data-defined values.</summary>
+    public CharacterCreationRuleset(
+        int characteristicPointPool,
+        int startingCharacteristicValue,
+        int characteristicCreationMaximum,
+        IReadOnlyDictionary<CharacteristicId, int> characteristicCosts,
+        int freeShiftPoints,
+        int professionalSkillPoints,
+        int personalSkillPointsIntMultiplier,
+        int increasedPersonalSkillPointsIntMultiplier,
+        int startingSkillCapPercent)
+    {
+        ArgumentNullException.ThrowIfNull(characteristicCosts);
+        if (characteristicCosts.Count == 0)
+        {
+            throw new ArgumentException("At least one characteristic cost is required.", nameof(characteristicCosts));
+        }
+
+        CharacteristicPointPool = characteristicPointPool;
+        StartingCharacteristicValue = startingCharacteristicValue;
+        CharacteristicCreationMaximum = characteristicCreationMaximum;
+        CharacteristicCosts = characteristicCosts;
+        FreeShiftPoints = freeShiftPoints;
+        ProfessionalSkillPoints = professionalSkillPoints;
+        PersonalSkillPointsIntMultiplier = personalSkillPointsIntMultiplier;
+        IncreasedPersonalSkillPointsIntMultiplier = increasedPersonalSkillPointsIntMultiplier;
+        StartingSkillCapPercent = startingSkillCapPercent;
+    }
+
+    /// <summary>
+    /// Ch 2 p.9: "You have 24 points to spend on characteristics. This is the equivalent of
+    /// the 'normal' power level for a campaign."
+    /// </summary>
+    public int CharacteristicPointPool { get; }
+
+    /// <summary>Ch 2 p.9: "All characteristics ... begin at 10."</summary>
+    public int StartingCharacteristicValue { get; }
+
+    /// <summary>
+    /// Ch 2 p.9: "No initial characteristic can be raised to higher than 21." This is a
+    /// creation-time ceiling distinct from <see cref="CharacteristicDefinition.Maximum"/>,
+    /// which is <see langword="null"/> for INT and POW because those two have no ceiling once
+    /// play begins (Ch 2 p.10, "Mental characteristics ... can usually be raised without
+    /// limits") -- the 21 cap applies only at character creation.
+    /// </summary>
+    public int CharacteristicCreationMaximum { get; }
+
+    /// <summary>
+    /// Ch 2 p.9: "Each point of STR, CON, SIZ, or CHA costs 1 point" and "Each point of DEX,
+    /// INT, and POW costs 3," symmetric for reductions ("For each point ... you reduce ...
+    /// you get [the same number] back"). Keyed by characteristic id.
+    /// </summary>
+    public IReadOnlyDictionary<CharacteristicId, int> CharacteristicCosts { get; }
+
+    /// <summary>
+    /// <strong>House rule, not printed for this path.</strong> Ch 2 p.8's rolled-Step-One
+    /// redistribution ("you may redistribute up to 3 points between your characteristics")
+    /// is written for the dice-rolled path. NoiRPG extends the same small post-allocation
+    /// adjustment to the point-buy path so a build can be fine-tuned without spending
+    /// additional pool points; see the ADR for this issue. Zero disables the shift entirely.
+    /// </summary>
+    public int FreeShiftPoints { get; }
+
+    /// <summary>
+    /// Ch 2 p.8, "Step Seven": Normal power level allots 250 points to professional skills.
+    /// </summary>
+    public int ProfessionalSkillPoints { get; }
+
+    /// <summary>
+    /// Ch 2 p.8: "multiply your character's INT×10 to determine their personal skill point
+    /// pool." The BRP RAW baseline.
+    /// </summary>
+    public int PersonalSkillPointsIntMultiplier { get; }
+
+    /// <summary>
+    /// Ch 2 p.8, "Increased Personal Skill Points (Option)": the book states INT×15/20/25 for
+    /// heroic/epic/superhuman tiers and is silent on a Normal-power-level increase. NoiRPG
+    /// runs at Normal power level (250 professional points, 75% cap) and borrows the heroic
+    /// tier's INT×15 personal multiplier only, per the Noir entry's recommendation
+    /// (`orc-scope-filter.md`) that the option suits "characters ... tremendously competent
+    /// and skilled beyond what their current profession would indicate." See the ADR.
+    /// </summary>
+    public int IncreasedPersonalSkillPointsIntMultiplier { get; }
+
+    /// <summary>
+    /// Ch 2 p.8: "No skill should begin higher than 75%," the Normal power level's starting
+    /// soft cap, enforced during creation only -- advancement can carry a skill past it.
+    /// </summary>
+    public int StartingSkillCapPercent { get; }
+}

--- a/src/Brp.Rules/Creation/CharacteristicPointBuy.cs
+++ b/src/Brp.Rules/Creation/CharacteristicPointBuy.cs
@@ -1,0 +1,129 @@
+using Brp.Core.Abilities;
+
+namespace Brp.Rules.Creation;
+
+/// <summary>
+/// Ch 2: Characters, "Point-Based Character Creation (option)" (pp.9-10): spends a fixed
+/// point pool across the seven point-buy characteristics (STR, CON, SIZ, INT, POW, DEX, CHA),
+/// then applies NoiRPG's optional ±<see cref="CharacterCreationRuleset.FreeShiftPoints"/>
+/// redistribution -- see that property's remarks for why this second step is a house-rule
+/// extension rather than a printed part of this option. EDU is out of scope here: the book
+/// assigns it separately from age and background (Ch 2 p.9, "Education (Option)"), which is
+/// deferred past this issue (see `docs/decisions/0006-skill-bonus-system.md`).
+/// </summary>
+public static class CharacteristicPointBuy
+{
+    /// <summary>
+    /// Spends <paramref name="deltas"/> (signed point-buy deltas from the ruleset's starting
+    /// value, keyed by characteristic) against the pool, validating cost, bounds, and the
+    /// ruleset's creation-time maximum. Returns the resulting absolute characteristic values.
+    /// </summary>
+    public static IReadOnlyDictionary<CharacteristicId, int> Allocate(
+        CharacterCreationRuleset ruleset,
+        AbilityRuleset abilityRuleset,
+        IReadOnlyDictionary<CharacteristicId, int> deltas)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(abilityRuleset);
+        ArgumentNullException.ThrowIfNull(deltas);
+
+        if (!deltas.Keys.OrderBy(id => id.Value).SequenceEqual(ruleset.CharacteristicCosts.Keys.OrderBy(id => id.Value)))
+        {
+            throw new ArgumentException(
+                "Deltas must be supplied for exactly the point-buy characteristics.", nameof(deltas));
+        }
+
+        var netSpend = 0;
+        var values = new Dictionary<CharacteristicId, int>();
+        foreach (var (id, delta) in deltas)
+        {
+            var cost = ruleset.CharacteristicCosts[id];
+            netSpend += cost * delta;
+            values[id] = ValidateBounds(ruleset, abilityRuleset, id, ruleset.StartingCharacteristicValue + delta);
+        }
+
+        if (netSpend > ruleset.CharacteristicPointPool)
+        {
+            throw new ArgumentException(
+                $"Point-buy spend of {netSpend} exceeds the {ruleset.CharacteristicPointPool}-point pool.",
+                nameof(deltas));
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// Applies a zero-sum redistribution of up to <see cref="CharacterCreationRuleset.FreeShiftPoints"/>
+    /// total points on top of an already-allocated set of characteristics -- the house-rule
+    /// extension documented on <see cref="CharacterCreationRuleset.FreeShiftPoints"/>.
+    /// <paramref name="shift"/> must sum to zero (points only move between characteristics,
+    /// none are created or destroyed) and its total moved (the sum of its positive entries)
+    /// must not exceed the ruleset's allowance.
+    /// </summary>
+    public static IReadOnlyDictionary<CharacteristicId, int> ApplyShift(
+        CharacterCreationRuleset ruleset,
+        AbilityRuleset abilityRuleset,
+        IReadOnlyDictionary<CharacteristicId, int> allocated,
+        IReadOnlyDictionary<CharacteristicId, int> shift)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(abilityRuleset);
+        ArgumentNullException.ThrowIfNull(allocated);
+        ArgumentNullException.ThrowIfNull(shift);
+
+        if (shift.Count == 0)
+        {
+            return allocated;
+        }
+
+        if (shift.Keys.Any(id => !allocated.ContainsKey(id)))
+        {
+            throw new ArgumentException("Shift keys must be a subset of the allocated characteristics.", nameof(shift));
+        }
+
+        var net = shift.Values.Sum();
+        if (net != 0)
+        {
+            throw new ArgumentException(
+                $"A characteristic shift must be zero-sum (points only move between characteristics); net was {net}.",
+                nameof(shift));
+        }
+
+        var moved = shift.Values.Where(v => v > 0).Sum();
+        if (moved > ruleset.FreeShiftPoints)
+        {
+            throw new ArgumentException(
+                $"Shift of {moved} points exceeds the {ruleset.FreeShiftPoints}-point allowance.", nameof(shift));
+        }
+
+        var result = new Dictionary<CharacteristicId, int>(allocated);
+        foreach (var (id, delta) in shift)
+        {
+            result[id] = ValidateBounds(ruleset, abilityRuleset, id, allocated[id] + delta);
+        }
+
+        return result;
+    }
+
+    private static int ValidateBounds(
+        CharacterCreationRuleset ruleset, AbilityRuleset abilityRuleset, CharacteristicId id, int value)
+    {
+        if (!abilityRuleset.Characteristics.TryGetValue(id, out var definition))
+        {
+            throw new KeyNotFoundException($"Ability ruleset does not define characteristic '{id}'.");
+        }
+
+        var effectiveMaximum = definition.Maximum is int max
+            ? Math.Min(max, ruleset.CharacteristicCreationMaximum)
+            : ruleset.CharacteristicCreationMaximum;
+
+        if (value < definition.Minimum || value > effectiveMaximum)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value), value,
+                $"{definition.DisplayName} must be between {definition.Minimum} and {effectiveMaximum} at creation.");
+        }
+
+        return value;
+    }
+}

--- a/tests/Brp.Rules.Tests/Advancement/ExperienceSystemTests.cs
+++ b/tests/Brp.Rules.Tests/Advancement/ExperienceSystemTests.cs
@@ -1,0 +1,220 @@
+using Brp.Core.Abilities;
+using Brp.Core.Primitives;
+using Brp.Core.Skills;
+using Brp.Data;
+using Brp.Rules.Advancement;
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Tests.Advancement;
+
+public class ExperienceSystemTests
+{
+    private static CharacterSkill MakeSkill(int rating = 20) => new(
+        new SkillDefinition(new SkillId("Test Skill"), "Test Skill", SkillCategory.Mental, new ConstantBaseChance(Percent.Of(5))),
+        rating);
+
+    /// <summary>Marks a skill's experience check via the public gate, exactly as play would.</summary>
+    private static void TickViaRealStakes(CharacterSkill skill) =>
+        ExperienceSystem.RecordUse(new CaseExperienceLedger(), skill, CheckStakes.RealStakes, succeeded: true, ExperiencePolicy.TickOnUse);
+
+    private static AbilitySet MakeAbilities()
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 10);
+        return new AbilitySet(ruleset, values);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Tick_on_use_records_a_tick_regardless_of_success_or_failure(bool succeeded)
+    {
+        var ledger = new CaseExperienceLedger();
+        var skill = MakeSkill();
+
+        var ticked = ExperienceSystem.RecordUse(ledger, skill, CheckStakes.RealStakes, succeeded, ExperiencePolicy.TickOnUse);
+
+        Assert.True(ticked);
+        Assert.True(skill.HasExperienceCheck);
+    }
+
+    [Theory]
+    [InlineData(CheckStakes.Easy)]
+    [InlineData(CheckStakes.NoStakes)]
+    public void Easy_or_no_stakes_checks_never_record_a_tick_under_either_policy(CheckStakes stakes)
+    {
+        // Ch 5: System, "Skill Improvement" (p.138): "If a skill roll was Easy, no
+        // experience check is allowed." The "nothing at stake" gate is enforced the same
+        // way -- mechanically, with no gamemaster to adjudicate it either way.
+        var tickOnUseLedger = new CaseExperienceLedger();
+        var rawLedger = new CaseExperienceLedger();
+        var tickOnUseSkill = MakeSkill();
+        var rawSkill = MakeSkill();
+
+        Assert.False(ExperienceSystem.RecordUse(tickOnUseLedger, tickOnUseSkill, stakes, succeeded: true, ExperiencePolicy.TickOnUse));
+        Assert.False(ExperienceSystem.RecordUse(rawLedger, rawSkill, stakes, succeeded: true, ExperiencePolicy.RawTickOnSuccess));
+        Assert.False(tickOnUseSkill.HasExperienceCheck);
+        Assert.False(rawSkill.HasExperienceCheck);
+    }
+
+    [Fact]
+    public void Raw_policy_requires_success_to_tick_the_falsification_target()
+    {
+        // rules-conformance's falsification target: the RAW toggle must reproduce BRP's
+        // tick-on-success behavior exactly. Ch 5 p.138: "If a skill is used successfully,
+        // you almost always get an experience check."
+        var ledger = new CaseExperienceLedger();
+        var failedSkill = MakeSkill();
+        var succeededSkill = MakeSkill();
+
+        var tickedOnFailure = ExperienceSystem.RecordUse(
+            ledger, failedSkill, CheckStakes.RealStakes, succeeded: false, ExperiencePolicy.RawTickOnSuccess);
+        var tickedOnSuccess = ExperienceSystem.RecordUse(
+            ledger, succeededSkill, CheckStakes.RealStakes, succeeded: true, ExperiencePolicy.RawTickOnSuccess);
+
+        Assert.False(tickedOnFailure);
+        Assert.True(tickedOnSuccess);
+    }
+
+    [Fact]
+    public void A_skill_ticks_at_most_once_per_case_no_matter_how_many_times_it_is_used()
+    {
+        // Ch 5 p.138: "An experience check for a particular skill is made only once per
+        // adventure, no matter how many times the skill is successfully used."
+        var ledger = new CaseExperienceLedger();
+        var skill = MakeSkill();
+
+        var firstUse = ExperienceSystem.RecordUse(ledger, skill, CheckStakes.RealStakes, succeeded: true, ExperiencePolicy.TickOnUse);
+        var secondUse = ExperienceSystem.RecordUse(ledger, skill, CheckStakes.RealStakes, succeeded: false, ExperiencePolicy.TickOnUse);
+
+        Assert.True(firstUse);
+        Assert.False(secondUse);
+    }
+
+    [Fact]
+    public void A_fresh_case_ledger_allows_the_same_skill_to_tick_again()
+    {
+        var skill = MakeSkill();
+        var caseOne = new CaseExperienceLedger();
+        var caseTwo = new CaseExperienceLedger();
+
+        ExperienceSystem.RecordUse(caseOne, skill, CheckStakes.RealStakes, succeeded: true, ExperiencePolicy.TickOnUse);
+        var tickedAgain = ExperienceSystem.RecordUse(caseTwo, skill, CheckStakes.RealStakes, succeeded: true, ExperiencePolicy.TickOnUse);
+
+        Assert.True(tickedAgain);
+    }
+
+    [Fact]
+    public void Improvement_roll_gains_when_the_roll_exceeds_the_current_rating()
+    {
+        // Ch 5 p.138: "If the result of an experience roll is higher than your character's
+        // current skill rating, then the experience roll succeeds", and "add +1D6 to the
+        // skill rating."
+        var skill = MakeSkill(rating: 20);
+        TickViaRealStakes(skill);
+        var entropy = new FixedEntropySource(21, 4);
+
+        var gain = ExperienceSystem.ImprovementRoll(skill, entropy);
+
+        Assert.Equal(4, gain);
+        Assert.Equal(24, skill.CurrentRating);
+        Assert.False(skill.HasExperienceCheck);
+    }
+
+    [Fact]
+    public void Improvement_roll_grants_nothing_when_the_roll_does_not_exceed_the_current_rating()
+    {
+        var skill = MakeSkill(rating: 20);
+        TickViaRealStakes(skill);
+        // Only one scripted value: a second draw (the gain die) would throw, proving the
+        // implementation does not draw it when the roll fails.
+        var entropy = new FixedEntropySource(20);
+
+        var gain = ExperienceSystem.ImprovementRoll(skill, entropy);
+
+        Assert.Equal(0, gain);
+        Assert.Equal(20, skill.CurrentRating);
+        Assert.False(skill.HasExperienceCheck);
+    }
+
+    [Fact]
+    public void Improvement_roll_is_a_no_op_without_an_experience_check()
+    {
+        var skill = MakeSkill(rating: 20);
+        var entropy = new FixedEntropySource(); // no scripted values: any draw throws
+
+        var gain = ExperienceSystem.ImprovementRoll(skill, entropy);
+
+        Assert.Equal(0, gain);
+        Assert.Equal(20, skill.CurrentRating);
+    }
+
+    [Fact]
+    public void Improvement_roll_adds_the_experience_bonus_to_the_roll_but_not_to_the_gain()
+    {
+        // Ch 5 p.138: "The experience bonus is not added to the actual skill points
+        // gained, just to the roll to see if there is improvement."
+        var skill = MakeSkill(rating: 20);
+        TickViaRealStakes(skill);
+        var entropy = new FixedEntropySource(19, 3); // 19 alone would fail; +2 bonus succeeds
+
+        var gain = ExperienceSystem.ImprovementRoll(skill, entropy, experienceBonus: 2);
+
+        Assert.Equal(3, gain);
+        Assert.Equal(23, skill.CurrentRating);
+    }
+
+    [Fact]
+    public void Close_case_resolves_every_ticked_skill_in_a_stable_deterministic_order()
+    {
+        var skillA = MakeSkill(rating: 10);
+        var skillB = MakeSkill(rating: 90);
+        TickViaRealStakes(skillA);
+        TickViaRealStakes(skillB);
+
+        var character = new Character(
+            new CharacterId("pc"),
+            "Case Closer",
+            MakeAbilities(),
+            new Dictionary<SkillId, CharacterSkill>
+            {
+                [new SkillId("A")] = skillA,
+                [new SkillId("B")] = skillB,
+            });
+
+        // A ticks first (alphabetical id order): rolls 50 (> 10, gains 2). B ticks second:
+        // rolls 50 (not > 90, no gain).
+        var entropy = new FixedEntropySource(50, 2, 50);
+
+        var results = ExperienceSystem.CloseCase(character, entropy);
+
+        Assert.Equal(2, results[new SkillId("A")]);
+        Assert.Equal(0, results[new SkillId("B")]);
+        Assert.Equal(12, skillA.CurrentRating);
+        Assert.Equal(90, skillB.CurrentRating);
+    }
+
+    [Fact]
+    public void Teach_grants_a_gain_on_a_successful_teach_roll()
+    {
+        var student = MakeSkill(rating: 30);
+        var entropy = new FixedEntropySource(50, 5); // teach roll 50 <= 60% chance, then +5
+
+        var taught = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+
+        Assert.True(taught);
+        Assert.Equal(35, student.CurrentRating);
+    }
+
+    [Fact]
+    public void Teach_grants_nothing_on_a_failed_teach_roll()
+    {
+        var student = MakeSkill(rating: 30);
+        var entropy = new FixedEntropySource(70); // teach roll 70 > 60% chance: fails
+
+        var taught = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+
+        Assert.False(taught);
+        Assert.Equal(30, student.CurrentRating);
+    }
+}

--- a/tests/Brp.Rules.Tests/Advancement/ExperienceSystemTests.cs
+++ b/tests/Brp.Rules.Tests/Advancement/ExperienceSystemTests.cs
@@ -9,6 +9,8 @@ namespace Brp.Rules.Tests.Advancement;
 
 public class ExperienceSystemTests
 {
+    private static readonly ExperienceRuleset Ruleset = NoirExperienceRuleset.Load();
+
     private static CharacterSkill MakeSkill(int rating = 20) => new(
         new SkillDefinition(new SkillId("Test Skill"), "Test Skill", SkillCategory.Mental, new ConstantBaseChance(Percent.Of(5))),
         rating);
@@ -234,7 +236,7 @@ public class ExperienceSystemTests
         var student = MakeSkill(rating: 30);
         var entropy = new FixedEntropySource(50, 5); // teach roll 50: a Success at 60% chance, then +5
 
-        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy, Ruleset);
 
         Assert.Equal(5, gain);
         Assert.Equal(35, student.CurrentRating);
@@ -246,7 +248,7 @@ public class ExperienceSystemTests
         var student = MakeSkill(rating: 30);
         var entropy = new FixedEntropySource(70); // teach roll 70: a plain Failure at 60% chance
 
-        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy, Ruleset);
 
         Assert.Equal(0, gain);
         Assert.Equal(30, student.CurrentRating);
@@ -255,13 +257,13 @@ public class ExperienceSystemTests
     [Fact]
     public void Teach_caps_the_gain_so_training_alone_cannot_carry_a_skill_past_the_seventy_five_percent_ceiling()
     {
-        // Ch 5 p.138: "No skill can be trained above 75%, no matter how good the
+        // Ch 5 p.139: "No skill can be trained above 75%, no matter how good the
         // instructor. Any increase above this must come through successful use of the
         // skill." 74 + a full 1D6 gain of 6 would reach 80%; training must stop at 75%.
         var student = MakeSkill(rating: 74);
         var entropy = new FixedEntropySource(50, 6); // teach roll 50: a Success at 80% chance, then +6
 
-        var gain = ExperienceSystem.Teach(student, Percent.Of(80), entropy);
+        var gain = ExperienceSystem.Teach(student, Percent.Of(80), entropy, Ruleset);
 
         Assert.Equal(1, gain);
         Assert.Equal(75, student.CurrentRating);
@@ -273,10 +275,32 @@ public class ExperienceSystemTests
         var student = MakeSkill(rating: 75);
         var entropy = new FixedEntropySource(50, 6); // a Success that would otherwise grant +6
 
-        var gain = ExperienceSystem.Teach(student, Percent.Of(80), entropy);
+        var gain = ExperienceSystem.Teach(student, Percent.Of(80), entropy, Ruleset);
 
         Assert.Equal(0, gain);
         Assert.Equal(75, student.CurrentRating);
+    }
+
+    [Fact]
+    public void Shipped_experience_ruleset_data_reproduces_ch5_p139s_seventy_five_percent_training_cap()
+    {
+        Assert.Equal(75, Ruleset.TrainingCapPercent);
+    }
+
+    [Fact]
+    public void Teach_reads_the_training_cap_from_ruleset_data_not_a_hardcoded_constant()
+    {
+        // A ruleset with a different training cap must produce a different clamp -- proof
+        // the value is read from the injected ExperienceRuleset, not a bare constant inside
+        // ExperienceSystem.
+        var lowCapRuleset = new ExperienceRuleset(trainingCapPercent: 40);
+        var student = MakeSkill(rating: 35);
+        var entropy = new FixedEntropySource(50, 6); // teach roll 50: a Success at 80% chance, then +6
+
+        var gain = ExperienceSystem.Teach(student, Percent.Of(80), entropy, lowCapRuleset);
+
+        Assert.Equal(5, gain);
+        Assert.Equal(40, student.CurrentRating);
     }
 
     [Fact]
@@ -289,7 +313,7 @@ public class ExperienceSystemTests
         var student = MakeSkill(rating: 30);
         var entropy = new FixedEntropySource(99, 2); // fumble roll, then a -1D3 of 2
 
-        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy, Ruleset);
 
         Assert.Equal(-2, gain);
         Assert.Equal(28, student.CurrentRating);
@@ -301,7 +325,7 @@ public class ExperienceSystemTests
         var student = MakeSkill(rating: 1);
         var entropy = new FixedEntropySource(99, 3); // fumble roll, then a -1D3 of 3
 
-        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy, Ruleset);
 
         // The rating can only fall from 1 to 0 -- the returned change reflects what was
         // actually applied, not the raw, unclamped -1D3 penalty.

--- a/tests/Brp.Rules.Tests/Advancement/ExperienceSystemTests.cs
+++ b/tests/Brp.Rules.Tests/Advancement/ExperienceSystemTests.cs
@@ -194,15 +194,49 @@ public class ExperienceSystemTests
         Assert.Equal(90, skillB.CurrentRating);
     }
 
+    [Theory]
+    [InlineData(100)]
+    [InlineData(130)]
+    public void Improvement_roll_grants_an_improvement_on_a_natural_100_once_the_skill_is_at_or_above_100_percent(int rating)
+    {
+        // Ch 5 p.138, "Exceeding 100% in a Skill": "No matter how much over 100% the skill
+        // has risen, any roll of 100 or over earns a skill improvement." Before this fix, a
+        // skill at or above 100% could never improve: `roll <= skill.CurrentRating` with
+        // roll capped at 100 is always true once the rating reaches 100.
+        var skill = MakeSkill(rating);
+        TickViaRealStakes(skill);
+        var entropy = new FixedEntropySource(100, 3); // natural 100, then a gain of 3
+
+        var gain = ExperienceSystem.ImprovementRoll(skill, entropy);
+
+        Assert.Equal(3, gain);
+        Assert.Equal(rating + 3, skill.CurrentRating);
+    }
+
+    [Fact]
+    public void Improvement_roll_below_100_percent_still_requires_beating_the_rating_not_just_reaching_100()
+    {
+        // A rating of 99 is still below the 100%-and-above regime: the roll must exceed
+        // 99, so a roll of exactly 99 still fails (unlike the >=100 case above).
+        var skill = MakeSkill(rating: 99);
+        TickViaRealStakes(skill);
+        var entropy = new FixedEntropySource(99); // one value only: a gain draw would throw
+
+        var gain = ExperienceSystem.ImprovementRoll(skill, entropy);
+
+        Assert.Equal(0, gain);
+        Assert.Equal(99, skill.CurrentRating);
+    }
+
     [Fact]
     public void Teach_grants_a_gain_on_a_successful_teach_roll()
     {
         var student = MakeSkill(rating: 30);
-        var entropy = new FixedEntropySource(50, 5); // teach roll 50 <= 60% chance, then +5
+        var entropy = new FixedEntropySource(50, 5); // teach roll 50: a Success at 60% chance, then +5
 
-        var taught = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
 
-        Assert.True(taught);
+        Assert.Equal(5, gain);
         Assert.Equal(35, student.CurrentRating);
     }
 
@@ -210,11 +244,68 @@ public class ExperienceSystemTests
     public void Teach_grants_nothing_on_a_failed_teach_roll()
     {
         var student = MakeSkill(rating: 30);
-        var entropy = new FixedEntropySource(70); // teach roll 70 > 60% chance: fails
+        var entropy = new FixedEntropySource(70); // teach roll 70: a plain Failure at 60% chance
 
-        var taught = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
 
-        Assert.False(taught);
+        Assert.Equal(0, gain);
         Assert.Equal(30, student.CurrentRating);
+    }
+
+    [Fact]
+    public void Teach_caps_the_gain_so_training_alone_cannot_carry_a_skill_past_the_seventy_five_percent_ceiling()
+    {
+        // Ch 5 p.138: "No skill can be trained above 75%, no matter how good the
+        // instructor. Any increase above this must come through successful use of the
+        // skill." 74 + a full 1D6 gain of 6 would reach 80%; training must stop at 75%.
+        var student = MakeSkill(rating: 74);
+        var entropy = new FixedEntropySource(50, 6); // teach roll 50: a Success at 80% chance, then +6
+
+        var gain = ExperienceSystem.Teach(student, Percent.Of(80), entropy);
+
+        Assert.Equal(1, gain);
+        Assert.Equal(75, student.CurrentRating);
+    }
+
+    [Fact]
+    public void Teach_grants_nothing_more_once_a_skill_is_already_at_the_training_ceiling()
+    {
+        var student = MakeSkill(rating: 75);
+        var entropy = new FixedEntropySource(50, 6); // a Success that would otherwise grant +6
+
+        var gain = ExperienceSystem.Teach(student, Percent.Of(80), entropy);
+
+        Assert.Equal(0, gain);
+        Assert.Equal(75, student.CurrentRating);
+    }
+
+    [Fact]
+    public void Teach_fumble_degrades_the_students_skill_instead_of_improving_it()
+    {
+        // Ch 5 p.138: "a fumble is counterproductive, with the teacher causing self-doubt
+        // and contradicting your character's prior learnings, reducing the skill by -1D3."
+        // At a 60% teach chance, the fumble band is 98-100 (Ch 5's standard fumble rule,
+        // Brp.Core.Resolution.ResolutionPolicy), so a roll of 99 fumbles.
+        var student = MakeSkill(rating: 30);
+        var entropy = new FixedEntropySource(99, 2); // fumble roll, then a -1D3 of 2
+
+        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+
+        Assert.Equal(-2, gain);
+        Assert.Equal(28, student.CurrentRating);
+    }
+
+    [Fact]
+    public void Teach_fumble_never_degrades_a_skill_below_zero()
+    {
+        var student = MakeSkill(rating: 1);
+        var entropy = new FixedEntropySource(99, 3); // fumble roll, then a -1D3 of 3
+
+        var gain = ExperienceSystem.Teach(student, Percent.Of(60), entropy);
+
+        // The rating can only fall from 1 to 0 -- the returned change reflects what was
+        // actually applied, not the raw, unclamped -1D3 penalty.
+        Assert.Equal(-1, gain);
+        Assert.Equal(0, student.CurrentRating);
     }
 }

--- a/tests/Brp.Rules.Tests/Advancement/FixedEntropySource.cs
+++ b/tests/Brp.Rules.Tests/Advancement/FixedEntropySource.cs
@@ -1,0 +1,40 @@
+using Brp.Core.Randomness;
+
+namespace Brp.Rules.Tests.Advancement;
+
+/// <summary>
+/// A test double that serves a pre-scripted sequence of die faces instead of generating them,
+/// so an improvement roll's exact outcome can be pinned. Mirrors
+/// <c>Brp.Core.Tests.Dice.FixedEntropySource</c>.
+/// </summary>
+internal sealed class FixedEntropySource : IEntropySource
+{
+    private readonly Queue<int> _values;
+
+    public FixedEntropySource(params int[] values) => _values = new Queue<int>(values);
+
+    public long DrawCount { get; private set; }
+
+    public int NextDie(int sides)
+    {
+        if (_values.Count == 0)
+        {
+            throw new InvalidOperationException("FixedEntropySource has no more scripted values.");
+        }
+
+        DrawCount++;
+        var value = _values.Dequeue();
+        if (value < 1 || value > sides)
+        {
+            throw new InvalidOperationException($"Scripted value {value} is out of range for a d{sides}.");
+        }
+
+        return value;
+    }
+
+    public int NextD100() => NextDie(100);
+
+    public EntropyState Capture() => new(0, 0, 0, 0, DrawCount);
+
+    public void Restore(EntropyState state) => DrawCount = state.DrawCount;
+}

--- a/tests/Brp.Rules.Tests/ArchitectureTests.cs
+++ b/tests/Brp.Rules.Tests/ArchitectureTests.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Tests;
+
+/// <summary>
+/// Guards AGENTS.md invariant 6: <c>Brp.Rules</c> takes no game-engine dependency.
+/// Mirrors <c>Brp.Core.Tests.ArchitectureTests</c>.
+/// </summary>
+public class ArchitectureTests
+{
+    private static readonly Assembly Rules = typeof(Character).Assembly;
+
+    [Theory]
+    [InlineData("UnityEngine")]
+    [InlineData("Godot")]
+    [InlineData("MonoGame")]
+    [InlineData("Microsoft.Xna")]
+    public void Rules_takes_no_game_engine_dependency(string forbidden)
+    {
+        var referenced = Rules.GetReferencedAssemblies()
+            .Select(a => a.Name ?? string.Empty);
+
+        Assert.DoesNotContain(
+            referenced,
+            name => name.StartsWith(forbidden, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Rules_targets_the_expected_framework()
+    {
+        var tfm = Rules
+            .GetCustomAttribute<System.Runtime.Versioning.TargetFrameworkAttribute>()?
+            .FrameworkName;
+
+        Assert.Equal(".NETCoreApp,Version=v10.0", tfm);
+    }
+
+    [Fact]
+    public void Character_carries_no_spendable_power_point_pool()
+    {
+        // Scope cut, `orc-scope-filter.md` "Chapter 4: Powers": POW remains a
+        // characteristic, but no spendable power-point / Fate Point reservoir exists on
+        // the type. A property or field whose name mentions power points would be the
+        // most likely place such a reservoir crept back in.
+        var members = typeof(Character).GetMembers(BindingFlags.Public | BindingFlags.Instance)
+            .Select(m => m.Name);
+
+        Assert.DoesNotContain(members, name =>
+            name.Contains("PowerPoint", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("FatePoint", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("PowerPool", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Brp.Rules.Tests/Brp.Rules.Tests.csproj
+++ b/tests/Brp.Rules.Tests/Brp.Rules.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Brp.Core\Brp.Core.csproj" />
+    <ProjectReference Include="..\..\src\Brp.Data\Brp.Data.csproj" />
+    <ProjectReference Include="..\..\src\Brp.Rules\Brp.Rules.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Brp.Rules.Tests/Characters/CharacterTests.cs
+++ b/tests/Brp.Rules.Tests/Characters/CharacterTests.cs
@@ -1,0 +1,87 @@
+using Brp.Core.Abilities;
+using Brp.Core.Skills;
+using Brp.Data;
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Tests.Characters;
+
+public class CharacterTests
+{
+    private static Character MakeCharacter(int con = 12, int siz = 12)
+    {
+        var abilityRuleset = NoirAbilityRuleset.Load();
+        var values = abilityRuleset.Characteristics.Keys.ToDictionary(id => id, _ => 10);
+        values[new CharacteristicId("CON")] = con;
+        values[new CharacteristicId("SIZ")] = siz;
+        var abilities = new AbilitySet(abilityRuleset, values);
+
+        var registry = NoirSkillRuleset.Load();
+        var spot = registry[new SkillId("Spot")];
+        var skills = new Dictionary<SkillId, CharacterSkill>
+        {
+            [spot.Id] = new CharacterSkill(spot, spot.BaseChanceFor(abilities).Value),
+        };
+
+        return new Character(new CharacterId("pc-1"), "Jane Doe", abilities, skills);
+    }
+
+    [Fact]
+    public void Maximum_hit_points_are_a_live_derived_value_that_moves_when_a_characteristic_drops()
+    {
+        // Ch 2: Characters, "Derived Characteristics" (p.13): HP must change immediately
+        // after a characteristic changes, not be baked in at creation.
+        var character = MakeCharacter(con: 12, siz: 12);
+        var before = character.MaximumHitPoints;
+
+        character.Abilities.Set(new CharacteristicId("CON"), 4);
+
+        Assert.True(character.MaximumHitPoints < before);
+        // Current HP is clamped down alongside the new, lower maximum (AbilitySet's own
+        // cap), which is the observable proof the value was not cached at construction.
+        Assert.True(character.CurrentHitPoints <= character.MaximumHitPoints);
+    }
+
+    [Fact]
+    public void Current_hit_points_start_at_maximum_and_track_it_before_any_damage()
+    {
+        var character = MakeCharacter();
+        Assert.Equal(character.MaximumHitPoints, character.CurrentHitPoints);
+    }
+
+    [Fact]
+    public void Skills_carry_a_current_rating_distinct_from_the_printed_base_chance()
+    {
+        var character = MakeCharacter();
+        var spot = character.Skill(new SkillId("Spot"));
+
+        // Spot's printed base is a flat 25% (Ch 3: Skills, p.50); bump the character's
+        // rating and the printed base must stay put -- that is the whole point of the
+        // two-number contract Layer 2 established.
+        var printedBefore = spot.PrintedBaseChance(character.Abilities);
+        Assert.Equal(25, printedBefore.Value);
+        Assert.Equal(25, spot.CurrentRating);
+    }
+
+    [Fact]
+    public void Wound_list_and_equipment_are_present_but_empty_structural_containers()
+    {
+        var character = MakeCharacter();
+
+        Assert.Empty(character.Wounds.Wounds);
+        Assert.Empty(character.Equipment.Items);
+
+        character.Wounds.Add(new Wound("grazed by a bullet"));
+        character.Equipment.Add(new EquipmentItem("revolver"));
+
+        Assert.Single(character.Wounds.Wounds);
+        Assert.Single(character.Equipment.Items);
+    }
+
+    [Fact]
+    public void Has_skill_reports_whether_the_character_has_a_skill_at_all()
+    {
+        var character = MakeCharacter();
+        Assert.True(character.HasSkill(new SkillId("Spot")));
+        Assert.False(character.HasSkill(new SkillId("Firearms (Handgun)")));
+    }
+}

--- a/tests/Brp.Rules.Tests/Creation/CharacterBuilderTests.cs
+++ b/tests/Brp.Rules.Tests/Creation/CharacterBuilderTests.cs
@@ -1,0 +1,184 @@
+using Brp.Core.Abilities;
+using Brp.Core.Skills;
+using Brp.Data;
+using Brp.Rules.Characters;
+using Brp.Rules.Creation;
+
+namespace Brp.Rules.Tests.Creation;
+
+public class CharacterBuilderTests
+{
+    private static readonly CharacterCreationRuleset Ruleset = NoirCharacterCreationRuleset.Load();
+    private static readonly AbilityRuleset AbilityRuleset = NoirAbilityRuleset.Load();
+    private static readonly SkillRegistry SkillRegistry = NoirSkillRuleset.Load();
+
+    private static Dictionary<CharacteristicId, int> ZeroDeltas() => Ruleset.CharacteristicCosts.Keys
+        .ToDictionary(id => id, _ => 0);
+
+    private static CharacterBuilder MakeBuilder() => new(Ruleset, AbilityRuleset, SkillRegistry);
+
+    [Fact]
+    public void Builds_a_valid_character_from_a_minimal_request()
+    {
+        var request = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-1"),
+            Name = "Jane Doe",
+            CharacteristicDeltas = ZeroDeltas(),
+        };
+
+        var character = MakeBuilder().Build(request);
+
+        Assert.Equal("Jane Doe", character.Name);
+        // Spot's printed base is a flat 25% (Ch 3, p.50); with no points spent, the
+        // starting rating is exactly the printed base.
+        Assert.Equal(25, character.Skill(new SkillId("Spot")).CurrentRating);
+    }
+
+    [Fact]
+    public void Applying_a_freeform_profession_package_sets_starting_skill_ratings()
+    {
+        var package = NoirBackgroundPackageRuleset.LoadAll().Single();
+        var request = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-2"),
+            Name = "Investigator",
+            CharacteristicDeltas = ZeroDeltas(),
+            Package = package,
+        };
+
+        var character = MakeBuilder().Build(request);
+
+        // Research: printed base 25% (Ch 3, p.48) + the package's 40 points.
+        Assert.Equal(65, character.Skill(new SkillId("Research")).CurrentRating);
+        // Streetwise: printed base 5% + the package's 30 points.
+        Assert.Equal(35, character.Skill(new SkillId("Streetwise")).CurrentRating);
+    }
+
+    [Fact]
+    public void Additional_professional_points_stack_with_the_packages_own_allocation()
+    {
+        var package = NoirBackgroundPackageRuleset.LoadAll().Single();
+        var request = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-3"),
+            Name = "Investigator",
+            CharacteristicDeltas = ZeroDeltas(),
+            Package = package,
+            AdditionalProfessionalSkillPoints = new Dictionary<SkillId, int>
+            {
+                [new SkillId("Research")] = 5,
+            },
+        };
+
+        var character = MakeBuilder().Build(request);
+
+        Assert.Equal(70, character.Skill(new SkillId("Research")).CurrentRating);
+    }
+
+    [Fact]
+    public void Professional_points_spent_beyond_the_pool_are_rejected()
+    {
+        var request = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-4"),
+            Name = "Overspender",
+            CharacteristicDeltas = ZeroDeltas(),
+            AdditionalProfessionalSkillPoints = new Dictionary<SkillId, int>
+            {
+                [new SkillId("Spot")] = 50,
+                [new SkillId("Insight")] = Ruleset.ProfessionalSkillPoints, // pushes total over 250
+            },
+        };
+
+        Assert.Throws<ArgumentException>(() => MakeBuilder().Build(request));
+    }
+
+    [Fact]
+    public void Personal_skill_points_are_capped_at_int_times_the_raw_multiplier_when_increased_points_are_off()
+    {
+        // INT 10 (default) x10 RAW multiplier (Ch 2 p.8) = 100 personal points available.
+        var request = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-5"),
+            Name = "Overspender",
+            CharacteristicDeltas = ZeroDeltas(),
+            UseIncreasedPersonalSkillPoints = false,
+            PersonalSkillPoints = new Dictionary<SkillId, int>
+            {
+                [new SkillId("Sense")] = 50,
+                [new SkillId("Navigate")] = 51, // 101 total, one over the INT x10 cap of 100
+            },
+        };
+
+        Assert.Throws<ArgumentException>(() => MakeBuilder().Build(request));
+    }
+
+    [Fact]
+    public void Increased_personal_skill_points_raises_the_pool_from_int_times_ten_to_int_times_fifteen()
+    {
+        // Ch 2 p.8, "Increased Personal Skill Points (Option)": this is a deliberate NoiRPG
+        // extension of the heroic-tier INT x15 multiplier to Normal power level -- see the
+        // ADR and CharacterCreationRuleset.IncreasedPersonalSkillPointsIntMultiplier.
+        var request = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-6"),
+            Name = "Competent Professional",
+            CharacteristicDeltas = ZeroDeltas(),
+            UseIncreasedPersonalSkillPoints = true,
+            PersonalSkillPoints = new Dictionary<SkillId, int>
+            {
+                // 130 points: impossible under INT x10 = 100, allowed under INT x15 = 150.
+                [new SkillId("Sense")] = 65,
+                [new SkillId("Navigate")] = 65,
+            },
+        };
+
+        var character = MakeBuilder().Build(request);
+
+        Assert.Equal(75, character.Skill(new SkillId("Sense")).CurrentRating);
+    }
+
+    [Fact]
+    public void No_skill_may_start_above_the_seventy_five_percent_soft_cap()
+    {
+        // Ch 2 p.8: "No skill should begin higher than 75%."
+        var request = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-7"),
+            Name = "Overqualified",
+            CharacteristicDeltas = ZeroDeltas(),
+            AdditionalProfessionalSkillPoints = new Dictionary<SkillId, int>
+            {
+                // Spot's printed base is 25%; 55 points would push it to 80%, above the cap.
+                [new SkillId("Spot")] = 55,
+            },
+        };
+
+        Assert.Throws<ArgumentException>(() => MakeBuilder().Build(request));
+    }
+
+    [Fact]
+    public void Education_defaults_to_the_ruleset_starting_value_and_can_be_overridden()
+    {
+        var defaultRequest = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-8"),
+            Name = "Default EDU",
+            CharacteristicDeltas = ZeroDeltas(),
+        };
+        var overriddenRequest = new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc-9"),
+            Name = "Overridden EDU",
+            CharacteristicDeltas = ZeroDeltas(),
+            Education = 16,
+        };
+
+        var defaultCharacter = MakeBuilder().Build(defaultRequest);
+        var overriddenCharacter = MakeBuilder().Build(overriddenRequest);
+
+        Assert.Equal(10, defaultCharacter.Abilities.ValueOf(new CharacteristicId("EDU")));
+        Assert.Equal(16, overriddenCharacter.Abilities.ValueOf(new CharacteristicId("EDU")));
+    }
+}

--- a/tests/Brp.Rules.Tests/Creation/CharacteristicPointBuyTests.cs
+++ b/tests/Brp.Rules.Tests/Creation/CharacteristicPointBuyTests.cs
@@ -1,0 +1,143 @@
+using Brp.Core.Abilities;
+using Brp.Data;
+using Brp.Rules.Creation;
+
+namespace Brp.Rules.Tests.Creation;
+
+public class CharacteristicPointBuyTests
+{
+    private static readonly CharacterCreationRuleset Ruleset = NoirCharacterCreationRuleset.Load();
+    private static readonly AbilityRuleset AbilityRuleset = NoirAbilityRuleset.Load();
+
+    private static Dictionary<CharacteristicId, int> ZeroDeltas() => Ruleset.CharacteristicCosts.Keys
+        .ToDictionary(id => id, _ => 0);
+
+    [Fact]
+    public void Ruleset_matches_ch2_point_based_character_creation()
+    {
+        // Ch 2: Characters, "Point-Based Character Creation (option)" (pp.9-10).
+        Assert.Equal(24, Ruleset.CharacteristicPointPool);
+        Assert.Equal(10, Ruleset.StartingCharacteristicValue);
+        Assert.Equal(21, Ruleset.CharacteristicCreationMaximum);
+        Assert.Equal(1, Ruleset.CharacteristicCosts[new CharacteristicId("STR")]);
+        Assert.Equal(1, Ruleset.CharacteristicCosts[new CharacteristicId("CON")]);
+        Assert.Equal(1, Ruleset.CharacteristicCosts[new CharacteristicId("SIZ")]);
+        Assert.Equal(1, Ruleset.CharacteristicCosts[new CharacteristicId("CHA")]);
+        Assert.Equal(3, Ruleset.CharacteristicCosts[new CharacteristicId("DEX")]);
+        Assert.Equal(3, Ruleset.CharacteristicCosts[new CharacteristicId("INT")]);
+        Assert.Equal(3, Ruleset.CharacteristicCosts[new CharacteristicId("POW")]);
+    }
+
+    [Fact]
+    public void All_characteristics_default_to_ten_when_no_points_are_spent()
+    {
+        var result = CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, ZeroDeltas());
+
+        Assert.All(result.Values, v => Assert.Equal(10, v));
+    }
+
+    [Fact]
+    public void Raising_a_one_point_characteristic_costs_one_pool_point_per_point()
+    {
+        var deltas = ZeroDeltas();
+        deltas[new CharacteristicId("STR")] = 11; // 10 -> 21, costs 11
+        deltas[new CharacteristicId("CON")] = -7; // 10 -> 3, refunds 7
+
+        var result = CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, deltas);
+
+        Assert.Equal(21, result[new CharacteristicId("STR")]);
+        Assert.Equal(3, result[new CharacteristicId("CON")]);
+    }
+
+    [Fact]
+    public void Raising_a_three_point_characteristic_costs_three_pool_points_per_point()
+    {
+        var deltas = ZeroDeltas();
+        deltas[new CharacteristicId("DEX")] = 8; // 10 -> 18, costs 24 (the whole pool)
+
+        var result = CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, deltas);
+
+        Assert.Equal(18, result[new CharacteristicId("DEX")]);
+    }
+
+    [Fact]
+    public void Spend_exceeding_the_point_pool_is_rejected()
+    {
+        var deltas = ZeroDeltas();
+        deltas[new CharacteristicId("DEX")] = 9; // costs 27, exceeds the 24-point pool
+
+        Assert.Throws<ArgumentException>(() => CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, deltas));
+    }
+
+    [Fact]
+    public void No_initial_characteristic_may_be_raised_above_the_creation_maximum_of_21()
+    {
+        // Ch 2 p.9: "No initial characteristic can be raised to higher than 21" -- this
+        // creation-time ceiling applies even to INT and POW, whose ongoing-play maximum
+        // (AbilityRuleset.Maximum) is unbounded.
+        var deltas = ZeroDeltas();
+        deltas[new CharacteristicId("INT")] = 12; // 10 -> 22, above the creation maximum
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, deltas));
+    }
+
+    [Fact]
+    public void Siz_and_int_cannot_be_lowered_below_their_printed_floor_of_eight()
+    {
+        var deltas = ZeroDeltas();
+        deltas[new CharacteristicId("SIZ")] = -3; // 10 -> 7, below SIZ's floor of 8
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, deltas));
+    }
+
+    [Fact]
+    public void Other_characteristics_cannot_be_lowered_below_the_general_floor_of_three()
+    {
+        var deltas = ZeroDeltas();
+        deltas[new CharacteristicId("CHA")] = -8; // 10 -> 2, below the general floor of 3
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, deltas));
+    }
+
+    [Fact]
+    public void Shift_moves_points_between_characteristics_without_spending_the_pool()
+    {
+        var allocated = CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, ZeroDeltas());
+        var shift = new Dictionary<CharacteristicId, int>
+        {
+            [new CharacteristicId("STR")] = 3,
+            [new CharacteristicId("CHA")] = -3,
+        };
+
+        var shifted = CharacteristicPointBuy.ApplyShift(Ruleset, AbilityRuleset, allocated, shift);
+
+        Assert.Equal(13, shifted[new CharacteristicId("STR")]);
+        Assert.Equal(7, shifted[new CharacteristicId("CHA")]);
+    }
+
+    [Fact]
+    public void Shift_beyond_the_three_point_allowance_is_rejected()
+    {
+        var allocated = CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, ZeroDeltas());
+        var shift = new Dictionary<CharacteristicId, int>
+        {
+            [new CharacteristicId("STR")] = 4,
+            [new CharacteristicId("CHA")] = -4,
+        };
+
+        Assert.Throws<ArgumentException>(() => CharacteristicPointBuy.ApplyShift(Ruleset, AbilityRuleset, allocated, shift));
+    }
+
+    [Fact]
+    public void A_non_zero_sum_shift_is_rejected()
+    {
+        var allocated = CharacteristicPointBuy.Allocate(Ruleset, AbilityRuleset, ZeroDeltas());
+        var shift = new Dictionary<CharacteristicId, int>
+        {
+            [new CharacteristicId("STR")] = 2,
+            [new CharacteristicId("CHA")] = -1,
+        };
+
+        Assert.Throws<ArgumentException>(() => CharacteristicPointBuy.ApplyShift(Ruleset, AbilityRuleset, allocated, shift));
+    }
+}

--- a/tools/advancement_sim.py
+++ b/tools/advancement_sim.py
@@ -11,8 +11,14 @@ their background package. Per case, each skill is exercised under real stakes
 with a tier-dependent probability (players lean into their build). A skill
 gets at most one tick per case. At case close, each ticked skill makes an
 improvement roll: d100 strictly greater than the current rating raises the
-skill by 1d6. Between cases, downtime training grants one chosen skill an
-extra improvement roll (the player trains their weakest primary).
+skill by 1d6, except that a skill at or above 100 uses a fixed threshold of
+100 instead of its own rating (Ch 5: System, "Exceeding 100% in a Skill",
+p.138 — "any roll of 100 or over earns a skill improvement"; an unmodified
+d100 can never again beat a rating that has itself reached 100). This mirrors
+`Brp.Rules.Advancement.ExperienceSystem.ImprovementRoll`, kept in sync so this
+simulation and the engine share one improvement rule. Between cases, downtime
+training grants one chosen skill an extra improvement roll (the player trains
+their weakest primary).
 
 Variants compared:
   A. RAW BRP  — a skill ticks only if it *succeeded* under stakes.
@@ -43,7 +49,14 @@ class Skill:
     gained: int = 0
 
     def improvement_roll(self, rng: random.Random) -> None:
-        if rng.randint(1, 100) > self.rating:
+        roll = rng.randint(1, 100)
+        # Ch 5 p.138, "Exceeding 100% in a Skill": once a rating reaches 100, an
+        # unmodified d100 can never again roll strictly higher than it, so the book
+        # pins the threshold at 100 itself ("any roll of 100 or over earns a skill
+        # improvement") rather than at the skill's own, possibly much higher, rating.
+        threshold = min(self.rating, 100)
+        succeeded = roll >= 100 if threshold >= 100 else roll > threshold
+        if succeeded:
             g = rng.randint(1, GAIN_DIE)
             self.rating += g
             self.gained += g


### PR DESCRIPTION
Implements **Layer 3 — Characters** (`engine-implementation-plan.md` §3). Closes #40.

## What this delivers

`Brp.Rules` now exists and can represent a whole character, build one by point-buy, and advance it by tick-on-use experience.

- **New projects** — `src/Brp.Rules` + `tests/Brp.Rules.Tests`, in `NoiRPG.slnx` and CI. `Brp.Rules` takes **no game-engine dependency** (invariant 6), enforced by an architecture test.
- **`Character` aggregate** — identity + `AbilitySet` (Layer 1) + a skill set of Layer 2 skill instances with per-skill experience flags; current/max **HP as a live derived value** that recomputes on characteristic change; wound-list and equipment **containers** (structure only). **No spendable power-point pool** — guarded by a reflection test.
- **`CharacterBuilder`** — point-buy path: characteristic allocation, ±3 shift, profession + personal skill points with *Increased Personal Skill Points*, and the 75% starting soft cap. **All creation parameters are `Brp.Data`, none hardcoded** (invariant 7).
- **Background-package mechanism** — data-loaded Freeform-Profession packages set starting ratings during creation (one placeholder; real noir packages are Layer 5).
- **`ExperienceSystem`** — tick-on-use default (one tick per skill per case, success *or* failure; Easy/no-stakes gated mechanically), improvement roll at case close (`d100 > min(rating,100) → +1D6`, deterministic via injected entropy), a **RAW toggle** that reproduces BRP tick-on-success, and teaching (75% training cap + −1D3 fumble).
- **ADR** `docs/decisions/0012-characters-and-advancement.md`, tick-on-use and the ±3 shift marked as **house rules**, creation numbers cited to the book.

## Verification

Reviewed by the required agent gate before this PR:
- **scope-warden** — clean (no power-point pool, CHA-not-APP, containers only, point-buy only, no Layer 4/5 leakage).
- **rules-conformance** — every creation number and the improvement/teaching rules verified against `BasicRoleplaying-ORC-Content-Document.pdf` (Ch 2 pp.7-10, Ch 5 pp.138-139). Found and closed two defects: the "Exceeding 100%" improvement cap and the missing 75% training cap. RAW-vs-tick-on-use falsification target holds — the default deviates from RAW *only* by ticking on failure.
- Improvement rule kept in lockstep with `tools/advancement_sim.py` (same gate, threshold, and gain), so the sim stays runnable against both policies.

**Tests:** 1737 passed, 0 failed (`Brp.Rules.Tests` 53 new). `dotnet build -warnaserror` and `dotnet format --verify-no-changes` clean.

## Deliberately out of scope

Combat / wound mechanics / gear stats (Layer 4, #21); Composure/Vices and real noir packages (Layer 5); downtime training and the dice-roll creation path (deferred, builder left open to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
