### PR TITLE
Layer 4 — CombatRound: three-phase round and DEX-rank action ordering (#47)

### DIFF
--- a/docs/decisions/0015-combat-round.md
+++ b/docs/decisions/0015-combat-round.md
@@ -1,0 +1,182 @@
+# 0015. Combat round: three phases, DEX-rank ordering, and the weapon-type tiebreak
+
+## Status
+
+Accepted — 2026-08-30. Resolves #47 (Layer 4 piece B). Feeds piece C
+(`AttackDefenseMatrix`, a future issue).
+
+## Context
+
+Layer 4 gear (#42) and range bands (#21, ADR 0014) exist, but nothing said *who acts when*
+in a combat round. Every combat mechanic above this layer — attacks, parries, dodges, spot
+rules — resolves inside a round and in an order. This record adds the round scaffold and the
+DEX-rank ordering engine, without resolving any attack (that is piece C's concern).
+
+Ch 6: Combat, pp.142–144, is the sole source consulted. `engine-implementation-plan.md`'s
+combat numbers are derivations, not authority (AGENTS.md invariant 2), and the plan's own
+phase list ("Intent → Movement → Actions → Resolution") does not match the printed text —
+see "The three-phase scope decision" below for what the book actually prints.
+
+## Decision
+
+### Combat round phases — sourced, with a scope-driven deviation
+
+Ch 6, "Combat Round Phases" (p.142): "A combat round consists of four phases: **Statements**,
+**Powers**, **Action**, and **Resolution**. These always occur in the same order and are
+repeated with each new combat round until the combat is over."
+
+NoiRPG implements **three** phases — `Statements`, `Action`, `Resolution` — omitting
+**Powers**. This is a deliberate, owner-approved scope deviation, not a transcription gap:
+the Powers phase (p.143) exists to sequence instantaneous-power activation by INT rank, and
+`orc-scope-filter.md` cuts the entire powers/magic subsystem that phase serves in full
+("Chapter 4: Powers — cut in full... Nothing in this chapter enters the codebase: magic,
+sorcery, spells, divine/rune magic, psychic abilities, superpowers, mutations"). With no
+powers to activate, the Powers phase has no content in this game; modelling it as a permanent
+no-op phase would be dead configuration, not fidelity. `CombatRoundPhase` therefore has three
+members, and `combat-round-ruleset.json`'s `combatRoundPhases` list carries three entries in
+book order.
+
+**Corrected transcription defect:** the rules-extractor's first pass at
+`combat-round-ruleset.json` also listed Powers as a phase (matching the book) — that draft
+was correct on this point and was edited down to three phases only after this owner decision,
+not because the extractor mistranscribed the count.
+
+### DEX rank: numerically equal to the DEX characteristic — sourced
+
+Ch 6, p.142: "your character can perform actions and react to other actions in an order
+usually determined by their DEX characteristic; higher DEX characters act before characters
+with lower DEX." The glossary (p.2) is consistent but non-numeric: "DEX Rank: Based on the
+Dexterity characteristic, this determines when your character can usually act."
+
+The exact numeric identity — DEX rank equals the DEX characteristic's value, not a derived or
+scaled figure — is confirmed by the (cut) spellcasting examples in Ch 4: Powers (p.57): "a
+magician with DEX 15 wants to cast a spell in a combat round, the spell is cast at DEX rank
+−1 per level of the spell. Thus, a level 1 spell is cast at DEX rank 14 (15−1=14)." This only
+works arithmetically if DEX rank starts as the bare DEX value. `CombatRoundRuleset` carries
+this as `DexRankSourceCharacteristic` ("DEX") for provenance; `CombatActionRequest.BaseDexRank`
+is supplied by the caller (typically `abilitySet.ValueOf(new CharacteristicId("DEX"))`) rather
+than derived internally — `Brp.Rules.Combat` takes no dependency on `Brp.Core.Abilities`,
+matching the existing pattern in `RangeBandResolver`, which likewise takes a plain `int
+dexterity` rather than an `AbilitySet`.
+
+### Ordering direction — sourced
+
+Ch 6, p.142: "higher DEX characters act before characters with lower DEX" — descending order.
+No alternative direction is stated; `CombatRoundRuleset.DexRankOrderedDescending` still reads
+this from data (invariant 7) rather than hardcoding the sort direction.
+
+### The weapon-type tiebreak: four tiers, not five — sourced, with a corrected transcription defect
+
+Ch 6, "Action" (p.143): "Within a particular DEX rank, attacks usually go in order of weapon
+type. Attackers armed with missile weapons (bows, guns, etc.) are considered to act before
+those in hand-to-hand (**melee**) combat. After these go characters armed with long weapons
+(spears, lances, etc.), then those with medium-length weapons (swords, axes, etc.) and finally
+those with short weapons (daggers, etc.) **or who are unarmed**."
+
+**Corrected transcription defect:** the rules-extractor's first pass at
+`combat-round-ruleset.json` listed `["missile", "melee", "long", "medium", "short"]` — five
+tiers, with "melee" as a distinct entry between missile and long. This misreads the passage:
+"hand-to-hand (melee)" is the umbrella term the sentence uses to name the *set* of the three
+tiers that follow it (long, medium, short/unarmed), not a fifth tier standing beside them.
+Nowhere in the weapon tables (Ch 8) is there a "melee" weapon class distinct from long,
+medium, or short — "melee" is a category label, not a weapon type. The corrected order is
+**missile → long → medium → short**, four tiers, with "short" also covering unarmed
+combatants per the printed text. `WeaponTypeTier` has four members
+(`Missile`, `LongWeapon`, `MediumWeapon`, `ShortOrUnarmed`; the `Weapon`/`OrUnarmed` suffixes
+avoid CA1720's "identifier contains a type name" analyzer rule, which flags bare `Long` and
+`Short`) and `combat-round-ruleset.json`'s `weaponTypeTiebreakOrder` carries the corrected
+four-entry list.
+
+The book's own fallback beyond weapon type — "If there is a need to determine who acts first
+when DEX ranks are tied, use the relevant skill... If these are still tied, the actions occur
+simultaneously" (p.142, restated for weapon-type ties by extension) — is not implemented here.
+`CombatRound.Create` leaves combatants tied on both DEX rank and weapon tier in their input
+order, which is out of scope for this piece (it needs each combatant's skill rating, which
+belongs to piece C).
+
+### Movement fractions the DEX rank, applied first — sourced
+
+Ch 6, "Move" (p.144): "Moving between 6-15 meters means that your character acts at 1/2 their
+normal DEX rank. Moving between 16-29 meters in a combat round means that your character acts
+at 1/4 their normal DEX rank. These modified DEX ranks are cumulative with penalties for
+additional actions, with movement modifiers to DEX rank being applied first." Distances of 5m
+or less (an ordinary attack's own "moving up to 5 meters" allowance, per "Attack," p.144) and
+distances of 30m or more (the book states no tier there; a fully-unengaged character's move
+without other actions) leave the DEX rank unmodified — no third tier is invented for either
+case.
+
+**House interpretation, unsourced:** the book states the 1/2 and 1/4 fractions but never
+states a rounding direction for the resulting rank. `EffectiveDexRankCalculator.ApplyMovement`
+truncates toward zero (rounds down for the non-negative ranks the game uses). No printed
+example in Ch 6 exercises this fraction with an odd DEX value to settle the direction either
+way; this is a house call, not a transcription from the text.
+
+### Flat penalties: drawing a weapon, and successive-attack spacing — sourced, modelled as ordering arithmetic only
+
+Ch 6, "Noncombat Action" (p.144): "An unengaged character can attempt the use of a skill or
+power or do some other action not requiring a skill check, such as drawing a weapon or opening
+a door. ... These actions, if combined with combat actions or multiple non-combat actions,
+incur a DEX rank penalty of 5 per action."
+
+Ch 6, "Attack" (p.144): "If your character can perform more than one action in a round (some
+weapons allow for multiple attacks, and combat skill levels in excess of 100% also allow
+multiple attacks), each attack should be separated by 5 DEX ranks. The first action is at the
+full DEX rank; the second is at DEX rank −5; the third at DEX rank −10; etc."
+
+Both passages state the same number — 5 — for two related but distinct situations: combining
+a noncombat action (e.g. drawing a weapon) with another action, and spacing successive attacks
+within a round. `CombatRoundRuleset` keeps these as two separate fields
+(`DrawWeaponDexRankPenalty`, `MultipleActionDexRankPenalty`), both sourced to the value 5
+today, so a future ruleset could diverge them without that being mistaken for two
+independently-stated printed numbers — the book gives one number used in two contexts, not
+two numbers.
+
+**Deliberately out of scope (the seam for piece C and beyond):** this piece models only the
+*spacing arithmetic* — given a flat penalty, subtract it after movement. It does **not**
+decide *whether* a combatant is drawing a weapon, or *what* grants more than one action per
+round (a multi-attack weapon, or combat skill over 100%). `CombatActionRequest.FlatDexRankPenalty`
+is supplied by the caller, who is expected to sum
+`ruleset.DrawWeaponDexRankPenalty` and/or `N * ruleset.MultipleActionDexRankPenalty` as their
+own situation requires. Building that decision logic is piece C's (or a later piece's)
+concern.
+
+### The DEX-rank-0 floor — sourced
+
+Ch 6, "Attack" (p.144): "Your character cannot act on DEX rank 0, so any actions that would
+occur below DEX rank 1 are lost." `CombatRoundRuleset.DexRankFloor` (0) is read from data
+rather than hardcoded; `EffectiveDexRankCalculator.Compute` returns `null` — not a clamped
+rank of 0 or 1 — for any action whose computed rank is at or below the floor, and
+`CombatRound.Create` drops such actions from `ActionPhaseOrder` entirely rather than ordering
+them last. A lost action is absent from the sequence, not merely ranked lowest.
+
+### What this piece does not build
+
+- **Attack/defense resolution** (`AttackDefenseMatrix`, Ch 6 "Resolution," p.145 onward) —
+  piece C, a separate issue.
+- **Damage, wounds, unconsciousness/death** — pieces D/E.
+- **Spot rules** (ambush, cover, darkness, etc.) — piece F.
+- **The optional Initiative Rolls variant** (Ch 6, "Initiative Rolls (Option)," p.143: D10 +
+  DEX, or D10 + INT for powers) — cut per `orc-scope-filter.md`'s OFF-list. `CombatRound`
+  exposes no D10 or initiative-value concept anywhere in its public surface; a reflection-based
+  scope test (`CombatRoundTests.The_optional_initiative_rolls_variant_is_not_implemented`)
+  pins this.
+- **What triggers a combatant having more than one action per round** (multi-attack weapons,
+  combat skill over 100%) — the spacing arithmetic exists; the trigger logic does not, and is
+  left for piece C or a later piece.
+- **Statements-phase alternates** (p.142: "Removing the Statement of Intent," "Reverse Order
+  Statement of Intent") — optional variants, out of scope, same reasoning as Initiative Rolls.
+- **Total Hit Points, Encumbrance, Miniatures/Maps/VTT grids, Fatigue Points** — cut/deferred
+  per the scope filter; none of these concepts appear in this piece's data or code.
+
+## Consequences
+
+- Piece C (`AttackDefenseMatrix`) consumes `CombatRound.ActionPhaseOrder` — an
+  `IReadOnlyList<CombatantTurn>` — to know when each combatant's attack/defense resolves, and
+  supplies `CombatActionRequest.FlatDexRankPenalty` itself once it has decided how many actions
+  a combatant is taking and whether one of them is a weapon draw.
+- The movement-fraction rounding direction is a house call (see above) and may need revisiting
+  if a later spot rule or worked example in the book turns out to depend on the opposite
+  direction; flag any such finding against this record rather than the new piece.
+- The two flat-penalty fields (`DrawWeaponDexRankPenalty`, `MultipleActionDexRankPenalty`) are
+  presently identical (5) because the book only ever states one number; this is not itself an
+  invariant a future edit should assume is permanent.

--- a/docs/decisions/0015-combat-round.md
+++ b/docs/decisions/0015-combat-round.md
@@ -105,11 +105,25 @@ distances of 30m or more (the book states no tier there; a fully-unengaged chara
 without other actions) leave the DEX rank unmodified — no third tier is invented for either
 case.
 
-**House interpretation, unsourced:** the book states the 1/2 and 1/4 fractions but never
-states a rounding direction for the resulting rank. `EffectiveDexRankCalculator.ApplyMovement`
-truncates toward zero (rounds down for the non-negative ranks the game uses). No printed
-example in Ch 6 exercises this fraction with an odd DEX value to settle the direction either
-way; this is a house call, not a transcription from the text.
+**Rounding direction — Ch 6 silent, decided by a governing precedent elsewhere in the book:**
+Ch 6 states the 1/2 and 1/4 fractions but never states a rounding direction for the resulting
+rank. Ch 5: System, "Characteristic Increases" (p.140) is the book's only explicit rounding
+convention for the same "half of X" shape, and it rounds up: "Any attempts to train or research
+an increase to the DEX or CHA characteristics are limited to half again the original
+characteristic (round up). For example, your character with DEX 13 can train or research their
+DEX up to 20 (1/2 of 13 rounds up to 7, and 13+7=20)." No passage anywhere in the book rounds a
+"half of a characteristic" calculation down. `EffectiveDexRankCalculator.ApplyMovement`
+therefore rounds the halved/quartered DEX rank **up** (ceiling), following that precedent rather
+than truncating toward zero.
+
+An earlier draft of this record truncated instead, reasoning only that the book was silent. That
+was wrong on two counts: it missed the p.140 precedent, and it produced a pathological result —
+a DEX-rank-1 combatant moving 6-15m truncated to floor(1/2) = 0 and lost their action entirely,
+when Ch 6 (p.144) names losing an action only as a consequence of *penalties* stacking a rank
+below the floor, never as a consequence of an ordinary walk. Rounding up keeps that combatant at
+rank 1 (ceil(1/2) = 1); they still act. The DEX-rank-0 floor itself is unchanged and still
+applies to cumulative penalties (movement plus stacked flat penalties) pushing a rank below 1 —
+only the movement fraction's rounding direction changed.
 
 ### Flat penalties: drawing a weapon, and successive-attack spacing — sourced, modelled as ordering arithmetic only
 
@@ -174,9 +188,10 @@ them last. A lost action is absent from the sequence, not merely ranked lowest.
   `IReadOnlyList<CombatantTurn>` — to know when each combatant's attack/defense resolves, and
   supplies `CombatActionRequest.FlatDexRankPenalty` itself once it has decided how many actions
   a combatant is taking and whether one of them is a weapon draw.
-- The movement-fraction rounding direction is a house call (see above) and may need revisiting
-  if a later spot rule or worked example in the book turns out to depend on the opposite
-  direction; flag any such finding against this record rather than the new piece.
+- The movement-fraction rounding direction follows the Ch 5 p.140 "half of X (round up)"
+  precedent (see above), since Ch 6 itself is silent. If a later spot rule or worked example
+  in the book is found to depend on rounding a combat movement fraction down instead, flag that
+  against this record rather than the new piece.
 - The two flat-penalty fields (`DrawWeaponDexRankPenalty`, `MultipleActionDexRankPenalty`) are
   presently identical (5) because the book only ever states one number; this is not itself an
   invariant a future edit should assume is permanent.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -37,3 +37,4 @@ supersedes it — the original is not edited or deleted.
 | [0012](0012-characters-and-advancement.md) | Layer 3 — Character, CharacterBuilder, and ExperienceSystem shape | Accepted |
 | [0013](0013-gear-definitions.md) | Layer 4 keystone — weapon/armor definition schema and the hand-picked subset | Accepted |
 | [0014](0014-range-bands.md) | Missile/firearm range bands: the four bands, the long-range override, and reconciling three treatments of range | Accepted |
+| [0015](0015-combat-round.md) | Combat round: three phases, DEX-rank ordering, and the weapon-type tiebreak | Accepted |

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -20,6 +20,7 @@
     <EmbeddedResource Include="weapon-ruleset.json" />
     <EmbeddedResource Include="armor-ruleset.json" />
     <EmbeddedResource Include="range-band-ruleset.json" />
+    <EmbeddedResource Include="combat-round-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirCombatRoundRuleset.cs
+++ b/src/Brp.Data/NoirCombatRoundRuleset.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using Brp.Rules.Combat;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's combat-round and DEX-rank ordering parameters from embedded JSON. Sourced:
+/// Ch 6: Combat, "Combat Round Phases" (p.142), "Action" (p.143), and "Move"/"Noncombat
+/// Action"/"Attack" (p.144) -- see each field on <see cref="CombatRoundRuleset"/> for its exact
+/// citation. Recorded in <c>docs/decisions/0015-combat-round.md</c>.
+/// </summary>
+public static class NoirCombatRoundRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable combat-round ruleset from the shipped data.</summary>
+    public static CombatRoundRuleset Load()
+    {
+        var assembly = typeof(NoirCombatRoundRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.combat-round-ruleset.json")
+            ?? throw new InvalidOperationException("The combat-round ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<CombatRoundRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The combat-round ruleset data is empty.");
+
+        var phases = data.CombatRoundPhases
+            .Select(ParsePhase)
+            .ToList();
+
+        var weaponTypeTiebreakOrder = data.WeaponTypeTiebreakOrder
+            .Select(ParseWeaponTypeTier)
+            .ToList();
+
+        var movementTiers = data.MovementTiers
+            .Select(tier => new MovementTier(
+                tier.MinMeters, tier.MaxMeters, tier.DexRankFractionNumerator, tier.DexRankFractionDenominator))
+            .ToList();
+
+        return new CombatRoundRuleset(
+            phases: phases,
+            dexRankSourceCharacteristic: data.DexRankDerivedFromCharacteristic,
+            dexRankOrderedDescending: ParseOrderingDirection(data.DexRankOrderingDirection),
+            weaponTypeTiebreakOrder: weaponTypeTiebreakOrder,
+            movementTiers: movementTiers,
+            drawWeaponDexRankPenalty: data.DrawWeaponDexRankPenalty,
+            multipleActionDexRankPenalty: data.MultipleActionDexRankPenalty,
+            dexRankFloor: data.DexRankFloor);
+    }
+
+    private static CombatRoundPhase ParsePhase(string value) => value switch
+    {
+        "Statements" => CombatRoundPhase.Statements,
+        "Action" => CombatRoundPhase.Action,
+        "Resolution" => CombatRoundPhase.Resolution,
+        _ => throw new InvalidOperationException($"Unknown combat round phase '{value}'."),
+    };
+
+    private static WeaponTypeTier ParseWeaponTypeTier(string value) => value switch
+    {
+        "missile" => WeaponTypeTier.Missile,
+        "long" => WeaponTypeTier.LongWeapon,
+        "medium" => WeaponTypeTier.MediumWeapon,
+        "short" => WeaponTypeTier.ShortOrUnarmed,
+        _ => throw new InvalidOperationException($"Unknown weapon-type tiebreak tier '{value}'."),
+    };
+
+    private static bool ParseOrderingDirection(string value) => value switch
+    {
+        "descending" => true,
+        "ascending" => false,
+        _ => throw new InvalidOperationException($"Unknown DEX rank ordering direction '{value}'."),
+    };
+
+    private sealed class CombatRoundRulesetData
+    {
+        public required IReadOnlyList<string> CombatRoundPhases { get; init; }
+
+        public required string DexRankDerivedFromCharacteristic { get; init; }
+
+        public required string DexRankOrderingDirection { get; init; }
+
+        public required IReadOnlyList<string> WeaponTypeTiebreakOrder { get; init; }
+
+        public required IReadOnlyList<MovementTierData> MovementTiers { get; init; }
+
+        public required int DrawWeaponDexRankPenalty { get; init; }
+
+        public required int MultipleActionDexRankPenalty { get; init; }
+
+        public required int DexRankFloor { get; init; }
+    }
+
+    private sealed class MovementTierData
+    {
+        public required int MinMeters { get; init; }
+
+        public required int MaxMeters { get; init; }
+
+        public required int DexRankFractionNumerator { get; init; }
+
+        public required int DexRankFractionDenominator { get; init; }
+    }
+}

--- a/src/Brp.Data/combat-round-ruleset.json
+++ b/src/Brp.Data/combat-round-ruleset.json
@@ -1,0 +1,32 @@
+{
+  "combatRoundPhases": [
+    "Statements",
+    "Action",
+    "Resolution"
+  ],
+  "dexRankDerivedFromCharacteristic": "DEX",
+  "dexRankOrderingDirection": "descending",
+  "weaponTypeTiebreakOrder": [
+    "missile",
+    "long",
+    "medium",
+    "short"
+  ],
+  "movementTiers": [
+    {
+      "minMeters": 6,
+      "maxMeters": 15,
+      "dexRankFractionNumerator": 1,
+      "dexRankFractionDenominator": 2
+    },
+    {
+      "minMeters": 16,
+      "maxMeters": 29,
+      "dexRankFractionNumerator": 1,
+      "dexRankFractionDenominator": 4
+    }
+  ],
+  "drawWeaponDexRankPenalty": 5,
+  "multipleActionDexRankPenalty": 5,
+  "dexRankFloor": 0
+}

--- a/src/Brp.Rules/Combat/CombatActionRequest.cs
+++ b/src/Brp.Rules/Combat/CombatActionRequest.cs
@@ -1,0 +1,35 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// One combatant's request to act in a combat round's Action phase (Ch 6, p.143), before the
+/// effective DEX rank and weapon-type tiebreak have been applied. See <see cref="CombatRound.Create"/>.
+/// </summary>
+/// <param name="CombatantId">
+/// Identifies whose action this is. Opaque to this layer -- a name, a character ID, anything the
+/// caller finds convenient -- since <c>Brp.Rules</c> takes no dependency on a specific character
+/// or engine representation.
+/// </param>
+/// <param name="BaseDexRank">
+/// The combatant's DEX rank before this round's movement and penalties -- numerically the DEX
+/// characteristic value itself (Ch 6, p.142; see <see cref="CombatRoundRuleset.DexRankSourceCharacteristic"/>).
+/// </param>
+/// <param name="MovementMeters">
+/// How far the combatant moves this round, in meters, for <see cref="EffectiveDexRankCalculator.ApplyMovement"/>
+/// to fraction the DEX rank against (Ch 6, "Move," p.144).
+/// </param>
+/// <param name="FlatDexRankPenalty">
+/// The sum of any flat penalties applying after movement -- drawing a weapon combined with
+/// another action, and/or this action's position in a multi-attack sequence (Ch 6, "Noncombat
+/// Action" and "Attack," p.144). Establishing which penalties apply and why is the caller's
+/// concern; see <see cref="EffectiveDexRankCalculator.Compute"/>.
+/// </param>
+/// <param name="WeaponTier">
+/// The weapon-type tier used to break a tie with another combatant at the same effective DEX
+/// rank (Ch 6, "Action," p.143). See <see cref="WeaponTypeTier"/>.
+/// </param>
+public readonly record struct CombatActionRequest(
+    string CombatantId,
+    int BaseDexRank,
+    int MovementMeters,
+    int FlatDexRankPenalty,
+    WeaponTypeTier WeaponTier);

--- a/src/Brp.Rules/Combat/CombatRound.cs
+++ b/src/Brp.Rules/Combat/CombatRound.cs
@@ -1,0 +1,78 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Models one combat round, per Ch 6: Combat, "Combat Round Phases" (p.142) and "Action" (p.143):
+/// the round's phases, and the Action phase's ordered sequence of combatant turns. Deliberately
+/// does not resolve any turn -- attacks, parries, and dodges are piece C's concern
+/// (<c>AttackDefenseMatrix</c>). See <c>docs/decisions/0015-combat-round.md</c> for the full
+/// rationale, including the 3-phase scope decision and the weapon-type tiebreak reading.
+/// </summary>
+public sealed class CombatRound
+{
+    private CombatRound(IReadOnlyList<CombatRoundPhase> phases, IReadOnlyList<CombatantTurn> actionPhaseOrder)
+    {
+        Phases = phases;
+        ActionPhaseOrder = actionPhaseOrder;
+    }
+
+    /// <summary>The round's phases in order, per <see cref="CombatRoundRuleset.Phases"/>.</summary>
+    public IReadOnlyList<CombatRoundPhase> Phases { get; }
+
+    /// <summary>
+    /// The Action phase's combatant turns, ordered high-to-low by effective DEX rank (Ch 6, p.142)
+    /// with the weapon-type tiebreak applied to ties (Ch 6, p.143). Combatants whose effective DEX
+    /// rank fell at or below the floor (Ch 6, p.144) are absent -- their action was lost, not
+    /// ordered last.
+    /// </summary>
+    public IReadOnlyList<CombatantTurn> ActionPhaseOrder { get; }
+
+    /// <summary>
+    /// Builds a <see cref="CombatRound"/> from a set of combatants' action requests: computes each
+    /// combatant's effective DEX rank (dropping any whose action is lost to the DEX-rank floor),
+    /// then orders the rest high-to-low by that rank, breaking ties with the weapon-type tiebreak
+    /// order (Ch 6, p.143). Combatants tied on both DEX rank and weapon tier keep their relative
+    /// input order -- the book's own fallback beyond weapon type (skill rating, then simultaneity;
+    /// p.143) is out of scope for this piece.
+    /// </summary>
+    public static CombatRound Create(IEnumerable<CombatActionRequest> requests, CombatRoundRuleset ruleset)
+    {
+        ArgumentNullException.ThrowIfNull(requests);
+        ArgumentNullException.ThrowIfNull(ruleset);
+
+        var turns = new List<CombatantTurn>();
+        foreach (var request in requests)
+        {
+            var effectiveRank = EffectiveDexRankCalculator.Compute(
+                request.BaseDexRank, request.MovementMeters, request.FlatDexRankPenalty, ruleset);
+
+            if (effectiveRank is int rank)
+            {
+                turns.Add(new CombatantTurn(request.CombatantId, rank, request.WeaponTier));
+            }
+        }
+
+        var rankOrdered = ruleset.DexRankOrderedDescending
+            ? turns.OrderByDescending(turn => turn.EffectiveDexRank)
+            : turns.OrderBy(turn => turn.EffectiveDexRank);
+
+        var ordered = rankOrdered
+            .ThenBy(turn => TiebreakIndex(turn.WeaponTier, ruleset))
+            .ToList();
+
+        return new CombatRound(ruleset.Phases, ordered);
+    }
+
+    private static int TiebreakIndex(WeaponTypeTier tier, CombatRoundRuleset ruleset)
+    {
+        var order = ruleset.WeaponTypeTiebreakOrder;
+        for (var i = 0; i < order.Count; i++)
+        {
+            if (order[i] == tier)
+            {
+                return i;
+            }
+        }
+
+        return order.Count;
+    }
+}

--- a/src/Brp.Rules/Combat/CombatRoundPhase.cs
+++ b/src/Brp.Rules/Combat/CombatRoundPhase.cs
@@ -1,0 +1,38 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// A phase of a combat round, per Ch 6: Combat, "Combat Round Phases" (p.142).
+/// <para>
+/// The book prints <em>four</em> phases in this order: Statements, Powers, Action, Resolution
+/// (p.142: "A combat round consists of four phases: Statements, Powers, Action, and Resolution.
+/// These always occur in the same order."). NoiRPG implements only three -- <see cref="Statements"/>,
+/// <see cref="Action"/>, <see cref="Resolution"/> -- a deliberate, owner-approved scope deviation:
+/// the Powers phase (p.143) exists solely to sequence instantaneous-power activation by INT rank,
+/// and NoiRPG cuts the entire powers/magic subsystem that phase serves
+/// (<c>orc-scope-filter.md</c>, "Chapter 4: Powers -- cut in full"). With no powers to activate,
+/// the phase has no content in this game and is omitted rather than modelled as a permanent no-op.
+/// See <c>docs/decisions/0015-combat-round.md</c>.
+/// </para>
+/// </summary>
+public enum CombatRoundPhase
+{
+    /// <summary>
+    /// Ch 6, "Statements" (p.142): players and the gamemaster announce, in DEX-rank order
+    /// (highest first), what their characters plan to do this round.
+    /// </summary>
+    Statements,
+
+    /// <summary>
+    /// Ch 6, "Action" (p.143): combatants act on their DEX ranks, attacks going in weapon-type
+    /// order within a tied rank (missile, then long, then medium, then short/unarmed).
+    /// </summary>
+    Action,
+
+    /// <summary>
+    /// Ch 6, "Resolution" (p.145): attack, parry, and dodge rolls are compared on the Attack and
+    /// Defense Matrix to determine the result of the round's actions. Resolving those rolls is
+    /// piece C's concern (<c>AttackDefenseMatrix</c>, Issue #48+); this phase is modelled here
+    /// only as a named step a round passes through.
+    /// </summary>
+    Resolution,
+}

--- a/src/Brp.Rules/Combat/CombatRoundRuleset.cs
+++ b/src/Brp.Rules/Combat/CombatRoundRuleset.cs
@@ -1,0 +1,115 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The data-defined parameters the combat round and its DEX-rank ordering read (AGENTS.md
+/// invariant 7: rules values are data, not constants). Every value is sourced or marked as a
+/// house interpretation on its own member below. Loaded from
+/// <c>combat-round-ruleset.json</c> by <c>Brp.Data.NoirCombatRoundRuleset.Load()</c>.
+/// </summary>
+public sealed class CombatRoundRuleset
+{
+    /// <summary>Creates a combat-round ruleset from data-defined values.</summary>
+    public CombatRoundRuleset(
+        IReadOnlyList<CombatRoundPhase> phases,
+        string dexRankSourceCharacteristic,
+        bool dexRankOrderedDescending,
+        IReadOnlyList<WeaponTypeTier> weaponTypeTiebreakOrder,
+        IReadOnlyList<MovementTier> movementTiers,
+        int drawWeaponDexRankPenalty,
+        int multipleActionDexRankPenalty,
+        int dexRankFloor)
+    {
+        ArgumentNullException.ThrowIfNull(phases);
+        ArgumentException.ThrowIfNullOrWhiteSpace(dexRankSourceCharacteristic);
+        ArgumentNullException.ThrowIfNull(weaponTypeTiebreakOrder);
+        ArgumentNullException.ThrowIfNull(movementTiers);
+        ArgumentOutOfRangeException.ThrowIfLessThan(drawWeaponDexRankPenalty, 0);
+        ArgumentOutOfRangeException.ThrowIfLessThan(multipleActionDexRankPenalty, 0);
+
+        if (phases.Count == 0)
+        {
+            throw new ArgumentException("A combat round must have at least one phase.", nameof(phases));
+        }
+
+        if (weaponTypeTiebreakOrder.Count == 0)
+        {
+            throw new ArgumentException(
+                "The weapon-type tiebreak order must not be empty.", nameof(weaponTypeTiebreakOrder));
+        }
+
+        Phases = phases;
+        DexRankSourceCharacteristic = dexRankSourceCharacteristic;
+        DexRankOrderedDescending = dexRankOrderedDescending;
+        WeaponTypeTiebreakOrder = weaponTypeTiebreakOrder;
+        MovementTiers = movementTiers;
+        DrawWeaponDexRankPenalty = drawWeaponDexRankPenalty;
+        MultipleActionDexRankPenalty = multipleActionDexRankPenalty;
+        DexRankFloor = dexRankFloor;
+    }
+
+    /// <summary>
+    /// Ch 6, "Combat Round Phases" (p.142), with the book's Powers phase omitted -- see
+    /// <see cref="CombatRoundPhase"/>'s remarks and <c>docs/decisions/0015-combat-round.md</c>.
+    /// </summary>
+    public IReadOnlyList<CombatRoundPhase> Phases { get; }
+
+    /// <summary>
+    /// Ch 6, p.142: "your character can perform actions ... in an order usually determined by
+    /// their DEX characteristic." Corroborated by the spellcasting examples (Ch 4: Powers, p.57 --
+    /// cut from this codebase per the scope filter, but still useful for reading the mechanic):
+    /// "a magician with DEX 15 ... casts at DEX rank 14" (DEX − 1), which only works arithmetically
+    /// if DEX rank starts numerically
+    /// equal to the DEX characteristic itself, not a derived or scaled value. This field records
+    /// which characteristic that identity mapping reads; it is metadata for provenance, not a
+    /// formula -- callers supply the already-read DEX value to <see cref="EffectiveDexRankCalculator"/>.
+    /// </summary>
+    public string DexRankSourceCharacteristic { get; }
+
+    /// <summary>
+    /// Ch 6, p.142: "higher DEX characters act before characters with lower DEX." The book states
+    /// no alternative ordering direction; this flag exists so the direction is read from data
+    /// (invariant 7) rather than hardcoded into the sort in <see cref="CombatRound"/>.
+    /// </summary>
+    public bool DexRankOrderedDescending { get; }
+
+    /// <summary>
+    /// Ch 6, "Action" (p.143), in tiebreak-priority order: missile, then long, then medium, then
+    /// short/unarmed. See <see cref="WeaponTypeTier"/> for why this is four tiers, not five.
+    /// </summary>
+    public IReadOnlyList<WeaponTypeTier> WeaponTypeTiebreakOrder { get; }
+
+    /// <summary>
+    /// Ch 6, "Move" (p.144): the 6-15m (1/2 DEX rank) and 16-29m (1/4 DEX rank) movement tiers.
+    /// </summary>
+    public IReadOnlyList<MovementTier> MovementTiers { get; }
+
+    /// <summary>
+    /// Ch 6, "Noncombat Action" (p.144): "An unengaged character can attempt the use of a skill or
+    /// power or do some other action not requiring a skill check, such as drawing a weapon or
+    /// opening a door. ... These actions, if combined with combat actions or multiple non-combat
+    /// actions, incur a DEX rank penalty of 5 per action." The book states one number (5) for both
+    /// combining a noncombat action (e.g. drawing a weapon) with another action and for spacing
+    /// successive attacks (see <see cref="MultipleActionDexRankPenalty"/>); this ruleset keeps them
+    /// as separate data fields -- both sourced to the same printed value today -- so a future
+    /// ruleset could diverge them without this being mistaken for two independently-stated rules.
+    /// </summary>
+    public int DrawWeaponDexRankPenalty { get; }
+
+    /// <summary>
+    /// Ch 6, "Attack" (p.144): "If your character can perform more than one action in a round
+    /// (some weapons allow for multiple attacks, and combat skill levels in excess of 100% also
+    /// allow multiple attacks), each attack should be separated by 5 DEX ranks. The first action
+    /// is at the full DEX rank; the second is at DEX rank -5; the third at DEX rank -10; etc."
+    /// This ruleset models only the spacing arithmetic; what triggers a combatant having more than
+    /// one action (multi-attack weapons, &gt;100% skill) is out of scope for this piece -- see
+    /// <c>docs/decisions/0015-combat-round.md</c>'s seam note for piece C.
+    /// </summary>
+    public int MultipleActionDexRankPenalty { get; }
+
+    /// <summary>
+    /// Ch 6, "Attack" (p.144): "Your character cannot act on DEX rank 0, so any actions that would
+    /// occur below DEX rank 1 are lost." The floor value itself (0) is unactable, and every rank at
+    /// or below it is lost -- see <see cref="EffectiveDexRankCalculator.Compute"/>.
+    /// </summary>
+    public int DexRankFloor { get; }
+}

--- a/src/Brp.Rules/Combat/CombatantTurn.cs
+++ b/src/Brp.Rules/Combat/CombatantTurn.cs
@@ -1,0 +1,15 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// One combatant's place in the Action phase's ordered sequence, after effective DEX rank and the
+/// weapon-type tiebreak have been resolved. This is the seam piece C (<c>AttackDefenseMatrix</c>)
+/// consumes: a <see cref="CombatantTurn"/> says <em>when</em> a combatant acts, not what happens
+/// when they do -- resolving an attack, parry, or dodge on this turn is out of scope for this
+/// piece. See <c>docs/decisions/0015-combat-round.md</c>.
+/// </summary>
+/// <param name="CombatantId">Identifies whose turn this is; see <see cref="CombatActionRequest.CombatantId"/>.</param>
+/// <param name="EffectiveDexRank">
+/// The DEX rank this turn occurs on, after movement and flat penalties (Ch 6, pp.143-144).
+/// </param>
+/// <param name="WeaponTier">The weapon-type tier that placed this turn among others tied on DEX rank.</param>
+public readonly record struct CombatantTurn(string CombatantId, int EffectiveDexRank, WeaponTypeTier WeaponTier);

--- a/src/Brp.Rules/Combat/EffectiveDexRankCalculator.cs
+++ b/src/Brp.Rules/Combat/EffectiveDexRankCalculator.cs
@@ -21,10 +21,18 @@ public static class EffectiveDexRankCalculator
     /// and movement of 5 meters or less, which the book folds into an ordinary attack's own "up to
     /// 5 meters" allowance) leave the rank unmodified.
     /// <para>
-    /// <strong>House interpretation:</strong> the book states the 1/2 and 1/4 fractions but not a
-    /// rounding direction for them. This implementation truncates toward zero (rounding down, for
-    /// the non-negative ranks the game uses). Unsourced for this specific fraction; see
-    /// <c>docs/decisions/0015-combat-round.md</c>.
+    /// <strong>House interpretation, governed by a nearby printed convention:</strong> Ch 6 never
+    /// states a rounding direction for these two fractions, but Ch 5: System, "Characteristic
+    /// Increases" (p.140) gives the book's only explicit rounding rule for the same "half of X"
+    /// shape: "Any attempts to train or research an increase to the DEX or CHA characteristics are
+    /// limited to half again the original characteristic (round up). For example, ... DEX 13 ...
+    /// (1/2 of 13 rounds up to 7 ...)." No BRP passage anywhere rounds a "half of a characteristic"
+    /// calculation down. This implementation follows that precedent and rounds the halved/quartered
+    /// DEX rank up (ceiling) rather than truncating -- the opposite of an earlier draft, which
+    /// truncated toward zero and had the pathological effect of a DEX-rank-1 combatant moving 6-15m
+    /// truncating to 0 and losing their action outright, when the sole named consequence in Ch 6 for
+    /// a rank of 0 or below is losing an action to <em>penalties</em> (p.144), not to a mid-range
+    /// walk. See <c>docs/decisions/0015-combat-round.md</c>.
     /// </para>
     /// </summary>
     public static int ApplyMovement(int baseDexRank, int movementMeters, CombatRoundRuleset ruleset)
@@ -36,7 +44,7 @@ public static class EffectiveDexRankCalculator
         {
             if (movementMeters >= tier.MinMeters && movementMeters <= tier.MaxMeters)
             {
-                return baseDexRank * tier.FractionNumerator / tier.FractionDenominator;
+                return CeilDiv(baseDexRank * tier.FractionNumerator, tier.FractionDenominator);
             }
         }
 
@@ -66,4 +74,6 @@ public static class EffectiveDexRankCalculator
 
         return effective > ruleset.DexRankFloor ? effective : null;
     }
+
+    private static int CeilDiv(int value, int divisor) => (value + divisor - 1) / divisor;
 }

--- a/src/Brp.Rules/Combat/EffectiveDexRankCalculator.cs
+++ b/src/Brp.Rules/Combat/EffectiveDexRankCalculator.cs
@@ -1,0 +1,69 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Computes a combatant's effective DEX rank for the Action phase, per Ch 6: Combat, "Move"
+/// (p.144) and "Attack" (p.144): movement fractions apply first, flat penalties (drawing a
+/// weapon combined with another action, or spacing successive attacks) apply after, and any
+/// result at or below the DEX-rank floor means the action is lost.
+/// <para>
+/// This is a pure ordering calculation: it does not decide <em>whether</em> a combatant is
+/// drawing a weapon or taking more than one action -- those facts, and in particular what
+/// triggers more than one action (a multi-attack weapon, &gt;100% skill), are for a caller (and,
+/// ultimately, piece C, the attack/defense resolver) to establish. See
+/// <c>docs/decisions/0015-combat-round.md</c>.
+/// </para>
+/// </summary>
+public static class EffectiveDexRankCalculator
+{
+    /// <summary>
+    /// Fractions <paramref name="baseDexRank"/> by the movement tier <paramref name="movementMeters"/>
+    /// falls into, per Ch 6, "Move" (p.144). Distances outside every tier (including "no movement,"
+    /// and movement of 5 meters or less, which the book folds into an ordinary attack's own "up to
+    /// 5 meters" allowance) leave the rank unmodified.
+    /// <para>
+    /// <strong>House interpretation:</strong> the book states the 1/2 and 1/4 fractions but not a
+    /// rounding direction for them. This implementation truncates toward zero (rounding down, for
+    /// the non-negative ranks the game uses). Unsourced for this specific fraction; see
+    /// <c>docs/decisions/0015-combat-round.md</c>.
+    /// </para>
+    /// </summary>
+    public static int ApplyMovement(int baseDexRank, int movementMeters, CombatRoundRuleset ruleset)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentOutOfRangeException.ThrowIfNegative(movementMeters);
+
+        foreach (var tier in ruleset.MovementTiers)
+        {
+            if (movementMeters >= tier.MinMeters && movementMeters <= tier.MaxMeters)
+            {
+                return baseDexRank * tier.FractionNumerator / tier.FractionDenominator;
+            }
+        }
+
+        return baseDexRank;
+    }
+
+    /// <summary>
+    /// Computes the effective DEX rank a combatant acts on this Action phase: movement fraction
+    /// first (Ch 6 p.144: "These modified DEX ranks are cumulative with penalties for additional
+    /// actions, with movement modifiers to DEX rank being applied first"), then
+    /// <paramref name="flatDexRankPenalty"/> subtracted -- the caller's sum of whichever flat
+    /// penalties apply (drawing a weapon combined with another action:
+    /// <see cref="CombatRoundRuleset.DrawWeaponDexRankPenalty"/>; the Nth successive attack:
+    /// <c>N * CombatRoundRuleset.MultipleActionDexRankPenalty</c>; or both). Returns <c>null</c>
+    /// when the result falls at or below <see cref="CombatRoundRuleset.DexRankFloor"/> -- Ch 6,
+    /// p.144: "Your character cannot act on DEX rank 0, so any actions that would occur below DEX
+    /// rank 1 are lost" -- meaning the action does not occur this round.
+    /// </summary>
+    public static int? Compute(
+        int baseDexRank, int movementMeters, int flatDexRankPenalty, CombatRoundRuleset ruleset)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentOutOfRangeException.ThrowIfNegative(flatDexRankPenalty);
+
+        var afterMovement = ApplyMovement(baseDexRank, movementMeters, ruleset);
+        var effective = afterMovement - flatDexRankPenalty;
+
+        return effective > ruleset.DexRankFloor ? effective : null;
+    }
+}

--- a/src/Brp.Rules/Combat/MovementTier.cs
+++ b/src/Brp.Rules/Combat/MovementTier.cs
@@ -1,0 +1,14 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// One row of the movement-distance table that fractions a combatant's effective DEX rank, per
+/// Ch 6: Combat, "Move" (p.144): "Moving between 6-15 meters means that your character acts at
+/// 1/2 their normal DEX rank. Moving between 16-29 meters in a combat round means that your
+/// character acts at 1/4 their normal DEX rank."
+/// </summary>
+/// <param name="MinMeters">The tier's lower bound in meters, inclusive.</param>
+/// <param name="MaxMeters">The tier's upper bound in meters, inclusive.</param>
+/// <param name="FractionNumerator">The numerator of the DEX-rank fraction this tier applies.</param>
+/// <param name="FractionDenominator">The denominator of the DEX-rank fraction this tier applies.</param>
+public readonly record struct MovementTier(
+    int MinMeters, int MaxMeters, int FractionNumerator, int FractionDenominator);

--- a/src/Brp.Rules/Combat/WeaponTypeTier.cs
+++ b/src/Brp.Rules/Combat/WeaponTypeTier.cs
@@ -1,0 +1,35 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The weapon-type tiebreak tier used to order actions within a tied DEX rank, per Ch 6: Combat,
+/// "Action" (p.143): "Within a particular DEX rank, attacks usually go in order of weapon type.
+/// Attackers armed with missile weapons (bows, guns, etc.) are considered to act before those in
+/// hand-to-hand (melee) combat. After these go characters armed with long weapons (spears,
+/// lances, etc.), then those with medium-length weapons (swords, axes, etc.) and finally those
+/// with short weapons (daggers, etc.) or who are unarmed."
+/// <para>
+/// <strong>Four tiers, not five.</strong> The passage's "hand-to-hand (melee)" is the umbrella
+/// term for the three hand-to-hand tiers that follow it (long, medium, short/unarmed), not a
+/// fifth tier standing beside them -- there is no example of a "melee" weapon distinct from a
+/// long, medium, or short one anywhere in the weapon tables. Reading "melee" as a separate tier
+/// (as an earlier transcription of this ruleset did) double-counts the umbrella as a member of
+/// the list it introduces. See <c>docs/decisions/0015-combat-round.md</c>.
+/// </para>
+/// </summary>
+public enum WeaponTypeTier
+{
+    /// <summary>Bows, guns, and other missile weapons: act first within a tied DEX rank.</summary>
+    Missile,
+
+    /// <summary>Long weapons such as spears and lances.</summary>
+    LongWeapon,
+
+    /// <summary>Medium-length weapons such as swords and axes.</summary>
+    MediumWeapon,
+
+    /// <summary>
+    /// Short weapons such as daggers, "or who are unarmed" (p.143) -- the book folds unarmed
+    /// combatants into this last tier rather than giving them a separate one.
+    /// </summary>
+    ShortOrUnarmed,
+}

--- a/tests/Brp.Data.Tests/NoirCombatRoundRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirCombatRoundRulesetTests.cs
@@ -1,0 +1,67 @@
+using Brp.Rules.Combat;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped combat-round data loads and carries the values printed in Ch 6: Combat,
+/// "Combat Round Phases" (p.142), "Action" (p.143), and "Move"/"Noncombat Action"/"Attack"
+/// (p.144). See <c>docs/decisions/0015-combat-round.md</c>.
+/// </summary>
+public class NoirCombatRoundRulesetTests
+{
+    [Fact]
+    public void The_shipped_ruleset_has_three_phases_with_powers_omitted()
+    {
+        var ruleset = NoirCombatRoundRuleset.Load();
+
+        Assert.Equal(
+            [CombatRoundPhase.Statements, CombatRoundPhase.Action, CombatRoundPhase.Resolution],
+            ruleset.Phases);
+    }
+
+    [Fact]
+    public void The_shipped_ruleset_orders_DEX_rank_descending()
+    {
+        var ruleset = NoirCombatRoundRuleset.Load();
+
+        Assert.True(ruleset.DexRankOrderedDescending);
+    }
+
+    [Fact]
+    public void The_shipped_ruleset_has_the_four_tier_weapon_type_tiebreak_order()
+    {
+        var ruleset = NoirCombatRoundRuleset.Load();
+
+        Assert.Equal(
+            [WeaponTypeTier.Missile, WeaponTypeTier.LongWeapon, WeaponTypeTier.MediumWeapon, WeaponTypeTier.ShortOrUnarmed],
+            ruleset.WeaponTypeTiebreakOrder);
+    }
+
+    [Fact]
+    public void The_shipped_ruleset_has_the_printed_movement_tiers()
+    {
+        var ruleset = NoirCombatRoundRuleset.Load();
+
+        Assert.Equal(
+            [new MovementTier(6, 15, 1, 2), new MovementTier(16, 29, 1, 4)],
+            ruleset.MovementTiers);
+    }
+
+    [Fact]
+    public void The_shipped_ruleset_has_the_printed_penalties_and_floor()
+    {
+        var ruleset = NoirCombatRoundRuleset.Load();
+
+        Assert.Equal(5, ruleset.DrawWeaponDexRankPenalty);
+        Assert.Equal(5, ruleset.MultipleActionDexRankPenalty);
+        Assert.Equal(0, ruleset.DexRankFloor);
+    }
+
+    [Fact]
+    public void The_shipped_ruleset_derives_DEX_rank_from_DEX()
+    {
+        var ruleset = NoirCombatRoundRuleset.Load();
+
+        Assert.Equal("DEX", ruleset.DexRankSourceCharacteristic);
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/CombatRoundTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/CombatRoundTests.cs
@@ -1,0 +1,173 @@
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Covers <see cref="CombatRound"/>'s phase structure and Action-phase ordering against Ch 6:
+/// Combat, "Combat Round Phases" (p.142) and "Action" (p.143). See
+/// <c>docs/decisions/0015-combat-round.md</c>.
+/// </summary>
+public class CombatRoundTests
+{
+    private static readonly CombatRoundRuleset Ruleset = new(
+        phases: [CombatRoundPhase.Statements, CombatRoundPhase.Action, CombatRoundPhase.Resolution],
+        dexRankSourceCharacteristic: "DEX",
+        dexRankOrderedDescending: true,
+        weaponTypeTiebreakOrder: [WeaponTypeTier.Missile, WeaponTypeTier.LongWeapon, WeaponTypeTier.MediumWeapon, WeaponTypeTier.ShortOrUnarmed],
+        movementTiers: [new MovementTier(6, 15, 1, 2), new MovementTier(16, 29, 1, 4)],
+        drawWeaponDexRankPenalty: 5,
+        multipleActionDexRankPenalty: 5,
+        dexRankFloor: 0);
+
+    // ---- Phase sequence: three phases, Powers omitted -----------------------------------------
+
+    [Fact]
+    public void A_round_has_the_three_phases_in_book_order_with_powers_omitted()
+    {
+        var round = CombatRound.Create([], Ruleset);
+
+        Assert.Equal(
+            [CombatRoundPhase.Statements, CombatRoundPhase.Action, CombatRoundPhase.Resolution],
+            round.Phases);
+    }
+
+    // ---- DEX-rank ordering, high to low ---------------------------------------------------------
+
+    [Fact]
+    public void Combatants_are_ordered_by_effective_DEX_rank_high_to_low()
+    {
+        var requests = new[]
+        {
+            new CombatActionRequest("low-dex", 8, 0, 0, WeaponTypeTier.MediumWeapon),
+            new CombatActionRequest("high-dex", 17, 0, 0, WeaponTypeTier.MediumWeapon),
+            new CombatActionRequest("mid-dex", 12, 0, 0, WeaponTypeTier.MediumWeapon),
+        };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        Assert.Equal(["high-dex", "mid-dex", "low-dex"], round.ActionPhaseOrder.Select(t => t.CombatantId));
+    }
+
+    // ---- Weapon-type tiebreak on an exact DEX-rank tie ------------------------------------------
+
+    [Fact]
+    public void A_tied_DEX_rank_is_broken_by_weapon_type_missile_before_medium()
+    {
+        // Ch 6, p.143: "Attackers armed with missile weapons ... are considered to act before
+        // those in hand-to-hand (melee) combat," e.g. a gunslinger and a swordsman at equal DEX.
+        var requests = new[]
+        {
+            new CombatActionRequest("swordsman", 13, 0, 0, WeaponTypeTier.MediumWeapon),
+            new CombatActionRequest("gunslinger", 13, 0, 0, WeaponTypeTier.Missile),
+        };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        Assert.Equal(["gunslinger", "swordsman"], round.ActionPhaseOrder.Select(t => t.CombatantId));
+    }
+
+    [Fact]
+    public void The_full_weapon_type_tiebreak_order_is_missile_long_medium_short()
+    {
+        var requests = new[]
+        {
+            new CombatActionRequest("short", 10, 0, 0, WeaponTypeTier.ShortOrUnarmed),
+            new CombatActionRequest("medium", 10, 0, 0, WeaponTypeTier.MediumWeapon),
+            new CombatActionRequest("long", 10, 0, 0, WeaponTypeTier.LongWeapon),
+            new CombatActionRequest("missile", 10, 0, 0, WeaponTypeTier.Missile),
+        };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        Assert.Equal(["missile", "long", "medium", "short"], round.ActionPhaseOrder.Select(t => t.CombatantId));
+    }
+
+    // ---- Movement tiers, applied before penalties ------------------------------------------------
+
+    [Theory]
+    [InlineData(0, 16)]  // no movement: unmodified
+    [InlineData(10, 8)]  // 6-15m: half of 16, rounded down
+    [InlineData(20, 4)]  // 16-29m: quarter of 16
+    public void Movement_fractions_the_effective_DEX_rank_before_any_flat_penalty(int movementMeters, int expectedRank)
+    {
+        var requests = new[] { new CombatActionRequest("mover", 16, movementMeters, 0, WeaponTypeTier.ShortOrUnarmed) };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        Assert.Equal(expectedRank, Assert.Single(round.ActionPhaseOrder).EffectiveDexRank);
+    }
+
+    [Fact]
+    public void Movement_and_a_flat_penalty_are_cumulative_with_movement_applied_first()
+    {
+        // Ch 6, p.144: "These modified DEX ranks are cumulative with penalties for additional
+        // actions, with movement modifiers to DEX rank being applied first." DEX 16, moving 10m
+        // (half rank -> 8), then drawing a weapon combined with an attack (-5) -> 3.
+        var requests = new[] { new CombatActionRequest("mover", 16, 10, 5, WeaponTypeTier.ShortOrUnarmed) };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        Assert.Equal(3, Assert.Single(round.ActionPhaseOrder).EffectiveDexRank);
+    }
+
+    // ---- Drawing a weapon: -5 DEX ranks -----------------------------------------------------------
+
+    [Fact]
+    public void Drawing_a_weapon_combined_with_another_action_costs_five_DEX_ranks()
+    {
+        var requests = new[]
+        {
+            new CombatActionRequest("draws", 15, 0, Ruleset.DrawWeaponDexRankPenalty, WeaponTypeTier.ShortOrUnarmed),
+        };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        Assert.Equal(10, Assert.Single(round.ActionPhaseOrder).EffectiveDexRank);
+    }
+
+    // ---- The DEX-rank-0 floor: actions below rank 1 are lost --------------------------------------
+
+    [Fact]
+    public void An_action_pushed_below_DEX_rank_one_is_lost_not_ordered_last()
+    {
+        var requests = new[]
+        {
+            new CombatActionRequest("survives", 6, 0, 0, WeaponTypeTier.ShortOrUnarmed),
+            new CombatActionRequest("lost", 4, 0, 5, WeaponTypeTier.ShortOrUnarmed), // 4 - 5 = -1, below the floor
+        };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        var turn = Assert.Single(round.ActionPhaseOrder);
+        Assert.Equal("survives", turn.CombatantId);
+    }
+
+    [Fact]
+    public void An_action_landing_exactly_on_DEX_rank_zero_is_also_lost()
+    {
+        var requests = new[] { new CombatActionRequest("at-zero", 5, 0, 5, WeaponTypeTier.ShortOrUnarmed) };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        Assert.Empty(round.ActionPhaseOrder);
+    }
+
+    // ---- Scope: the optional Initiative Rolls variant is absent ------------------------------------
+
+    [Fact]
+    public void The_optional_initiative_rolls_variant_is_not_implemented()
+    {
+        // Ch 6, "Initiative Rolls (Option)" (p.143): D10 + DEX (or D10 + INT for powers), cut per
+        // orc-scope-filter.md's OFF-list. CombatRound exposes no D10/initiative concept anywhere
+        // in its public surface -- only the default DEX-rank system.
+        var members = typeof(CombatRound).GetMembers()
+            .Concat(typeof(CombatRoundRuleset).GetMembers())
+            .Concat(typeof(CombatActionRequest).GetMembers())
+            .Concat(typeof(CombatantTurn).GetMembers())
+            .Select(m => m.Name);
+
+        Assert.DoesNotContain(members, name =>
+            name.Contains("Initiative", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("D10", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/CombatRoundTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/CombatRoundTests.cs
@@ -86,8 +86,8 @@ public class CombatRoundTests
 
     [Theory]
     [InlineData(0, 16)]  // no movement: unmodified
-    [InlineData(10, 8)]  // 6-15m: half of 16, rounded down
-    [InlineData(20, 4)]  // 16-29m: quarter of 16
+    [InlineData(10, 8)]  // 6-15m: half of 16 (exact, so rounding direction doesn't discriminate here)
+    [InlineData(20, 4)]  // 16-29m: quarter of 16 (also exact)
     public void Movement_fractions_the_effective_DEX_rank_before_any_flat_penalty(int movementMeters, int expectedRank)
     {
         var requests = new[] { new CombatActionRequest("mover", 16, movementMeters, 0, WeaponTypeTier.ShortOrUnarmed) };
@@ -95,6 +95,34 @@ public class CombatRoundTests
         var round = CombatRound.Create(requests, Ruleset);
 
         Assert.Equal(expectedRank, Assert.Single(round.ActionPhaseOrder).EffectiveDexRank);
+    }
+
+    [Fact]
+    public void Movement_fraction_rounds_up_per_Ch5_p140s_half_of_X_convention()
+    {
+        // Ch 5: System, "Characteristic Increases" (p.140): "1/2 of 13 rounds up to 7" -- the
+        // book's only explicit rounding rule for this fraction shape. DEX rank 15 moving 6-15m ->
+        // ceil(15/2) = 8, not the floor(15/2) = 7 an earlier draft used.
+        var requests = new[] { new CombatActionRequest("mover", 15, 10, 0, WeaponTypeTier.ShortOrUnarmed) };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        Assert.Equal(8, Assert.Single(round.ActionPhaseOrder).EffectiveDexRank);
+    }
+
+    [Fact]
+    public void A_DEX_rank_one_combatant_moving_6_to_15_meters_still_acts()
+    {
+        // Rounding up avoids the pathological truncate-to-zero case: a rank-1 combatant walking
+        // 6-15m stays at rank 1 (ceil(1/2) = 1) and is present in the action order, rather than
+        // being dropped for taking an ordinary walk.
+        var requests = new[] { new CombatActionRequest("walker", 1, 10, 0, WeaponTypeTier.ShortOrUnarmed) };
+
+        var round = CombatRound.Create(requests, Ruleset);
+
+        var turn = Assert.Single(round.ActionPhaseOrder);
+        Assert.Equal("walker", turn.CombatantId);
+        Assert.Equal(1, turn.EffectiveDexRank);
     }
 
     [Fact]

--- a/tests/Brp.Rules.Tests/Combat/EffectiveDexRankCalculatorTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/EffectiveDexRankCalculatorTests.cs
@@ -21,16 +21,29 @@ public class EffectiveDexRankCalculatorTests
     [Theory]
     [InlineData(0, 15)]  // no movement: unmodified
     [InlineData(5, 15)]  // 5m or less folds into an ordinary attack's own allowance: unmodified
-    [InlineData(6, 7)]   // lower edge of 6-15m: half of 15, rounded down
-    [InlineData(15, 7)]  // upper edge of 6-15m
-    [InlineData(16, 3)]  // lower edge of 16-29m: quarter of 15, rounded down
-    [InlineData(29, 3)]  // upper edge of 16-29m
+    [InlineData(6, 8)]   // lower edge of 6-15m: half of 15, rounded up -- ceil(15/2) = 8
+    [InlineData(15, 8)]  // upper edge of 6-15m
+    [InlineData(16, 4)]  // lower edge of 16-29m: quarter of 15, rounded up -- ceil(15/4) = 4
+    [InlineData(29, 4)]  // upper edge of 16-29m
     [InlineData(30, 15)] // beyond every printed tier: unmodified (book defines no band past 29m)
-    public void Movement_fractions_the_DEX_rank_at_the_printed_tiers(int movementMeters, int expected)
+    public void Movement_fractions_the_DEX_rank_at_the_printed_tiers_rounding_up(int movementMeters, int expected)
     {
         var rank = EffectiveDexRankCalculator.ApplyMovement(15, movementMeters, Ruleset);
 
         Assert.Equal(expected, rank);
+    }
+
+    [Fact]
+    public void A_DEX_rank_one_combatant_moving_6_to_15_meters_still_rounds_up_to_rank_one()
+    {
+        // Ch 5: System, "Characteristic Increases" (p.140) is the book's only explicit rounding
+        // convention for a "half of X" calculation -- "(round up)," worked as "1/2 of 13 rounds up
+        // to 7." Truncating instead would send a DEX-rank-1 combatant moving 6-15m to rank 0 and
+        // lose their action to an ordinary walk, which Ch 6 never names as a consequence of
+        // movement (only of penalties stacking below the floor, p.144). Rounding up keeps rank 1.
+        var rank = EffectiveDexRankCalculator.ApplyMovement(1, movementMeters: 10, Ruleset);
+
+        Assert.Equal(1, rank);
     }
 
     [Fact]

--- a/tests/Brp.Rules.Tests/Combat/EffectiveDexRankCalculatorTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/EffectiveDexRankCalculatorTests.cs
@@ -1,0 +1,65 @@
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Covers <see cref="EffectiveDexRankCalculator"/> against Ch 6: Combat, "Move" and "Attack"
+/// (p.144). See <c>docs/decisions/0015-combat-round.md</c>.
+/// </summary>
+public class EffectiveDexRankCalculatorTests
+{
+    private static readonly CombatRoundRuleset Ruleset = new(
+        phases: [CombatRoundPhase.Statements, CombatRoundPhase.Action, CombatRoundPhase.Resolution],
+        dexRankSourceCharacteristic: "DEX",
+        dexRankOrderedDescending: true,
+        weaponTypeTiebreakOrder: [WeaponTypeTier.Missile, WeaponTypeTier.LongWeapon, WeaponTypeTier.MediumWeapon, WeaponTypeTier.ShortOrUnarmed],
+        movementTiers: [new MovementTier(6, 15, 1, 2), new MovementTier(16, 29, 1, 4)],
+        drawWeaponDexRankPenalty: 5,
+        multipleActionDexRankPenalty: 5,
+        dexRankFloor: 0);
+
+    [Theory]
+    [InlineData(0, 15)]  // no movement: unmodified
+    [InlineData(5, 15)]  // 5m or less folds into an ordinary attack's own allowance: unmodified
+    [InlineData(6, 7)]   // lower edge of 6-15m: half of 15, rounded down
+    [InlineData(15, 7)]  // upper edge of 6-15m
+    [InlineData(16, 3)]  // lower edge of 16-29m: quarter of 15, rounded down
+    [InlineData(29, 3)]  // upper edge of 16-29m
+    [InlineData(30, 15)] // beyond every printed tier: unmodified (book defines no band past 29m)
+    public void Movement_fractions_the_DEX_rank_at_the_printed_tiers(int movementMeters, int expected)
+    {
+        var rank = EffectiveDexRankCalculator.ApplyMovement(15, movementMeters, Ruleset);
+
+        Assert.Equal(expected, rank);
+    }
+
+    [Fact]
+    public void Movement_is_applied_before_a_flat_penalty()
+    {
+        // Ch 6, p.144: movement modifiers apply first. DEX 20, moving 10m (half -> 10), then a
+        // flat -5 (e.g. drawing a weapon combined with an attack) -> 5. Applying the penalty
+        // before halving would instead give (20-5)/2 = 7, a different, wrong result.
+        var effective = EffectiveDexRankCalculator.Compute(20, 10, 5, Ruleset);
+
+        Assert.Equal(5, effective);
+    }
+
+    [Fact]
+    public void Drawing_a_weapon_combined_with_another_action_costs_five_DEX_ranks()
+    {
+        var effective = EffectiveDexRankCalculator.Compute(15, 0, Ruleset.DrawWeaponDexRankPenalty, Ruleset);
+
+        Assert.Equal(10, effective);
+    }
+
+    [Theory]
+    [InlineData(1, 0, null)]  // 1 - 5 = -4, below the floor: lost
+    [InlineData(5, 0, null)]  // exactly at the floor (0): lost
+    [InlineData(6, 0, 1)]     // just above the floor: survives at rank 1
+    public void An_action_at_or_below_the_DEX_rank_floor_is_lost(int baseDexRank, int movementMeters, int? expected)
+    {
+        var effective = EffectiveDexRankCalculator.Compute(baseDexRank, movementMeters, flatDexRankPenalty: 5, Ruleset);
+
+        Assert.Equal(expected, effective);
+    }
+}


### PR DESCRIPTION
Implements Layer 4 piece **B** — the combat-round structure and DEX-rank action ordering. Closes #47. The keystone that pieces C (attack/defense matrix) and D (damage) plug into.

## What this delivers (`Brp.Rules.Combat`)

- **`CombatRound`** — three phases: Statements → Action → Resolution. The Action phase yields an **ordered sequence of combatant turns** for a later piece to resolve; it does not resolve attacks.
- **Effective DEX-rank ordering** — base rank = DEX; movement fraction applied first (6–15 m = ½, 16–29 m = ¼), then the −5 draw / −5-per-additional-action penalties; DEX-rank-0 floor drops actions that fall below rank 1. Combatants sequence high → low, ties broken by weapon type: **missile → long → medium → short/unarmed**.
- All ordering parameters are `Brp.Data` (`combat-round-ruleset.json` + `NoirCombatRoundRuleset`); none hardcoded. Deterministic; no engine dependency.

## Two settled decisions (recorded in ADR 0015)

- **3 phases, not 4.** The book prints Statements/**Powers**/Action/Resolution; the Powers phase exists only to sequence spellcasting, which NoiRPG cuts entirely — so it's omitted as a documented scope deviation. (The plan's "Intent → Movement → Actions → Resolution" was simply wrong against the book; the real phase names are used.)
- **Weapon tiebreak = 4 tiers.** Per Ch 6 p.143, "hand-to-hand (melee)" is the umbrella for long/medium/short, not a fifth tier — `missile → long → medium → short/unarmed`.

## Verification

Built **extraction-first** — `rules-extractor` pinned the Ch 6 numbers before the build, which caught the plan's phase error up front.

- **`scope-warden`** — PASS (containment; Initiative-Rolls variant absent and reflection-test-guarded; no magic/powers concept; all params in data).
- **`rules-conformance`** — 6/7 CONFIRMED against Ch 6 pp.142–144 (DEX=rank, four-tier tiebreak, movement tiers + apply-order, draw/spacing/floor, 3-phase cut). The one finding: movement-fraction **rounding** was truncating; the book's only halving convention (Ch 5 p.140) is **round up**, so it now rounds up — fixing a side effect where a rank-1 mover truncated to 0 and lost their action.

**Tests:** 1853 passed, 0 failed. `-warnaserror` and `dotnet format --verify-no-changes` clean. ADR: `docs/decisions/0015-combat-round.md`.

## Deferred (documented seams)

Attack/defense resolution (piece C), damage/wounds (D/E), spot rules (F); what *grants* multiple actions (multi-attack weapons, >100% skill) and the skill-rating same-tier tiebreak — all left to piece C, which owns the skill data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
