### PR TITLE
Layer 4 — Damage: normal/special/critical damage, armor, and unconscious/dead/knockout (#52)

### DIFF
--- a/docs/decisions/0017-damage.md
+++ b/docs/decisions/0017-damage.md
@@ -1,0 +1,203 @@
+# 0017. Damage: normal/special/critical arithmetic, hit-point conditions, and knockout attacks
+
+## Status
+
+Accepted — 2026-08-30. Resolves #52 (Layer 4 piece D). Consumes #49 (piece C,
+`AttackDefenseOutcome`), #42 (gear, `WeaponDefinition`), and Layer 1/3 (`AbilitySet`,
+`WoundTrack`). Feeds piece E (First Aid, Major Wounds) and the injury spot-rules issue.
+
+## Context
+
+Piece C (#49) says *whether and how well* an attack lands; nothing yet turned that into hit
+points lost. This record adds `DamageResolver`: it rolls damage for a landed hit, applies it to
+a target's hit points (tracking negative HP), records the blow as a wound for piece E, and
+determines the resulting condition — unconscious, fatally wounded, or (for a declared knockout
+attack) knocked out.
+
+Ch 6: Combat, pp.146–156, and Ch 7: Spot Rules, "Knockout Attacks" (p.174), are the sole sources
+consulted. `src/Brp.Data/damage-ruleset.json` was drafted by a prior extraction pass before this
+issue's implementation began; per AGENTS.md ("the extractor confirmed them but you own
+correctness"), every formula in it was re-verified against the printed text while building this
+piece, and one was found and corrected — see "The special-success formula" below.
+
+## Decision
+
+### Normal and Special hits share identical damage arithmetic — corrected against the ruleset draft
+
+`damage-ruleset.json`'s original `specialSuccessDamage.formula` read
+`weaponMaxDieResult + normalDamageDiceRoll + damageBonus - armor` — the weapon's maximum result
+plus a *second*, fresh roll of the same dice. This is not what the book says.
+
+Ch 6, p.147, footnote `**` (the footnote the ruleset's own `printedFootnoteExplanation` field
+already quoted, without drawing the conclusion its own prose demanded): "This is the damage
+which that type of attack would normally do. This is not the same as 'maximum damage'. **For a
+greatsword, full damage is 2D8 on a normal success, 2D8 bleeding damage on a special success**,
+and on a critical success it does 16 damage ignoring armor." The greatsword's normal-success
+dice (2D8) and special-success dice (2D8) are identical — the "bleeding" label names the
+special-effect *type* (Ch 6, "Special Successes and Damage," pp.148–149: bleeding, crushing,
+entangling, impaling, knockback — all out of scope, see below), not extra dice.
+
+Ch 6, p.146's general "Special Success" entry independently confirms this: "An exceptional
+roll... Often, a special attack means that **the weapon does normal damage** in addition to a
+special result based on the weapon's type," with a worked example: "with Firearm 60%, your
+character achieves a special success... **This does normal damage (1D8, for example)**, but in
+the case of a firearm, also does impaling damage." No maximum-plus-normal-roll combination
+appears anywhere in either passage. Only Critical uses the weapon's maximum (p.146: "the maximum
+possible damage for the weapon used... plus the normal rolled damage modifier").
+
+**Corrected formula, as implemented in `DamageResolver.RollDamage`:**
+
+| Landed grade | Damage | Armor |
+|---|---|---|
+| Miss | none | n/a |
+| Normal | weapon dice + db | subtracted |
+| Special | weapon dice + db (same as Normal) | subtracted |
+| Critical | weapon maximum + db | ignored |
+
+`damage-ruleset.json` was updated in the same change to record the correction inline
+(`specialSuccessDamage.correctionNote`) rather than silently overwritten, so the discrepancy and
+its citation stay visible to future readers of the data file, not only this record.
+`rules-conformance` and Codex's cross-check were both told, before this correction, to
+falsify exactly this formula — this is the falsification they should confirm caught something
+real, not a formality that passed by construction.
+
+Db is rolled once, separately, and added to the raw (pre-floor) weapon-dice total before the
+floor-at-zero and armor subtraction are applied — Ch 6, p.147 footnote: "Damage modifier, in all
+cases, is rolled separately and added afterwards." `WeaponDefinition.ApplyDamageBonus` gates
+whether it applies at all (firearms do not receive it).
+
+### Armor treatment collapse
+
+`ArmorTreatment.Bypassed` and `ArmorTreatment.DoesNotApply` both mean "ignore armor entirely" for
+damage purposes, per ADR 0016's note that the book uses two distinct phrases for what may be the
+same rule. `DamageResolver` treats both identically; a landed hit with `ArmorTreatment.Subtracted`
+subtracts the applicable armor value (supplied by the caller — this resolver does not roll hit
+locations, per #52's scope). `ArmorTreatment.NotApplicable` is valid only for a Miss; passing it
+alongside any other landed grade throws, since the matrix never pairs them (ADR 0016's 17 cells).
+
+### Hit-point conditions — data-driven thresholds, `AbilitySet.MajorWoundLevel` reused
+
+- **Unconscious**: current HP at or below `DamageRuleset.UnconsciousHitPointLevel` (2), Ch 2,
+  p.13: "Your character loses consciousness when their hit points are reduced to 2 or less."
+- **Fatally wounded** (the *flag*, not resolved death): current HP at or below
+  `DamageRuleset.DeadHitPointLevel` (0). Ch 2, p.13 / Ch 6, p.156 ("Fatal Wound"): "if their hit
+  points reach 0, they die at the end of the following round"; "Your character is immediately
+  knocked prone but unable to take any action of any type."
+- Both thresholds are loaded from `damage-ruleset.json` by `Brp.Data.NoirDamageRuleset.Load()`,
+  not hardcoded (AGENTS.md invariant 7).
+- Negative HP is tracked: `DamageResolver.Apply` calls `AbilitySet.SetCurrentHitPoints` with the
+  unclamped (possibly negative) result, matching Ch 6, p.156's "0 or negative hit points."
+
+**Knockout's major-wound threshold reuses `AbilitySet.MajorWoundLevel`** (Layer 1,
+`majorWoundDivisor` = 2, rounded up) rather than a second copy of the same "half of maximum hit
+points" figure in `damage-ruleset.json`. Ch 6, p.156 defines a major wound as "equal to or more
+than half the character's total hit points" — `>=`, not the ruleset draft's looser "exceeds half"
+prose — so `DamageResolver` compares with `>=` against `target.MajorWoundLevel`, and
+`damage-ruleset.json`'s `knockoutRule.damageThresholdNote` records why this is intentional and
+where the authoritative figure lives.
+
+### Dead-at-end-of-following-round — modeled as a caller-driven seam, not a round loop
+
+Ch 2 p.13 and Ch 6 p.156 both describe death as *timed*, not instantaneous: a character reduced
+to 0 HP is fatally wounded immediately but does not die until the end of the *following* round,
+and Ch 6's fuller "Fatal Wound" spot rule (p.156) gives a window in that round or the one after
+for medical attention (First Aid, Medicine, a power, an item) to restore them above 0 first.
+
+This piece deliberately does not build a round-tracking mechanism to enforce that timing itself
+— that would either duplicate piece B's `CombatRound` inappropriately or reach into piece E's
+First Aid window, both out of scope for #52. Instead:
+
+- `ApplyDamage` returns `HitPointCondition.FatallyWounded` the instant HP crosses the threshold
+  — the flag Ch 6 p.156 describes ("immediately knocked prone").
+- `DamageResolver.ResolvesToDeath(int hitPointsAtEndOfFollowingRound, DamageRuleset ruleset)` is
+  a pure, stateless function a future combat-round loop calls *at the actual end of the following
+  round*, with whatever HP the target has by then (after any First Aid piece E might have
+  applied). It returns whether death resolves.
+
+This is a thin seam, not a full implementation of the spot rule's medical-attention window —
+piece E and the injury spot rules own that logic; this resolver only guarantees the timing
+question has a place to be asked from data-driven thresholds rather than an instant kill.
+
+### Knockout attacks (Ch 7, p.174) — the real two-branch rule, not a bare fraction check
+
+The printed rule has more structure than "damage > half HP knocks out":
+
+> A Difficult attack roll is made as if targeting a particular body part... The attack is
+> non-lethal and is not intended to do damage, though damage is rolled to determine the potential
+> for a knockout. **Armor defends normally in all cases.** If the damage is equivalent to a minor
+> wound, the original damage rolled is ignored and **the target is dealt the minimum damage for
+> the weapon (after armor) but is not knocked out**. If the attack is successful and the rolled
+> damage is equivalent to a major wound (after armor), **the target takes 1 damage and is knocked
+> out for 1D10+10 rounds**... The effects of special or critical successes (such as extra damage
+> or bypassing armor) apply in all cases, while other special effects (slashing damage, knockback,
+> etc.) do not apply to knockout attempts.
+
+`DamageResolver.ResolveKnockoutAttack` implements exactly this:
+
+1. Roll damage for the landed grade using the ordinary `RollDamage` path — "armor defends
+   normally in all cases" is read as "apply the grade's ordinary armor treatment" (still ignored
+   on a Critical), which is also what "special or critical successes... apply in all cases" says
+   in the same paragraph; not a knockout-specific armor override.
+2. Compare that rolled damage against `target.MajorWoundLevel` (`>=` is major, `<` is minor).
+3. **Minor branch**: the rolled damage is discarded; the target instead takes
+   `weapon.Damage.MinimumPossible()` (a new method added to `DiceExpression` for this — see
+   below), after the same armor treatment, and is not knocked out.
+4. **Major branch**: the target takes a flat 1 damage and is knocked out for
+   `DamageRuleset.KnockoutDuration.Roll(entropy)` (`1D10+10`, from data).
+5. A Miss deals no damage and does not knock out (the attack simply failed).
+
+What this piece does **not** validate: that the declared attack roll was actually made at
+Difficult odds, that it targeted a valid head-bearing creature, or that the declaration happened
+at the start of the round. Those are the attack-roll and declaration mechanics of the round loop
+and skill-resolution layers, not this resolver's concern; `ResolveKnockoutAttack`'s parameter
+docs name this as the caller's responsibility.
+
+### `DiceExpression.MaximumPossible()` / `MinimumPossible()` — a small Core addition
+
+Neither method existed before this piece, and both Critical damage (needs the weapon's maximum)
+and the knockout minor-wound branch (needs the weapon's minimum) require them. Added to
+`Brp.Core.Dice.DiceExpression` as pure, entropy-free computations over the parsed terms — signed
+dice terms contribute their highest face when positively signed and lowest (1) when negatively
+signed (the reverse for the minimum), constants contribute their fixed value either way. Both
+throw `NotSupportedException` for a `db`/`db/2` term: weapon damage notation never embeds one (db
+is rolled and added separately, per the p.147 footnote), so no in-scope caller can trigger this,
+and no rule in Ch 6 or Ch 7 defines what a context-free bound on a rolled-elsewhere value would
+even mean.
+
+## Explicitly out of scope (seams for other pieces)
+
+- **First Aid / healing per wound, the Major-Wound *effect*** (shock collapse, unconscious for
+  an hour) — piece E. `AbilitySet.MajorWoundLevel` already exists; this piece only reads it for
+  the knockout comparison, it does not implement what happens when a *non-knockout* attack
+  crosses it.
+- **Hit-location rolling / targeting** — the applicable armor value is supplied by the caller to
+  every `DamageResolver` method; which location was struck and how per-location armor is selected
+  is a separate, not-yet-built concern.
+- **The injury/environmental spot rules** (falling, poison, disease) — a sibling issue. They will
+  produce damage that flows through `DamageResolver.Apply`'s HP-application path, but are not
+  authored here.
+- **Fumble tables** — piece C already carries the flags (`DefenderRollsOnFumbleTable` /
+  `AttackerRollsOnFumbleTable`); the tables themselves are a separate piece.
+- **The five special-success damage *types*** (bleeding, crushing, entangling, impaling,
+  knockback, Ch 6 pp.148–149) and their mechanical effects (e.g. bleeding's ongoing 1 HP/round,
+  crushing's doubled damage modifier and Stamina-roll-or-stunned check) — #52's scope names these
+  explicitly out; `DamageRoll`'s `SourceText` notes where a Special hit's grade is available for a
+  future piece to key off of, but no special-effect logic exists here.
+- **Half damage bonus for thrown weapons** (Ch 6 p.147 / Ch 3 p.47's "entirely self-propelled"
+  distinction) — no thrown weapon exists in the hand-picked gear subset yet (#42), so
+  `WeaponDefinition.ApplyDamageBonus` stays a boolean rather than a three-way (none/half/full)
+  value. `DamageResolver`'s private `RollDamageBonus` helper documents this as the seam a future
+  thrown-weapon addition would extend.
+- **Total Hit Points / Death's Door optional rules** — cut per `orc-scope-filter.md`.
+
+## Consequences
+
+- `DamageResolver` is the single seam piece C and future combat-loop code call to turn a landed
+  hit into HP loss and a wound; `Brp.Rules.Combat` still has no game-engine dependency.
+- `damage-ruleset.json`'s corrected `specialSuccessDamage` section and its `correctionNote` are
+  the load-bearing artifact for future rules-conformance passes: if a later change reintroduces
+  "weaponMax + normalRoll" for Special, `Special_success_uses_the_same_dice_arithmetic_as_a_normal_hit_not_weaponMax_plus_a_fresh_roll`
+  in `DamageResolverTests` fails, by design.
+- The dead-at-end-of-following-round timing is a stateless predicate, not a scheduled event —
+  piece B's combat-round loop (not yet extended to call it) and piece E's First Aid window are
+  both future consumers of `DamageResolver.ResolvesToDeath`.

--- a/docs/decisions/0017-damage.md
+++ b/docs/decisions/0017-damage.md
@@ -18,53 +18,113 @@ Ch 6: Combat, pp.146–156, and Ch 7: Spot Rules, "Knockout Attacks" (p.174), ar
 consulted. `src/Brp.Data/damage-ruleset.json` was drafted by a prior extraction pass before this
 issue's implementation began; per AGENTS.md ("the extractor confirmed them but you own
 correctness"), every formula in it was re-verified against the printed text while building this
-piece, and one was found and corrected — see "The special-success formula" below.
+piece. **Two** successive corrections were needed to the special-success formula before it
+matched the book — see "Special-success damage is weapon-type-dependent" below, which records
+both, since the record of a wrong correction being caught is as load-bearing as the fix itself
+(AGENTS.md's "an unmarked assertion is a defect even when it happens to be right").
 
 ## Decision
 
-### Normal and Special hits share identical damage arithmetic — corrected against the ruleset draft
+### Special-success damage is weapon-type-dependent — corrected twice against the ruleset draft
 
-`damage-ruleset.json`'s original `specialSuccessDamage.formula` read
-`weaponMaxDieResult + normalDamageDiceRoll + damageBonus - armor` — the weapon's maximum result
-plus a *second*, fresh roll of the same dice. This is not what the book says.
+**First (wrong) draft** — `damage-ruleset.json`'s original `specialSuccessDamage.formula` read
+`weaponMaxDieResult + normalDamageDiceRoll + damageBonus - armor`: the weapon's maximum result
+plus a *second*, fresh roll of the same dice, for every weapon. Ch 6, p.147, footnote `**` (the
+footnote the ruleset's own `printedFootnoteExplanation` field already quoted, without drawing the
+conclusion its own prose demanded) disproves this: "This is the damage which that type of attack
+would normally do. This is not the same as 'maximum damage'. **For a greatsword, full damage is
+2D8 on a normal success, 2D8 bleeding damage on a special success**, and on a critical success it
+does 16 damage ignoring armor." The greatsword's normal-success dice (2D8) and special-success
+dice (2D8) are identical — no maximum-plus-fresh-roll combination anywhere.
 
-Ch 6, p.147, footnote `**` (the footnote the ruleset's own `printedFootnoteExplanation` field
-already quoted, without drawing the conclusion its own prose demanded): "This is the damage
-which that type of attack would normally do. This is not the same as 'maximum damage'. **For a
-greatsword, full damage is 2D8 on a normal success, 2D8 bleeding damage on a special success**,
-and on a critical success it does 16 damage ignoring armor." The greatsword's normal-success
-dice (2D8) and special-success dice (2D8) are identical — the "bleeding" label names the
-special-effect *type* (Ch 6, "Special Successes and Damage," pp.148–149: bleeding, crushing,
-entangling, impaling, knockback — all out of scope, see below), not extra dice.
+**Second (also wrong) draft, made during this same issue's implementation** —
+"Special repeats Normal's dice + db exactly, for every weapon," on the strength of Ch 6, p.146's
+general "Special Success" entry ("Often, a special attack means that the weapon does normal
+damage in addition to a special result") and the same p.147 footnote. This is **also wrong**,
+independently caught by both `rules-conformance` and Codex: it is only true for the three special
+types whose special *result* is a separable effect layered on unchanged damage. It is false for
+the other two types, whose special success changes the damage *number* itself:
 
-Ch 6, p.146's general "Special Success" entry independently confirms this: "An exceptional
-roll... Often, a special attack means that **the weapon does normal damage** in addition to a
-special result based on the weapon's type," with a worked example: "with Firearm 60%, your
-character achieves a special success... **This does normal damage (1D8, for example)**, but in
-the case of a firearm, also does impaling damage." No maximum-plus-normal-roll combination
-appears anywhere in either passage. Only Critical uses the weapon's maximum (p.146: "the maximum
-possible damage for the weapon used... plus the normal rolled damage modifier").
+- **Impaling** (Ch 6, pp.149–150): "An impale doubles the dice and modifier for the weapon's
+  normal rolled damage... a short sword normally does 1D6+1 points of damage, while an impale
+  with the same weapon does twice that, or 2D6+2 points of damage... Only the weapon's damage is
+  doubled. If the attacker has a damage modifier, the damage modifier is not doubled, but is
+  instead rolled normally and added to the damage." Ch 6, p.148 (the type's own definition):
+  "Firearms, arrows, and other pointed weapons inflict impaling damage."
+- **Crushing** (Ch 6, p.149): "A crushing special success doubles the damage modifier normally
+  applied to the attack. If the attacker has a negative damage modifier, this becomes no damage
+  modifier, and if there is no damage modifier, it becomes +1D4... The weapon's damage is rolled
+  normally, but the damage modifier is increased." Ch 6, p.148: "Clubs, unarmed strikes, and
+  other blunt weapons can cause crushing damage."
+- **Bleeding / Entangling / Knockback** (Ch 6, pp.149–151): each has a genuinely unchanged-damage
+  special success — the *effect* (ongoing bleeding, pinning, being sent sprawling) is what
+  differs, matching the second draft's premise. No weapon in the hand-picked gear subset uses any
+  of these three types, so the earlier (wrong) blanket rule never actually surfaced in a shipped
+  weapon's numbers — which is exactly why two independent falsification passes, not one, were
+  needed to catch it.
 
-**Corrected formula, as implemented in `DamageResolver.RollDamage`:**
+**Corrected formula, as implemented in `DamageResolver.RollDamage` / `RollSpecialDamage`:**
 
 | Landed grade | Damage | Armor |
 |---|---|---|
 | Miss | none | n/a |
 | Normal | weapon dice + db | subtracted |
-| Special | weapon dice + db (same as Normal) | subtracted |
+| Special — Impaling | 2 × weapon dice (dice **and** fixed modifier) + db (undoubled) | subtracted |
+| Special — Crushing | weapon dice (normal) + doubled db (or +1D4 if none; negative db → 0) | subtracted |
+| Special — Bleeding/Entangling/Knockback | weapon dice + db (identical to Normal); effect deferred | subtracted |
 | Critical | weapon maximum + db | ignored |
 
-`damage-ruleset.json` was updated in the same change to record the correction inline
-(`specialSuccessDamage.correctionNote`) rather than silently overwritten, so the discrepancy and
-its citation stay visible to future readers of the data file, not only this record.
-`rules-conformance` and Codex's cross-check were both told, before this correction, to
-falsify exactly this formula — this is the falsification they should confirm caught something
-real, not a formality that passed by construction.
+**Doubling technique.** Rather than parsing and doubling a `DiceExpression`'s internal terms,
+`DamageResolver` rolls the same expression *twice*, independently, and sums the raw totals. This
+is not an approximation: for a weapon `NdM+C`, two independent rolls summed have exactly the
+distribution of `2N`d`M`+`2C` — each of the `N`-dice groups draws its own `M`-sided faces, so
+summing two independent `N`-dice draws is indistinguishable from drawing `2N` dice from the same
+population, and the fixed constant doubles arithmetically either way. The book's own worked
+example is consistent with this: a short sword's `1D6+1` impale becomes `2D6+2`, which is exactly
+what summing two independent `1D6+1` rolls produces. `RollCrushingDamageBonus` reuses the
+identical technique for a Crushing special's doubled damage bonus.
+
+**Worked examples** (from `DamageResolverTests`, fixed entropy):
+
+- *Medium Pistol* (`1D8`, no db, Impaling) special success with scripted dice `6, 7`: two
+  independent `1D8` rolls, summed = `13`. **Not** a single `1D8` roll (which would cap at 8) —
+  this is the test the coordinator's brief named directly
+  (`Medium_pistol_special_success_doubles_1D8_not_a_single_1D8_roll`).
+- *Club* (`1D8`, db `1D4`, Crushing) special success with scripted dice `5, 3, 2`: one normal
+  weapon roll (`5`), then the db rolled *twice* and summed (`3 + 2 = 5`) for a doubled db, total
+  `10`. A no-db Crushing club instead substitutes the ruleset's `+1D4` fallback for the (absent)
+  db roll.
+
+**Weapon classification** (`weapon-ruleset.json`'s `specialDamageType` field, all 18 shipped
+weapons, each with an inline `specialDamageTypeSource` citation):
+
+- **Impaling** — all 12 firearms (`pistolDerringer`, `pistolLight`, `pistolMedium`,
+  `pistolHeavy`, `revolverLight`, `revolverMedium`, `revolverHeavy`, `rifleBoltAction`,
+  `rifleSniper`, `shotgunDoubleBarreled`, `shotgunSawedOff`, `gunSubmachine`) and the 3 knives
+  (`knifeButcher`, `knifePocket`, `knifeSwitchblade`) — 15 weapons. Ch 6, p.148: "Firearms,
+  arrows, and other pointed weapons inflict impaling damage"; knives are pointed/thrusting
+  weapons (Ch 8's Dagger class), not edged slashing weapons, so they classify as pointed rather
+  than as the (unused) Bleeding type.
+- **Crushing** — `brassKnuckles`, `clubHeavy`, `clubLight` — 3 weapons. Ch 6, p.148: "Clubs,
+  unarmed strikes, and other blunt weapons can cause crushing damage."
+- **Bleeding / Entangling / Knockback** — no shipped weapon (no edged slashing weapon, net,
+  rope, or shield exists in the hand-picked subset); the enum values and their unchanged-damage
+  formula exist for a future weapon addition, per `SpecialDamageType`'s own remarks.
+
+15 + 3 = 18, covering every weapon in `weapon-ruleset.json`;
+`NoirGearRulesetTests.The_special_damage_type_table_covers_every_shipped_weapon_exactly_once`
+pins this as a table, not a sample.
+
+`damage-ruleset.json` records both corrections inline
+(`specialSuccessDamage.correctionHistory`, an ordered list of what was tried and why each attempt
+failed) rather than silently overwriting the file a second time, so a future reader sees the
+falsification history, not just the final answer.
 
 Db is rolled once, separately, and added to the raw (pre-floor) weapon-dice total before the
 floor-at-zero and armor subtraction are applied — Ch 6, p.147 footnote: "Damage modifier, in all
 cases, is rolled separately and added afterwards." `WeaponDefinition.ApplyDamageBonus` gates
-whether it applies at all (firearms do not receive it).
+whether it applies at all (firearms do not receive it) — this still holds for Impaling (db added
+once, undoubled) and is superseded only for Crushing's own doubling/substitution rule.
 
 ### Armor treatment collapse
 
@@ -137,7 +197,13 @@ The printed rule has more structure than "damage > half HP knocks out":
 1. Roll damage for the landed grade using the ordinary `RollDamage` path — "armor defends
    normally in all cases" is read as "apply the grade's ordinary armor treatment" (still ignored
    on a Critical), which is also what "special or critical successes... apply in all cases" says
-   in the same paragraph; not a knockout-specific armor override.
+   in the same paragraph; not a knockout-specific armor override. Because this reuses
+   `RollDamage` unchanged, an Impaling special's doubled damage (or a Crushing special's
+   doubled/substituted damage modifier) already flows into the roll used for the next step —
+   `ResolveKnockoutAttack` does not special-case this itself, and
+   `Knockout_attack_with_an_impaling_special_uses_the_doubled_damage_for_the_major_wound_determination`
+   pins that an undoubled roll that would otherwise fall short of a major wound crosses the
+   threshold once Impaling's doubling is applied.
 2. Compare that rolled damage against `target.MajorWoundLevel` (`>=` is major, `<` is minor).
 3. **Minor branch**: the rolled damage is discarded; the target instead takes
    `weapon.Damage.MinimumPossible()` (a new method added to `DiceExpression` for this — see
@@ -178,11 +244,12 @@ even mean.
   authored here.
 - **Fumble tables** — piece C already carries the flags (`DefenderRollsOnFumbleTable` /
   `AttackerRollsOnFumbleTable`); the tables themselves are a separate piece.
-- **The five special-success damage *types*** (bleeding, crushing, entangling, impaling,
-  knockback, Ch 6 pp.148–149) and their mechanical effects (e.g. bleeding's ongoing 1 HP/round,
-  crushing's doubled damage modifier and Stamina-roll-or-stunned check) — #52's scope names these
-  explicitly out; `DamageRoll`'s `SourceText` notes where a Special hit's grade is available for a
-  future piece to key off of, but no special-effect logic exists here.
+- **The special-success *effects*** (bleeding's ongoing 1 HP/round, crushing's
+  Stamina-roll-or-stunned check, entangling's pinning, impaling's lodged-weapon/extraction rules,
+  knockback's resisted shove, Ch 6 pp.149–151) — #52's scope names these explicitly out. Only the
+  *damage number* each type produces is implemented (see above); `DamageRoll.SpecialDamageTypeApplied`
+  and `SourceText` carry which type applied so a future piece can key its effect off of the same
+  roll without re-deriving it.
 - **Half damage bonus for thrown weapons** (Ch 6 p.147 / Ch 3 p.47's "entirely self-propelled"
   distinction) — no thrown weapon exists in the hand-picked gear subset yet (#42), so
   `WeaponDefinition.ApplyDamageBonus` stays a boolean rather than a three-way (none/half/full)
@@ -194,10 +261,14 @@ even mean.
 
 - `DamageResolver` is the single seam piece C and future combat-loop code call to turn a landed
   hit into HP loss and a wound; `Brp.Rules.Combat` still has no game-engine dependency.
-- `damage-ruleset.json`'s corrected `specialSuccessDamage` section and its `correctionNote` are
-  the load-bearing artifact for future rules-conformance passes: if a later change reintroduces
-  "weaponMax + normalRoll" for Special, `Special_success_uses_the_same_dice_arithmetic_as_a_normal_hit_not_weaponMax_plus_a_fresh_roll`
-  in `DamageResolverTests` fails, by design.
+- `damage-ruleset.json`'s `specialSuccessDamage.correctionHistory` and `specialDamageByType`
+  section, plus `weapon-ruleset.json`'s per-weapon `specialDamageType` field, are the load-bearing
+  artifacts for future rules-conformance passes: if a later change reintroduces a uniform
+  "special = normal" or "special = weaponMax + normalRoll" formula, either
+  `Impaling_special_doubles_the_whole_weapon_damage_expression_and_adds_an_undoubled_damage_bonus`
+  or `Crushing_special_rolls_normal_weapon_dice_but_doubles_a_positive_damage_bonus` in
+  `DamageResolverTests` fails, by design — and `A_special_hit_deals_more_than_a_normal_hit_for_every_shipped_special_damage_type`
+  fails if either type's damage number regresses to match Normal.
 - The dead-at-end-of-following-round timing is a stateless predicate, not a scheduled event —
   piece B's combat-round loop (not yet extended to call it) and piece E's First Aid window are
   both future consumers of `DamageResolver.ResolvesToDeath`.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -39,3 +39,4 @@ supersedes it — the original is not edited or deleted.
 | [0014](0014-range-bands.md) | Missile/firearm range bands: the four bands, the long-range override, and reconciling three treatments of range | Accepted |
 | [0015](0015-combat-round.md) | Combat round: three phases, DEX-rank ordering, and the weapon-type tiebreak | Accepted |
 | [0016](0016-attack-defense-matrix.md) | Attack/defense matrix: data-driven cells, the undefended case, and the deferred -30% | Accepted |
+| [0017](0017-damage.md) | Damage: normal/special/critical arithmetic, hit-point conditions, and knockout attacks | Accepted |

--- a/src/Brp.Core/Dice/DiceExpression.cs
+++ b/src/Brp.Core/Dice/DiceExpression.cs
@@ -108,6 +108,30 @@ public sealed class DiceExpression
         return new DiceRoll(total, rawTotal, results);
     }
 
+    /// <summary>
+    /// The highest total this expression can produce, with no entropy consumed -- e.g. Ch 6:
+    /// Combat, "Critical Success" (p.146): "the maximum possible damage for the weapon used
+    /// (6 for 1D6, 9 for 1D8+1, etc.)". Dice terms contribute their highest face when positively
+    /// signed and their lowest (1) when negatively signed, since a negative term's least-negative
+    /// contribution to the total is what a die of 1 gives it.
+    /// </summary>
+    /// <exception cref="NotSupportedException">
+    /// The expression contains a <c>db</c> or half-<c>db</c> term. Weapon damage notation never
+    /// embeds these (the damage bonus is rolled and added separately -- Ch 6, p.147 footnote
+    /// **), so this is a caller-misuse guard rather than a rule this type needs to model.
+    /// </exception>
+    public int MaximumPossible() => _terms.Sum(term => term.MaximumPossible());
+
+    /// <summary>
+    /// The lowest total this expression can produce (before the zero floor <see cref="Roll"/>
+    /// applies to a rolled total), with no entropy consumed -- e.g. Ch 7: Spot Rules, "Knockout
+    /// Attacks" (p.174): "the target is dealt the minimum damage for the weapon."
+    /// </summary>
+    /// <exception cref="NotSupportedException">
+    /// The expression contains a <c>db</c> or half-<c>db</c> term. See <see cref="MaximumPossible"/>.
+    /// </exception>
+    public int MinimumPossible() => _terms.Sum(term => term.MinimumPossible());
+
     private static bool TryParseCore(string? notation, out DiceExpression? expression, out string error)
     {
         expression = null;
@@ -314,6 +338,22 @@ public sealed class DiceExpression
                     throw new InvalidOperationException($"Unknown term kind {Kind}.");
             }
         }
+
+        public int MaximumPossible() => Kind switch
+        {
+            TermKind.Dice => Sign > 0 ? Sign * Count * Sides : Sign * Count,
+            TermKind.Constant => Sign * Constant,
+            _ => throw new NotSupportedException(
+                $"'{Bare}' has no context-free maximum -- damage-bonus terms are rolled and added separately."),
+        };
+
+        public int MinimumPossible() => Kind switch
+        {
+            TermKind.Dice => Sign > 0 ? Sign * Count : Sign * Count * Sides,
+            TermKind.Constant => Sign * Constant,
+            _ => throw new NotSupportedException(
+                $"'{Bare}' has no context-free minimum -- damage-bonus terms are rolled and added separately."),
+        };
 
         private static (int RawTotal, IReadOnlyList<int> Faces) RollDamageBonus(
             DiceExpression? damageBonus, IEntropySource entropy)

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -22,6 +22,7 @@
     <EmbeddedResource Include="range-band-ruleset.json" />
     <EmbeddedResource Include="combat-round-ruleset.json" />
     <EmbeddedResource Include="attack-defense-matrix-ruleset.json" />
+    <EmbeddedResource Include="damage-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirDamageRuleset.cs
+++ b/src/Brp.Data/NoirDamageRuleset.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Brp.Core.Dice;
+using Brp.Rules.Combat;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's damage thresholds from embedded JSON. Sourced: Ch 2: Characters, "Hit Points"
+/// (p.13); Ch 6: Combat, "Damage &amp; Healing" (pp.154-156); Ch 7: Spot Rules, "Knockout
+/// Attacks" (p.174). Recorded in <c>docs/decisions/0017-damage.md</c>.
+/// </summary>
+public static class NoirDamageRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable damage ruleset from the shipped data.</summary>
+    public static DamageRuleset Load()
+    {
+        var assembly = typeof(NoirDamageRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.damage-ruleset.json")
+            ?? throw new InvalidOperationException("The damage ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<DamageRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The damage ruleset data is empty.");
+
+        var knockoutDuration = DiceExpression.Parse(data.KnockoutRule.KnockoutDurationRoundsFormula);
+
+        return new DamageRuleset(
+            unconsciousHitPointLevel: data.DamageThresholds.UnconsciousHitPointLevel,
+            deadHitPointLevel: data.DamageThresholds.DeadHitPointLevel,
+            knockoutDuration: knockoutDuration);
+    }
+
+    private sealed class DamageRulesetData
+    {
+        public required DamageThresholdsData DamageThresholds { get; init; }
+
+        public required KnockoutRuleData KnockoutRule { get; init; }
+    }
+
+    private sealed class DamageThresholdsData
+    {
+        public required int UnconsciousHitPointLevel { get; init; }
+
+        public required int DeadHitPointLevel { get; init; }
+    }
+
+    private sealed class KnockoutRuleData
+    {
+        public required string KnockoutDurationRoundsFormula { get; init; }
+    }
+}

--- a/src/Brp.Data/NoirDamageRuleset.cs
+++ b/src/Brp.Data/NoirDamageRuleset.cs
@@ -26,11 +26,14 @@ public static class NoirDamageRuleset
             ?? throw new InvalidOperationException("The damage ruleset data is empty.");
 
         var knockoutDuration = DiceExpression.Parse(data.KnockoutRule.KnockoutDurationRoundsFormula);
+        var crushingNoModifierBonus = DiceExpression.Parse(
+            data.DamageFormulas.SpecialSuccessDamage.SpecialDamageByType.Crushing.CrushingNoModifierBonusFormula);
 
         return new DamageRuleset(
             unconsciousHitPointLevel: data.DamageThresholds.UnconsciousHitPointLevel,
             deadHitPointLevel: data.DamageThresholds.DeadHitPointLevel,
-            knockoutDuration: knockoutDuration);
+            knockoutDuration: knockoutDuration,
+            crushingNoModifierBonus: crushingNoModifierBonus);
     }
 
     private sealed class DamageRulesetData
@@ -38,6 +41,8 @@ public static class NoirDamageRuleset
         public required DamageThresholdsData DamageThresholds { get; init; }
 
         public required KnockoutRuleData KnockoutRule { get; init; }
+
+        public required DamageFormulasData DamageFormulas { get; init; }
     }
 
     private sealed class DamageThresholdsData
@@ -50,5 +55,25 @@ public static class NoirDamageRuleset
     private sealed class KnockoutRuleData
     {
         public required string KnockoutDurationRoundsFormula { get; init; }
+    }
+
+    private sealed class DamageFormulasData
+    {
+        public required SpecialSuccessDamageData SpecialSuccessDamage { get; init; }
+    }
+
+    private sealed class SpecialSuccessDamageData
+    {
+        public required SpecialDamageByTypeData SpecialDamageByType { get; init; }
+    }
+
+    private sealed class SpecialDamageByTypeData
+    {
+        public required CrushingData Crushing { get; init; }
+    }
+
+    private sealed class CrushingData
+    {
+        public required string CrushingNoModifierBonusFormula { get; init; }
     }
 }

--- a/src/Brp.Data/NoirGearRuleset.cs
+++ b/src/Brp.Data/NoirGearRuleset.cs
@@ -87,6 +87,7 @@ public static class NoirGearRuleset
             ApplyDamageBonus: entry.ApplyDamageBonus,
             DamageByRange: damageByRange,
             Firearm: firearm,
+            SpecialDamageType: ToSpecialDamageType(entry.SpecialDamageType),
             Source: entry.Source);
     }
 
@@ -144,6 +145,16 @@ public static class NoirGearRuleset
 
     private static int? SingleNumber(JsonElement element) =>
         element.ValueKind == JsonValueKind.Number ? element.GetInt32() : null;
+
+    private static SpecialDamageType ToSpecialDamageType(string value) => value switch
+    {
+        "bleeding" => SpecialDamageType.Bleeding,
+        "crushing" => SpecialDamageType.Crushing,
+        "entangling" => SpecialDamageType.Entangling,
+        "impaling" => SpecialDamageType.Impaling,
+        "knockback" => SpecialDamageType.Knockback,
+        _ => throw new InvalidOperationException($"Unknown special damage type '{value}'."),
+    };
 
     private static WeaponClass ToWeaponClass(string value) => value switch
     {
@@ -219,6 +230,8 @@ public static class NoirGearRuleset
         public int? BaseChanceWithoutBipod { get; init; }
 
         public DamageByRangeData? DamageByRange { get; init; }
+
+        public required string SpecialDamageType { get; init; }
 
         public required string Source { get; init; }
     }

--- a/src/Brp.Data/damage-ruleset.json
+++ b/src/Brp.Data/damage-ruleset.json
@@ -21,7 +21,7 @@
       {
         "title": "Knockout Attacks (Ch 7: Spot Rules)",
         "printedPage": 174,
-        "sourceNote": "Defines the condition for a knockout (Difficult attack, damage > 1/2 total HP)."
+        "sourceNote": "Defines the condition for a knockout (Difficult attack, damage >= 1/2 total HP -- 'equivalent to a major wound')."
       }
     ]
   },
@@ -29,7 +29,7 @@
     "unconsciousHitPointLevel": 2,
     "unconsciousHitPointCondition": "Character falls unconscious when hit points reduced to 1 or 2",
     "deadHitPointLevel": 0,
-    "deadHitPointCondition": "Character dies at end of round if hit points reach 0 or below",
+    "deadHitPointCondition": "Character dies at end of the following round if hit points reach 0 or below",
     "deadHitPointResolutionTiming": "end of following round",
     "trackNegativeHitPoints": true
   },
@@ -39,8 +39,8 @@
       "numerator": 1,
       "denominator": 2
     },
-    "damageThresholdDescription": "Damage exceeds half (1/2) of the target's total hit points",
-    "damageThresholdNote": "The engine reuses AbilitySet.MajorWoundLevel (Ch 2, p.14, majorWoundDivisor=2, rounded up) already computed in Layer 1, rather than re-deriving this fraction here, so the half-hit-points figure is defined in exactly one place. Comparison is '>=' (major wound, Ch 6 p.156: 'equal to or more than half'), not the loose '>' this description's prose implies.",
+    "damageThresholdDescription": "Damage is at least half (1/2) of the target's total hit points (equivalent to a major wound)",
+    "damageThresholdNote": "The engine reuses AbilitySet.MajorWoundLevel (Ch 2, p.14, majorWoundDivisor=2, rounded up) already computed in Layer 1, rather than re-deriving this fraction here, so the half-hit-points figure is defined in exactly one place. Comparison is '>=' (major wound, Ch 6 p.156: 'equal to or more than half'), matching this description.",
     "knockoutDurationRoundsFormula": "1D10+10",
     "printedRule": "A Difficult attack roll is made as if targeting a particular body part (such as the head). The attack is non-lethal and is not intended to do damage, though damage is rolled to determine the potential for a knockout. Armor defends normally in all cases. If the damage is equivalent to a minor wound, the original damage rolled is ignored and the target is dealt the minimum damage for the weapon (after armor) but is not knocked out. If the attack is successful and the rolled damage is equivalent to a major wound (after armor), the target takes 1 damage and is knocked out for 1D10+10 rounds. The effects of special or critical successes (such as extra damage or bypassing armor) apply in all cases, while other special effects (slashing damage, knockback, etc.) do not apply to knockout attempts."
   },
@@ -72,8 +72,40 @@
       "printedSource": "Attack and Defense Matrix, p.147"
     },
     "specialSuccessDamage": {
-      "formula": "weaponDamageDice + damageBonus - armor",
-      "correctionNote": "CORRECTED during #52 implementation. This section originally read 'weaponMaxDieResult + normalDamageDiceRoll + damageBonus - armor', attributed to the footnote below -- but the footnote's own greatsword example contradicts that formula: 'full damage is 2D8 on a normal success, 2D8 bleeding damage on a special success' is the SAME dice (2D8), not the weapon's maximum (16) plus a fresh 2D8. Ch 6 p.146's general 'Special Success' entry confirms this independently: 'the weapon does normal damage in addition to a special result' -- e.g. 'This does normal damage (1D8, for example)' for a firearm example. So Normal and Special share identical damage arithmetic; the only difference is the (out-of-scope) special-effect type layered on top. Only Critical adds the weapon's maximum. See docs/decisions/0017-damage.md.",
+      "correctionHistory": [
+        "ORIGINAL (rules-extractor draft): 'weaponMaxDieResult + normalDamageDiceRoll + damageBonus - armor' for every weapon, citing the p.147 footnote's greatsword example. WRONG: the footnote's own example ('full damage is 2D8 on a normal success, 2D8 bleeding damage on a special success') shows special repeats the normal dice, it never adds the weapon's maximum.",
+        "FIRST CORRECTION (during #52 implementation): 'special = normal weapon dice + damage bonus - armor' for every weapon, i.e. identical to Normal. ALSO WRONG, caught independently by rules-conformance and Codex: this is only true for the three special-damage types whose special RESULT is a separable effect layered on top of unchanged damage (bleeding, entangling, knockback -- pp.149-151). It is not true for impaling (p.150) or crushing (p.149), whose special success changes the damage NUMBER itself, not just an added effect.",
+        "CURRENT (correct): the formula is weapon-type-dependent -- see specialDamageByType below. Every shipped weapon (weapon-ruleset.json's specialDamageType field) is either impaling (firearms, pointed knives) or crushing (clubs, brass knuckles); no shipped weapon uses bleeding/entangling/knockback, though the type and its unchanged-damage formula are still modeled for future weapons."
+      ],
+      "specialDamageByType": {
+        "impaling": {
+          "formula": "2 x weaponDamageDice (dice AND any fixed modifier doubled) + damageBonus (rolled once, NOT doubled) - armor",
+          "printedRule": "An impale doubles the dice and modifier for the weapon's normal rolled damage. For example, a short sword normally does 1D6+1 points of damage, while an impale with the same weapon does twice that, or 2D6+2 points of damage. Only the weapon's damage is doubled. If the attacker has a damage modifier, the damage modifier is not doubled, but is instead rolled normally and added to the damage.",
+          "printedSource": "Ch 6: Combat, \"Impaling\", pp.149-150"
+        },
+        "crushing": {
+          "formula": "weaponDamageDice (normal, not doubled) + doubledDamageBonus - armor",
+          "doubledDamageBonusRule": "If the attacker's damage modifier is positive, roll it twice (fresh) and sum, equivalent to doubling its dice count. If the attacker has a negative damage modifier, it becomes no modifier at all (0, not rolled). If the attacker has no damage modifier, it becomes a flat bonus rolled from crushingNoModifierBonusFormula (below) instead.",
+          "crushingNoModifierBonusFormula": "1D4",
+          "printedRule": "A crushing special success doubles the damage modifier normally applied to the attack. If the attacker has a negative damage modifier, this becomes no damage modifier, and if there is no damage modifier, it becomes +1D4 (see the Damage Modifier Table). The weapon's damage is rolled normally, but the damage modifier is increased.",
+          "printedSource": "Ch 6: Combat, \"Crushing\", p.149"
+        },
+        "bleeding": {
+          "formula": "weaponDamageDice + damageBonus - armor (unchanged from Normal)",
+          "note": "The special RESULT (ongoing 1 HP/round bleeding until stopped or healed) is a deferred effect, not a damage-number change. No shipped weapon uses this type.",
+          "printedSource": "Ch 6: Combat, \"Bleeding\", p.149"
+        },
+        "entangling": {
+          "formula": "weaponDamageDice + damageBonus - armor (unchanged from Normal)",
+          "note": "The special RESULT (pinning/ensnaring) is a deferred effect, not a damage-number change. No shipped weapon uses this type.",
+          "printedSource": "Ch 6: Combat, \"Entangling\", p.151"
+        },
+        "knockback": {
+          "formula": "weaponDamageDice + damageBonus - armor (unchanged from Normal)",
+          "note": "The special RESULT (sent sprawling backwards, resisted vs. SIZ) is a deferred effect, not a damage-number change. No shipped weapon uses this type.",
+          "printedSource": "Ch 6: Combat, \"Knockback\", p.151"
+        }
+      },
       "printedDescription": "Attack does full damage** plus normal damage modifier and appropriate special result. Defender's armor value subtracted from damage.",
       "printedFootnoteExplanation": "** This is the damage which that type of attack would normally do. This is not the same as 'maximum damage'. For a greatsword, full damage is 2D8 on a normal success, 2D8 bleeding damage on a special success, and on a critical success it does 16 damage ignoring armor. Damage modifier, in all cases, is rolled separately and added afterwards.",
       "specialDamageTypes": [
@@ -83,7 +115,7 @@
         "impaling",
         "knockback"
       ],
-      "printedSource": "Special Success, p.146; Special Successes and Damage, pp.148-149; Attack and Defense Matrix footnote **, p.147"
+      "printedSource": "Special Success, p.146; Special Successes and Damage, pp.148-151; Attack and Defense Matrix footnote **, p.147"
     },
     "criticalSuccessDamage": {
       "formula": "weaponMaxDieResult + damageBonus, armor ignored",
@@ -116,10 +148,10 @@
   },
   "notes": [
     "All threshold values (unconscious level, dead level, knockout fraction) are provided as ruleset data for the engine to consume, not as hardcoded constants.",
-    "CORRECTED (#52): the special-success formula is the SAME weapon dice + damage bonus as a normal hit, not 'weapon max die result + fresh normal roll + damage bonus'. The footnote's own greatsword example proves it: '2D8 on normal success, 2D8 bleeding damage on special success, and 16 damage on critical success ignoring armor' -- special repeats the normal dice (2D8), it does not add the maximum (16) on top. Only critical uses the maximum. See specialSuccessDamage.correctionNote and docs/decisions/0017-damage.md.",
+    "CORRECTED TWICE (#52): the special-success formula is NOT 'weapon max die result + fresh normal roll + damage bonus' (the original draft), and is NOT uniformly 'the same weapon dice + damage bonus as a normal hit' either (a first, still-wrong correction made during #52's own implementation). It is weapon-type-dependent -- see damageFormulas.specialSuccessDamage.specialDamageByType: impaling (firearms, pointed knives) doubles the weapon's whole damage expression (dice and fixed modifier) and adds an undoubled damage bonus (Ch 6, p.150); crushing (clubs, brass knuckles) rolls normal weapon dice but doubles the damage bonus, or substitutes +1D4 if there is none (Ch 6, p.149); the remaining three types (bleeding, entangling, knockback -- unused by any shipped weapon) use the same dice+bonus arithmetic as Normal, with only their special effect deferred. See docs/decisions/0017-damage.md.",
     "Armor treatment: Subtracted for normal/special, Bypassed or DoesNotApply both collapse to 'ignored' for critical outcomes (ADR 0016).",
     "Negative HP is tracked per the ruleset.",
-    "Knockout requires a Difficult attack whose damage (after armor) exceeds 1/2 of target's total HP. The knocked-out duration is 1D10+10 rounds.",
+    "Knockout requires a Difficult attack whose damage (after armor) is at least (>=) half of the target's total HP -- 'equivalent to a major wound', Ch 6 p.156. The knocked-out duration is 1D10+10 rounds. An impaling special used as the knockout's damage roll uses the doubled impaling damage, per Ch 7 p.174: 'The effects of special or critical successes... apply in all cases.'",
     "The damage bonus (damage modifier) table (STR+SIZ → dice) already exists in Layer 1 (ability-ruleset.json) and is sourced from Ch 2: Characters, pp.10-13."
   ],
   "verbatimPrintedRules": {

--- a/src/Brp.Data/damage-ruleset.json
+++ b/src/Brp.Data/damage-ruleset.json
@@ -1,0 +1,132 @@
+{
+  "damageRulesetSource": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 6: Combat",
+    "sections": [
+      {
+        "title": "Damage (Attack and Defense Matrix footnote **)",
+        "printedPage": 147,
+        "sourceNote": "Footnote ** on the Attack and Defense Matrix explains damage formulas by outcome grade."
+      },
+      {
+        "title": "Special Successes and Damage",
+        "printedPages": "148-149",
+        "sourceNote": "Defines the five special damage types and their mechanical effects."
+      },
+      {
+        "title": "Damage & Healing",
+        "printedPages": "154-156",
+        "sourceNote": "Defines conscious/unconscious/dead thresholds and minor/major/fatal wound classifications."
+      },
+      {
+        "title": "Knockout Attacks (Ch 7: Spot Rules)",
+        "printedPage": 174,
+        "sourceNote": "Defines the condition for a knockout (Difficult attack, damage > 1/2 total HP)."
+      }
+    ]
+  },
+  "damageThresholds": {
+    "unconsciousHitPointLevel": 2,
+    "unconsciousHitPointCondition": "Character falls unconscious when hit points reduced to 1 or 2",
+    "deadHitPointLevel": 0,
+    "deadHitPointCondition": "Character dies at end of round if hit points reach 0 or below",
+    "deadHitPointResolutionTiming": "end of following round",
+    "trackNegativeHitPoints": true
+  },
+  "knockoutRule": {
+    "requirementGrade": "Difficult",
+    "damageThresholdFraction": {
+      "numerator": 1,
+      "denominator": 2
+    },
+    "damageThresholdDescription": "Damage exceeds half (1/2) of the target's total hit points",
+    "damageThresholdNote": "The engine reuses AbilitySet.MajorWoundLevel (Ch 2, p.14, majorWoundDivisor=2, rounded up) already computed in Layer 1, rather than re-deriving this fraction here, so the half-hit-points figure is defined in exactly one place. Comparison is '>=' (major wound, Ch 6 p.156: 'equal to or more than half'), not the loose '>' this description's prose implies.",
+    "knockoutDurationRoundsFormula": "1D10+10",
+    "printedRule": "A Difficult attack roll is made as if targeting a particular body part (such as the head). The attack is non-lethal and is not intended to do damage, though damage is rolled to determine the potential for a knockout. Armor defends normally in all cases. If the damage is equivalent to a minor wound, the original damage rolled is ignored and the target is dealt the minimum damage for the weapon (after armor) but is not knocked out. If the attack is successful and the rolled damage is equivalent to a major wound (after armor), the target takes 1 damage and is knocked out for 1D10+10 rounds. The effects of special or critical successes (such as extra damage or bypassing armor) apply in all cases, while other special effects (slashing damage, knockback, etc.) do not apply to knockout attempts."
+  },
+  "minorWoundClassification": {
+    "damageThreshold": 0.5,
+    "damageThresholdDescription": "A single wound that costs up to half of the character's total hit points",
+    "unconsciousFromCumulative": true,
+    "unconsciousFromCumulativeCondition": "If minor wounds total to equal the amount of a major wound (half total HP), character must make successful Luck roll or fall unconscious",
+    "unconsciousFromMinimalHP": true,
+    "unconsciousFromMinimalHPCondition": "If minor wounds reduce character to 1 or 2 hit points, they are knocked out for up to an hour"
+  },
+  "majorWoundClassification": {
+    "damageThreshold": 0.5,
+    "damageThresholdDescription": "Injury equal to or more than half the character's total hit points",
+    "shockDuration": "Combat rounds equal to current remaining hit points",
+    "immediateUnconsciousCondition": "A character possessing 2 or fewer hit points after suffering a major wound collapses immediately from shock and loss of blood and is unconscious for an hour"
+  },
+  "fatalWoundClassification": {
+    "damageThreshold": "exceeds current hit points",
+    "damageThresholdDescription": "Damage that reduces character to 0 or negative hit points",
+    "immediateEffect": "Character is immediately knocked prone but unable to take any action of any type",
+    "resolutionCondition": "If fatally wounded character receives medical attention (First Aid, Medicine, a power, an item, etc.) in the round they received the fatal wound or the round immediately after, and their hit points are brought up to 1 or more, they survive"
+  },
+  "damageFormulas": {
+    "normalHitDamage": {
+      "formula": "weaponDamageDice + damageBonus - armor",
+      "printedDescription": "Attack strikes defender and rolls damage normally. Defender's armor value subtracted from damage.",
+      "damageModifierApplication": "rolled separately and added after",
+      "printedSource": "Attack and Defense Matrix, p.147"
+    },
+    "specialSuccessDamage": {
+      "formula": "weaponDamageDice + damageBonus - armor",
+      "correctionNote": "CORRECTED during #52 implementation. This section originally read 'weaponMaxDieResult + normalDamageDiceRoll + damageBonus - armor', attributed to the footnote below -- but the footnote's own greatsword example contradicts that formula: 'full damage is 2D8 on a normal success, 2D8 bleeding damage on a special success' is the SAME dice (2D8), not the weapon's maximum (16) plus a fresh 2D8. Ch 6 p.146's general 'Special Success' entry confirms this independently: 'the weapon does normal damage in addition to a special result' -- e.g. 'This does normal damage (1D8, for example)' for a firearm example. So Normal and Special share identical damage arithmetic; the only difference is the (out-of-scope) special-effect type layered on top. Only Critical adds the weapon's maximum. See docs/decisions/0017-damage.md.",
+      "printedDescription": "Attack does full damage** plus normal damage modifier and appropriate special result. Defender's armor value subtracted from damage.",
+      "printedFootnoteExplanation": "** This is the damage which that type of attack would normally do. This is not the same as 'maximum damage'. For a greatsword, full damage is 2D8 on a normal success, 2D8 bleeding damage on a special success, and on a critical success it does 16 damage ignoring armor. Damage modifier, in all cases, is rolled separately and added afterwards.",
+      "specialDamageTypes": [
+        "bleeding",
+        "crushing",
+        "entangling",
+        "impaling",
+        "knockback"
+      ],
+      "printedSource": "Special Success, p.146; Special Successes and Damage, pp.148-149; Attack and Defense Matrix footnote **, p.147"
+    },
+    "criticalSuccessDamage": {
+      "formula": "weaponMaxDieResult + damageBonus, armor ignored",
+      "printedDescription": "Attack does full damage** plus normal damage modifier. Defender's armor value is bypassed (or does not apply).",
+      "armorTreatment": "ignored",
+      "collapseBypassed": "Both Bypassed and DoesNotApply outcomes treat armor as ignored",
+      "printedSource": "Critical Success, p.146; Attack and Defense Matrix, p.147"
+    }
+  },
+  "armorSubtraction": {
+    "normalAndSpecial": "Defender's armor value subtracted from damage",
+    "critical": "Armor is bypassed and does not apply"
+  },
+  "damageBonusHandling": {
+    "dataSourceReference": "Layer 1: damage-modifier table in ability-ruleset.json (Ch 2, pp.10-15)",
+    "dataSourceNote": "The damage bonus (damage modifier) table is derived from STR+SIZ and already exists in Layer 1. It is NOT retranscribed here.",
+    "damageModifierTable": {
+      "source": "Chapter 2: Characters, pp.10-13",
+      "location": "ability-ruleset.json",
+      "alreadyImplemented": true
+    },
+    "application": {
+      "weaponAppliesBonus": "weapon.applyDamageBonus flag determines if bonus is added",
+      "bonusRolledSeparately": true,
+      "bonusAddedAfterWeaponDice": true,
+      "firearmExemption": "Self-propelled weapons (firearms) do not receive damage modifier"
+    },
+    "printedRule": "Damage modifier, in all cases, is rolled separately and added afterwards.",
+    "printedSource": "Attack and Defense Matrix footnote **, p.147"
+  },
+  "notes": [
+    "All threshold values (unconscious level, dead level, knockout fraction) are provided as ruleset data for the engine to consume, not as hardcoded constants.",
+    "CORRECTED (#52): the special-success formula is the SAME weapon dice + damage bonus as a normal hit, not 'weapon max die result + fresh normal roll + damage bonus'. The footnote's own greatsword example proves it: '2D8 on normal success, 2D8 bleeding damage on special success, and 16 damage on critical success ignoring armor' -- special repeats the normal dice (2D8), it does not add the maximum (16) on top. Only critical uses the maximum. See specialSuccessDamage.correctionNote and docs/decisions/0017-damage.md.",
+    "Armor treatment: Subtracted for normal/special, Bypassed or DoesNotApply both collapse to 'ignored' for critical outcomes (ADR 0016).",
+    "Negative HP is tracked per the ruleset.",
+    "Knockout requires a Difficult attack whose damage (after armor) exceeds 1/2 of target's total HP. The knocked-out duration is 1D10+10 rounds.",
+    "The damage bonus (damage modifier) table (STR+SIZ → dice) already exists in Layer 1 (ability-ruleset.json) and is sourced from Ch 2: Characters, pp.10-13."
+  ],
+  "verbatimPrintedRules": {
+    "unconsciousThreshold": "Your character loses consciousness when their hit points are reduced to 2 or less, and if their hit points reach 0, they die at the end of the following round. (Ch 2, p.13)",
+    "minorWound": "A minor wound is a single wound that costs your character up to half of their total hit points. [...] Additionally, if your character suffers minor wounds enough to reduce them to 1 or 2 hit points, this knocks them out for up to an hour. (Ch 6, p.154)",
+    "majorWound": "When your character has sustained an injury equal to or more than half the character's total hit points, they have suffered a major wound. [...] A character possessing 2 or fewer hit points after suffering a major wound collapses immediately from shock and loss of blood and is unconscious for an hour. (Ch 6, pp.155-156)",
+    "fatalWound": "A fatal wound is one that does more hit points in damage than your character has currently. If an injury reduces your character to 0 or negative hit points, they have suffered a fatal wound. Your character is immediately knocked prone but unable to take any action of any type. (Ch 6, p.156)",
+    "knockoutAttacks": "Knockout attacks only work against humans and humanoids, or other living beings with clearly defined heads. To render a target unconscious, declare your character's intent at the beginning of the round. A Difficult attack roll is made as if targeting a particular body part (such as the head). The attack is non-lethal and is not intended to do damage, though damage is rolled to determine the potential for a knockout. Armor defends normally in all cases. If the damage is equivalent to a minor wound, the original damage rolled is ignored and the target is dealt the minimum damage for the weapon (after armor) but is not knocked out. If the attack is successful and the rolled damage is equivalent to a major wound (after armor), the target takes 1 damage and is knocked out for 1D10+10 rounds (the gamemaster rolls secretly for this). (Ch 7, p.174)"
+  }
+}

--- a/src/Brp.Data/weapon-ruleset.json
+++ b/src/Brp.Data/weapon-ruleset.json
@@ -7,7 +7,9 @@
       "damage": "2",
       "applyDamageBonus": true,
       "weaponClass": "Brawl",
-      "source": "Ch 8, Modern Melee Weapons table (p.201)"
+      "source": "Ch 8, Modern Melee Weapons table (p.201)",
+      "specialDamageType": "crushing",
+      "specialDamageTypeSource": "Ch 6, p.149 (Special Successes and Damage, 'Crushing'): 'Clubs, unarmed strikes, and other blunt weapons can cause crushing damage.'"
     },
     {
       "id": "clubHeavy",
@@ -16,7 +18,9 @@
       "damage": "1D8",
       "applyDamageBonus": true,
       "weaponClass": "Club",
-      "source": "Ch 8, Primitive Melee Weapons table (p.196); description text (p.194) names the modern equivalent as a crowbar"
+      "source": "Ch 8, Primitive Melee Weapons table (p.196); description text (p.194) names the modern equivalent as a crowbar",
+      "specialDamageType": "crushing",
+      "specialDamageTypeSource": "Ch 6, p.149 (Special Successes and Damage, 'Crushing'): 'Clubs, unarmed strikes, and other blunt weapons can cause crushing damage.'"
     },
     {
       "id": "clubLight",
@@ -25,7 +29,9 @@
       "damage": "1D6",
       "applyDamageBonus": true,
       "weaponClass": "Club",
-      "source": "Ch 8, Primitive Melee Weapons table (p.196); description text (p.194) names modern equivalents: baseball bat, tire iron, truncheon"
+      "source": "Ch 8, Primitive Melee Weapons table (p.196); description text (p.194) names modern equivalents: baseball bat, tire iron, truncheon",
+      "specialDamageType": "crushing",
+      "specialDamageTypeSource": "Ch 6, p.149 (Special Successes and Damage, 'Crushing'): 'Clubs, unarmed strikes, and other blunt weapons can cause crushing damage.'"
     },
     {
       "id": "knifeButcher",
@@ -34,7 +40,9 @@
       "damage": "1D6",
       "applyDamageBonus": true,
       "weaponClass": "Dagger",
-      "source": "Ch 8, Modern Melee Weapons table (p.201)"
+      "source": "Ch 8, Modern Melee Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "knifePocket",
@@ -43,7 +51,9 @@
       "damage": "1D4",
       "applyDamageBonus": true,
       "weaponClass": "Dagger",
-      "source": "Ch 8, Modern Melee Weapons table (p.201)"
+      "source": "Ch 8, Modern Melee Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "knifeSwitchblade",
@@ -52,7 +62,9 @@
       "damage": "1D4",
       "applyDamageBonus": true,
       "weaponClass": "Dagger",
-      "source": "Ch 8, Modern Melee Weapons table (p.201)"
+      "source": "Ch 8, Modern Melee Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "pistolDerringer",
@@ -66,7 +78,9 @@
       "ammoCapacity": "1 or 2",
       "attacksPerRound": 1,
       "baseChance": 20,
-      "source": "Ch 8, Modern Missile Weapons table (p.201)"
+      "source": "Ch 8, Modern Missile Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "pistolLight",
@@ -80,7 +94,9 @@
       "ammoCapacity": 8,
       "attacksPerRound": 3,
       "baseChance": 20,
-      "source": "Ch 8, Modern Missile Weapons table (p.201)"
+      "source": "Ch 8, Modern Missile Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "pistolMedium",
@@ -94,7 +110,9 @@
       "ammoCapacity": 12,
       "attacksPerRound": 2,
       "baseChance": 20,
-      "source": "Ch 8, Modern Missile Weapons table (p.201)"
+      "source": "Ch 8, Modern Missile Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "pistolHeavy",
@@ -108,7 +126,9 @@
       "ammoCapacity": 8,
       "attacksPerRound": 1,
       "baseChance": 20,
-      "source": "Ch 8, Modern Missile Weapons table (p.201)"
+      "source": "Ch 8, Modern Missile Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "revolverLight",
@@ -122,7 +142,9 @@
       "ammoCapacity": 6,
       "attacksPerRound": 2,
       "baseChance": 20,
-      "source": "Ch 8, Modern Missile Weapons table (p.201)"
+      "source": "Ch 8, Modern Missile Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "revolverMedium",
@@ -136,7 +158,9 @@
       "ammoCapacity": 6,
       "attacksPerRound": 1,
       "baseChance": 20,
-      "source": "Ch 8, Modern Missile Weapons table (p.201)"
+      "source": "Ch 8, Modern Missile Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "revolverHeavy",
@@ -150,7 +174,9 @@
       "ammoCapacity": 6,
       "attacksPerRound": 1,
       "baseChance": 20,
-      "source": "Ch 8, Modern Missile Weapons table (p.201)"
+      "source": "Ch 8, Modern Missile Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "rifleBoltAction",
@@ -164,7 +190,9 @@
       "ammoCapacity": 5,
       "attacksPerRound": 0.5,
       "baseChance": 25,
-      "source": "Ch 8, Modern Missile Weapons table (p.201)"
+      "source": "Ch 8, Modern Missile Weapons table (p.201)",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "rifleSniper",
@@ -181,7 +209,9 @@
       "ammoCapacity": 11,
       "attacksPerRound": 1,
       "baseChance": 20,
-      "source": "Ch 8, Modern Missile Weapons table (p.201), with notes 4 and 5 on bipod and scope (p.202). Note 4: 'usually equipped with a bipod, doubling the chance; without a bipod ... reduce the base chance to 10%' -- the printed 20% base already assumes the usual bipod, so 20 is the with-bipod figure and 10 is the without-bipod figure, not 40/20 as an earlier transcription had it."
+      "source": "Ch 8, Modern Missile Weapons table (p.201), with notes 4 and 5 on bipod and scope (p.202). Note 4: 'usually equipped with a bipod, doubling the chance; without a bipod ... reduce the base chance to 10%' -- the printed 20% base already assumes the usual bipod, so 20 is the with-bipod figure and 10 is the without-bipod figure, not 40/20 as an earlier transcription had it.",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "shotgunDoubleBarreled",
@@ -200,7 +230,9 @@
       "ammoCapacity": 2,
       "attacksPerRound": "1 or 2",
       "baseChance": 30,
-      "source": "Ch 8, Modern Missile Weapons table (p.201); note 6 on damage by range"
+      "source": "Ch 8, Modern Missile Weapons table (p.201); note 6 on damage by range",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "shotgunSawedOff",
@@ -218,7 +250,9 @@
       "ammoCapacity": "1 or 2",
       "attacksPerRound": "1 or 2",
       "baseChance": 30,
-      "source": "Ch 8, Modern Missile Weapons table (p.201); note 7: not effective beyond 20 yards"
+      "source": "Ch 8, Modern Missile Weapons table (p.201); note 7: not effective beyond 20 yards",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     },
     {
       "id": "gunSubmachine",
@@ -232,7 +266,9 @@
       "ammoCapacity": 32,
       "attacksPerRound": "2 or burst",
       "baseChance": 15,
-      "source": "Ch 8, Modern Missile Weapons table (p.201). Skill mapping note: the book treats Submachine Gun as its own Firearm specialty, distinct from Pistol/Revolver/Rifle/Shotgun (Ch 3 p.39, 'Specialties: Machine Gun, Pistol, Revolver, Rifle, Shotgun, Submachine Gun'). NoiRPG's Layer 2 skill list (skill-ruleset.json) only defines Firearms (Handgun|Shotgun|Rifle) -- no standalone Submachine Gun specialty. Mapped here to Firearms (Handgun) as the closest existing specialty (one-handed, short-to-medium range weapon per its own description) rather than inventing a new specialty out of scope for this issue. Flagged for rules-conformance/scope-warden review; revisit if/when the skill list is revisited."
+      "source": "Ch 8, Modern Missile Weapons table (p.201). Skill mapping note: the book treats Submachine Gun as its own Firearm specialty, distinct from Pistol/Revolver/Rifle/Shotgun (Ch 3 p.39, 'Specialties: Machine Gun, Pistol, Revolver, Rifle, Shotgun, Submachine Gun'). NoiRPG's Layer 2 skill list (skill-ruleset.json) only defines Firearms (Handgun|Shotgun|Rifle) -- no standalone Submachine Gun specialty. Mapped here to Firearms (Handgun) as the closest existing specialty (one-handed, short-to-medium range weapon per its own description) rather than inventing a new specialty out of scope for this issue. Flagged for rules-conformance/scope-warden review; revisit if/when the skill list is revisited.",
+      "specialDamageType": "impaling",
+      "specialDamageTypeSource": "Ch 6, p.150 (Special Successes and Damage, 'Impaling'): 'Firearms, arrows, and other pointed weapons inflict impaling damage.'"
     }
   ]
 }

--- a/src/Brp.Rules/Combat/DamageApplicationResult.cs
+++ b/src/Brp.Rules/Combat/DamageApplicationResult.cs
@@ -1,0 +1,20 @@
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The result of applying a rolled damage amount to a target's hit points --
+/// <see cref="DamageResolver.ApplyDamage"/>'s output.
+/// </summary>
+/// <param name="DamageDealt">The hit points actually removed (0 for a Miss).</param>
+/// <param name="ResultingHitPoints">The target's hit points after the change; may be negative.</param>
+/// <param name="Condition">The condition <see cref="ResultingHitPoints"/> puts the target in.</param>
+/// <param name="Wound">
+/// The wound recorded for this blow, for piece E to heal later. <see langword="null"/> for a
+/// Miss, which lands no blow to record.
+/// </param>
+public sealed record DamageApplicationResult(
+    int DamageDealt,
+    int ResultingHitPoints,
+    HitPointCondition Condition,
+    Wound? Wound);

--- a/src/Brp.Rules/Combat/DamageResolver.cs
+++ b/src/Brp.Rules/Combat/DamageResolver.cs
@@ -9,17 +9,37 @@ namespace Brp.Rules.Combat;
 /// <summary>
 /// Turns a landed attack (piece C's <see cref="AttackDefenseOutcome"/>) into damage, applies it
 /// to a target's hit points, and determines the resulting condition. Ch 6: Combat, "Levels of
-/// Success and Failure" (pp.146-147) and "Damage &amp; Healing" (pp.154-156); Ch 7: Spot Rules,
-/// "Knockout Attacks" (p.174). This is Layer 4 piece D (#52). See
-/// <c>docs/decisions/0017-damage.md</c> for the corrections made against the initial ruleset
-/// transcription and the seams this leaves for piece E and the injury spot rules.
+/// Success and Failure" (pp.146-147), "Special Successes and Damage" (pp.148-151), and "Damage
+/// &amp; Healing" (pp.154-156); Ch 7: Spot Rules, "Knockout Attacks" (p.174). This is Layer 4
+/// piece D (#52). See <c>docs/decisions/0017-damage.md</c> for the two corrections made against
+/// the initial ruleset transcription and the seams this leaves for piece E and the injury spot
+/// rules.
 /// <para>
-/// <strong>Normal and Special hits share identical damage arithmetic</strong> -- Ch 6, p.147,
-/// footnote **: "For a greatsword, full damage is 2D8 on a normal success, 2D8 bleeding damage
-/// on a special success" -- the dice are the same (2D8 both times); only the (out-of-scope)
-/// special-effect type (bleeding, crushing, entangling, impaling, knockback) differs. Only a
-/// Critical hit uses the weapon's maximum instead of a fresh roll (Ch 6, p.146: "the maximum
-/// possible damage for the weapon used ... plus the normal rolled damage modifier").
+/// <strong>Special-success damage is weapon-type-dependent</strong> (Ch 6, "Special Successes
+/// and Damage", pp.148-151), keyed by <see cref="WeaponDefinition.SpecialDamageType"/>:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <strong>Impaling</strong> (firearms, pointed knives -- p.150): doubles the weapon's whole
+/// damage expression (a fresh, independent second roll of the same dice, summed with the first
+/// -- mathematically identical to doubling the dice count and any fixed modifier, per the
+/// greatsword-style worked example "1D6+1 ... twice that, or 2D6+2"). The damage bonus is added
+/// once, undoubled.
+/// </description></item>
+/// <item><description>
+/// <strong>Crushing</strong> (clubs, brass knuckles -- p.149): weapon dice roll normally, but the
+/// damage bonus doubles (rolled twice and summed) -- unless the attacker has no damage bonus, in
+/// which case a flat <c>+1D4</c> substitutes, or a negative damage bonus, which collapses to no
+/// bonus at all rather than doubling the negative.
+/// </description></item>
+/// <item><description>
+/// <strong>Bleeding / Entangling / Knockback</strong> (no shipped weapon uses these): the base
+/// damage number is identical to a Normal hit; only the (deferred) special effect differs.
+/// </description></item>
+/// </list>
+/// <para>
+/// A Critical hit is unrelated to any of this -- it always uses the weapon's maximum instead of
+/// rolling (Ch 6, p.146).
 /// </para>
 /// </summary>
 public static class DamageResolver
@@ -31,7 +51,10 @@ public static class DamageResolver
     /// </summary>
     /// <param name="landedGrade">The effective grade of hit, from piece C's outcome.</param>
     /// <param name="armorTreatment">How armor applies, from piece C's outcome.</param>
-    /// <param name="weapon">The attacker's weapon.</param>
+    /// <param name="weapon">
+    /// The attacker's weapon. Its <see cref="WeaponDefinition.SpecialDamageType"/> selects which
+    /// Special-success formula applies -- see the type remarks.
+    /// </param>
     /// <param name="damageBonus">
     /// The attacker's damage bonus expression (<see cref="AbilitySet.DamageModifier"/>), or
     /// <see langword="null"/> if none applies. Added only when
@@ -43,6 +66,10 @@ public static class DamageResolver
     /// The applicable armor value at the location struck. Supplied by the caller -- this
     /// resolver does not roll hit locations or select armor by location.
     /// </param>
+    /// <param name="ruleset">
+    /// Supplies the Crushing special success's no-damage-bonus fallback (<c>+1D4</c>, Ch 6,
+    /// p.149).
+    /// </param>
     /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
     public static DamageRoll RollDamage(
         LandedGrade landedGrade,
@@ -50,17 +77,19 @@ public static class DamageResolver
         WeaponDefinition weapon,
         DiceExpression? damageBonus,
         int armorValue,
+        DamageRuleset ruleset,
         IEntropySource entropy)
     {
         ArgumentNullException.ThrowIfNull(weapon);
+        ArgumentNullException.ThrowIfNull(ruleset);
         ArgumentNullException.ThrowIfNull(entropy);
         ArgumentOutOfRangeException.ThrowIfNegative(armorValue);
 
         if (landedGrade == LandedGrade.Miss)
         {
             return new DamageRoll(
-                landedGrade, WeaponRoll: null, DamageBonusRoll: null, WeaponMaximum: null,
-                ArmorApplied: 0, DamageDealt: 0,
+                landedGrade, SpecialDamageTypeApplied: null, WeaponRolls: [], DamageBonusRolls: [],
+                WeaponMaximum: null, ArmorApplied: 0, DamageDealt: 0,
                 SourceText: "Ch 6: Combat, Attack and Defense Matrix (p.147): a Miss deals no damage.");
         }
 
@@ -74,27 +103,92 @@ public static class DamageResolver
         if (landedGrade == LandedGrade.Critical)
         {
             var weaponMaximum = weapon.Damage.MaximumPossible();
-            var (bonusValue, bonusRoll) = RollDamageBonus(weapon, damageBonus, entropy);
+            var (bonusValue, bonusRolls) = RollNormalDamageBonus(weapon, damageBonus, entropy);
             var criticalDamage = Math.Max(0, weaponMaximum + bonusValue);
             return new DamageRoll(
-                landedGrade, WeaponRoll: null, bonusRoll, weaponMaximum,
+                landedGrade, SpecialDamageTypeApplied: null, WeaponRolls: [], bonusRolls, weaponMaximum,
                 ArmorApplied: 0, DamageDealt: criticalDamage,
                 SourceText: "Ch 6: Combat, \"Critical Success\" (p.146): maximum weapon damage " +
                     "plus the damage modifier, ignoring armor.");
         }
 
-        // Normal and Special: identical dice arithmetic -- see the type remarks.
-        var weaponRoll = weapon.Damage.Roll(entropy);
-        var (dbValue, dbRoll) = RollDamageBonus(weapon, damageBonus, entropy);
-        var rawTotal = weaponRoll.RawTotal + dbValue;
-        var armorApplied = ignoreArmor ? 0 : Math.Min(armorValue, Math.Max(0, rawTotal));
-        var damageDealt = ignoreArmor ? Math.Max(0, rawTotal) : Math.Max(0, rawTotal - armorValue);
-        var sourceText = landedGrade == LandedGrade.Special
-            ? "Ch 6: Combat, \"Special Success\" (p.146) and Attack and Defense Matrix footnote " +
-              "** (p.147): normal weapon damage plus the damage modifier, armor subtracted " +
-              "(the special-effect type is out of scope -- see docs/decisions/0017-damage.md)."
-            : "Ch 6: Combat, \"Success\" (p.146): weapon damage plus the damage modifier, armor subtracted.";
-        return new DamageRoll(landedGrade, weaponRoll, dbRoll, WeaponMaximum: null, armorApplied, damageDealt, sourceText);
+        if (landedGrade == LandedGrade.Normal)
+        {
+            var weaponRoll = weapon.Damage.Roll(entropy);
+            var (bonusValue, bonusRolls) = RollNormalDamageBonus(weapon, damageBonus, entropy);
+            var (armorApplied, damageDealt) = ApplyArmor(weaponRoll.RawTotal + bonusValue, ignoreArmor, armorValue);
+            return new DamageRoll(
+                landedGrade, SpecialDamageTypeApplied: null, [weaponRoll], bonusRolls, WeaponMaximum: null,
+                armorApplied, damageDealt,
+                SourceText: "Ch 6: Combat, \"Success\" (p.146): weapon damage plus the damage modifier, armor subtracted.");
+        }
+
+        // Special -- the weapon-type-dependent branch. See the type remarks.
+        return RollSpecialDamage(weapon, damageBonus, ignoreArmor, armorValue, ruleset, entropy);
+    }
+
+    private static DamageRoll RollSpecialDamage(
+        WeaponDefinition weapon,
+        DiceExpression? damageBonus,
+        bool ignoreArmor,
+        int armorValue,
+        DamageRuleset ruleset,
+        IEntropySource entropy)
+    {
+        switch (weapon.SpecialDamageType)
+        {
+            case SpecialDamageType.Impaling:
+                {
+                    // Ch 6, p.150: "An impale doubles the dice and modifier for the weapon's
+                    // normal rolled damage... a short sword ... 1D6+1 ... does twice that, or
+                    // 2D6+2." Summing two independent rolls of the same weapon-damage expression
+                    // has the identical distribution to doubling its dice count and constant
+                    // (see docs/decisions/0017-damage.md's worked proof), and lets this reuse
+                    // WeaponDefinition.Damage as-is rather than needing to double a parsed
+                    // expression's terms. The damage bonus is added once, undoubled -- "the
+                    // damage modifier is not doubled, but is instead rolled normally and added."
+                    var first = weapon.Damage.Roll(entropy);
+                    var second = weapon.Damage.Roll(entropy);
+                    var (bonusValue, bonusRolls) = RollNormalDamageBonus(weapon, damageBonus, entropy);
+                    var (armorApplied, damageDealt) = ApplyArmor(first.RawTotal + second.RawTotal + bonusValue, ignoreArmor, armorValue);
+                    return new DamageRoll(
+                        LandedGrade.Special, SpecialDamageType.Impaling, [first, second], bonusRolls, WeaponMaximum: null,
+                        armorApplied, damageDealt,
+                        SourceText: "Ch 6: Combat, \"Impaling\" (pp.149-150): the weapon's damage " +
+                            "(dice and any fixed modifier) doubled, plus an undoubled damage modifier, armor subtracted.");
+                }
+
+            case SpecialDamageType.Crushing:
+                {
+                    // Ch 6, p.149: "A crushing special success doubles the damage modifier
+                    // normally applied... The weapon's damage is rolled normally, but the damage
+                    // modifier is increased."
+                    var weaponRoll = weapon.Damage.Roll(entropy);
+                    var (bonusValue, bonusRolls) = RollCrushingDamageBonus(weapon, damageBonus, ruleset, entropy);
+                    var (armorApplied, damageDealt) = ApplyArmor(weaponRoll.RawTotal + bonusValue, ignoreArmor, armorValue);
+                    return new DamageRoll(
+                        LandedGrade.Special, SpecialDamageType.Crushing, [weaponRoll], bonusRolls, WeaponMaximum: null,
+                        armorApplied, damageDealt,
+                        SourceText: "Ch 6: Combat, \"Crushing\" (p.149): normal weapon damage plus " +
+                            "a doubled (or, absent one, +1D4) damage modifier, armor subtracted.");
+                }
+
+            default:
+                {
+                    // Bleeding / Entangling / Knockback (Ch 6, pp.149-151): the special RESULT is
+                    // a separable effect (deferred -- see docs/decisions/0017-damage.md); the
+                    // base damage number is identical to a Normal hit. No shipped weapon uses
+                    // any of these three types.
+                    var weaponRoll = weapon.Damage.Roll(entropy);
+                    var (bonusValue, bonusRolls) = RollNormalDamageBonus(weapon, damageBonus, entropy);
+                    var (armorApplied, damageDealt) = ApplyArmor(weaponRoll.RawTotal + bonusValue, ignoreArmor, armorValue);
+                    return new DamageRoll(
+                        LandedGrade.Special, weapon.SpecialDamageType, [weaponRoll], bonusRolls, WeaponMaximum: null,
+                        armorApplied, damageDealt,
+                        SourceText: $"Ch 6: Combat, \"{weapon.SpecialDamageType}\" (pp.149-151): damage number " +
+                            "unchanged from a Normal hit; the special effect is deferred (see docs/decisions/0017-damage.md).");
+                }
+        }
     }
 
     /// <summary>
@@ -138,11 +232,15 @@ public static class DamageResolver
     /// <param name="armorValue">
     /// The applicable armor value. Ch 7, p.174: "Armor defends normally in all cases" -- this
     /// resolver applies <paramref name="outcome"/>'s ordinary per-grade armor treatment (still
-    /// ignored on a Critical), not a knockout-specific rule.
+    /// ignored on a Critical), not a knockout-specific rule. Likewise, "the effects of special or
+    /// critical successes... apply in all cases" means an Impaling special's doubled damage (or
+    /// a Crushing special's doubled/substituted damage modifier) still applies to the damage
+    /// rolled here to determine minor-vs-major wound equivalence -- this falls out of reusing
+    /// <see cref="RollDamage"/> unchanged, not a separate rule.
     /// </param>
     /// <param name="target">The target, whose <see cref="AbilitySet.MajorWoundLevel"/> (Ch 2,
     /// p.14) supplies the half-total-hit-points threshold this rule compares against.</param>
-    /// <param name="ruleset">Supplies the knockout duration dice.</param>
+    /// <param name="ruleset">Supplies the knockout duration dice and the Crushing fallback bonus.</param>
     /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
     public static KnockoutOutcome ResolveKnockoutAttack(
         AttackDefenseOutcome outcome,
@@ -159,7 +257,7 @@ public static class DamageResolver
         ArgumentNullException.ThrowIfNull(ruleset);
         ArgumentNullException.ThrowIfNull(entropy);
 
-        var roll = RollDamage(outcome.LandedGrade, outcome.ArmorTreatment, weapon, damageBonus, armorValue, entropy);
+        var roll = RollDamage(outcome.LandedGrade, outcome.ArmorTreatment, weapon, damageBonus, armorValue, ruleset, entropy);
 
         if (outcome.LandedGrade == LandedGrade.Miss)
         {
@@ -168,12 +266,14 @@ public static class DamageResolver
 
         // Ch 6, p.156: "equal to or more than half the character's total hit points" is a major
         // wound -- reuse the already-tested Layer 1 figure rather than a second copy of the
-        // fraction (see DamageRuleset's remarks).
+        // fraction (see DamageRuleset's remarks). roll.DamageDealt already reflects any
+        // weapon-type-dependent Special formula (e.g. a doubled Impaling roll), per Ch 7 p.174.
         var isMajorWound = roll.DamageDealt >= target.MajorWoundLevel;
         if (!isMajorWound)
         {
             // Ch 7, p.174: "the original damage rolled is ignored and the target is dealt the
-            // minimum damage for the weapon (after armor) but is not knocked out."
+            // minimum damage for the weapon (after armor) but is not knocked out." This is a
+            // flat baseline unrelated to the grade or special-damage type that landed.
             var ignoreArmor = outcome.ArmorTreatment is ArmorTreatment.Bypassed or ArmorTreatment.DoesNotApply;
             var weaponMinimum = weapon.Damage.MinimumPossible();
             var minorDamage = ignoreArmor ? Math.Max(0, weaponMinimum) : Math.Max(0, weaponMinimum - armorValue);
@@ -250,12 +350,22 @@ public static class DamageResolver
             : HitPointCondition.Unaffected;
     }
 
-    private static (int Value, DiceRoll? Roll) RollDamageBonus(
+    private static (int ArmorApplied, int DamageDealt) ApplyArmor(int rawTotal, bool ignoreArmor, int armorValue)
+    {
+        if (ignoreArmor)
+        {
+            return (0, Math.Max(0, rawTotal));
+        }
+
+        return (Math.Min(armorValue, Math.Max(0, rawTotal)), Math.Max(0, rawTotal - armorValue));
+    }
+
+    private static (int Value, IReadOnlyList<DiceRoll> Rolls) RollNormalDamageBonus(
         WeaponDefinition weapon, DiceExpression? damageBonus, IEntropySource entropy)
     {
         if (!weapon.ApplyDamageBonus || damageBonus is null)
         {
-            return (0, null);
+            return (0, []);
         }
 
         // Thrown weapons take half db, rounded up (Ch 6, p.147 note on missile weapons carried
@@ -263,6 +373,36 @@ public static class DamageResolver
         // hand-picked subset), so WeaponDefinition.ApplyDamageBonus stays a boolean and this is
         // the seam a future thrown-weapon addition would extend, not a rule implemented here.
         var roll = damageBonus.Roll(entropy);
-        return (roll.RawTotal, roll);
+        return (roll.RawTotal, [roll]);
+    }
+
+    private static (int Value, IReadOnlyList<DiceRoll> Rolls) RollCrushingDamageBonus(
+        WeaponDefinition weapon, DiceExpression? damageBonus, DamageRuleset ruleset, IEntropySource entropy)
+    {
+        if (!weapon.ApplyDamageBonus)
+        {
+            return (0, []);
+        }
+
+        if (damageBonus is null)
+        {
+            // Ch 6, p.149: "if there is no damage modifier, it becomes +1D4."
+            var fallback = ruleset.CrushingNoModifierBonus.Roll(entropy);
+            return (fallback.RawTotal, [fallback]);
+        }
+
+        if (damageBonus.MaximumPossible() <= 0)
+        {
+            // Ch 6, p.149: "If the attacker has a negative damage modifier, this becomes no
+            // damage modifier" -- not rolled at all, not doubled-then-floored.
+            return (0, []);
+        }
+
+        // Ch 6, p.149: "doubles the damage modifier." Two independent rolls of the same
+        // expression, summed, have the identical distribution to doubling its dice count (the
+        // same technique RollSpecialDamage's Impaling branch uses for the weapon's own dice).
+        var first = damageBonus.Roll(entropy);
+        var second = damageBonus.Roll(entropy);
+        return (first.RawTotal + second.RawTotal, [first, second]);
     }
 }

--- a/src/Brp.Rules/Combat/DamageResolver.cs
+++ b/src/Brp.Rules/Combat/DamageResolver.cs
@@ -1,0 +1,268 @@
+using Brp.Core.Abilities;
+using Brp.Core.Dice;
+using Brp.Core.Randomness;
+using Brp.Rules.Characters;
+using Brp.Rules.Gear;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Turns a landed attack (piece C's <see cref="AttackDefenseOutcome"/>) into damage, applies it
+/// to a target's hit points, and determines the resulting condition. Ch 6: Combat, "Levels of
+/// Success and Failure" (pp.146-147) and "Damage &amp; Healing" (pp.154-156); Ch 7: Spot Rules,
+/// "Knockout Attacks" (p.174). This is Layer 4 piece D (#52). See
+/// <c>docs/decisions/0017-damage.md</c> for the corrections made against the initial ruleset
+/// transcription and the seams this leaves for piece E and the injury spot rules.
+/// <para>
+/// <strong>Normal and Special hits share identical damage arithmetic</strong> -- Ch 6, p.147,
+/// footnote **: "For a greatsword, full damage is 2D8 on a normal success, 2D8 bleeding damage
+/// on a special success" -- the dice are the same (2D8 both times); only the (out-of-scope)
+/// special-effect type (bleeding, crushing, entangling, impaling, knockback) differs. Only a
+/// Critical hit uses the weapon's maximum instead of a fresh roll (Ch 6, p.146: "the maximum
+/// possible damage for the weapon used ... plus the normal rolled damage modifier").
+/// </para>
+/// </summary>
+public static class DamageResolver
+{
+    /// <summary>
+    /// Rolls damage for one landed hit (or returns zero for a Miss). Consumes entropy for the
+    /// weapon dice (Normal/Special) and, when applicable, the damage bonus -- never for a Miss
+    /// or for the constant weapon maximum a Critical hit uses instead.
+    /// </summary>
+    /// <param name="landedGrade">The effective grade of hit, from piece C's outcome.</param>
+    /// <param name="armorTreatment">How armor applies, from piece C's outcome.</param>
+    /// <param name="weapon">The attacker's weapon.</param>
+    /// <param name="damageBonus">
+    /// The attacker's damage bonus expression (<see cref="AbilitySet.DamageModifier"/>), or
+    /// <see langword="null"/> if none applies. Added only when
+    /// <paramref name="weapon"/>'s <see cref="WeaponDefinition.ApplyDamageBonus"/> is
+    /// <see langword="true"/> -- firearms (Ch 6, p.147 footnote, "Damage modifier ... rolled
+    /// separately") are exempt via that flag, not here.
+    /// </param>
+    /// <param name="armorValue">
+    /// The applicable armor value at the location struck. Supplied by the caller -- this
+    /// resolver does not roll hit locations or select armor by location.
+    /// </param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    public static DamageRoll RollDamage(
+        LandedGrade landedGrade,
+        ArmorTreatment armorTreatment,
+        WeaponDefinition weapon,
+        DiceExpression? damageBonus,
+        int armorValue,
+        IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(weapon);
+        ArgumentNullException.ThrowIfNull(entropy);
+        ArgumentOutOfRangeException.ThrowIfNegative(armorValue);
+
+        if (landedGrade == LandedGrade.Miss)
+        {
+            return new DamageRoll(
+                landedGrade, WeaponRoll: null, DamageBonusRoll: null, WeaponMaximum: null,
+                ArmorApplied: 0, DamageDealt: 0,
+                SourceText: "Ch 6: Combat, Attack and Defense Matrix (p.147): a Miss deals no damage.");
+        }
+
+        var ignoreArmor = armorTreatment is ArmorTreatment.Bypassed or ArmorTreatment.DoesNotApply;
+        if (!ignoreArmor && armorTreatment != ArmorTreatment.Subtracted)
+        {
+            throw new ArgumentException(
+                $"Armor treatment '{armorTreatment}' is not valid for a landed hit.", nameof(armorTreatment));
+        }
+
+        if (landedGrade == LandedGrade.Critical)
+        {
+            var weaponMaximum = weapon.Damage.MaximumPossible();
+            var (bonusValue, bonusRoll) = RollDamageBonus(weapon, damageBonus, entropy);
+            var criticalDamage = Math.Max(0, weaponMaximum + bonusValue);
+            return new DamageRoll(
+                landedGrade, WeaponRoll: null, bonusRoll, weaponMaximum,
+                ArmorApplied: 0, DamageDealt: criticalDamage,
+                SourceText: "Ch 6: Combat, \"Critical Success\" (p.146): maximum weapon damage " +
+                    "plus the damage modifier, ignoring armor.");
+        }
+
+        // Normal and Special: identical dice arithmetic -- see the type remarks.
+        var weaponRoll = weapon.Damage.Roll(entropy);
+        var (dbValue, dbRoll) = RollDamageBonus(weapon, damageBonus, entropy);
+        var rawTotal = weaponRoll.RawTotal + dbValue;
+        var armorApplied = ignoreArmor ? 0 : Math.Min(armorValue, Math.Max(0, rawTotal));
+        var damageDealt = ignoreArmor ? Math.Max(0, rawTotal) : Math.Max(0, rawTotal - armorValue);
+        var sourceText = landedGrade == LandedGrade.Special
+            ? "Ch 6: Combat, \"Special Success\" (p.146) and Attack and Defense Matrix footnote " +
+              "** (p.147): normal weapon damage plus the damage modifier, armor subtracted " +
+              "(the special-effect type is out of scope -- see docs/decisions/0017-damage.md)."
+            : "Ch 6: Combat, \"Success\" (p.146): weapon damage plus the damage modifier, armor subtracted.";
+        return new DamageRoll(landedGrade, weaponRoll, dbRoll, WeaponMaximum: null, armorApplied, damageDealt, sourceText);
+    }
+
+    /// <summary>
+    /// Applies a rolled damage amount to <paramref name="target"/>'s hit points, tracking
+    /// negative HP (Ch 2, p.13), recording the blow as a wound in
+    /// <paramref name="wounds"/> for piece E, and returning the resulting condition. A Miss
+    /// changes nothing and records no wound.
+    /// </summary>
+    public static DamageApplicationResult ApplyDamage(
+        AbilitySet target,
+        WoundTrack wounds,
+        DamageRoll damage,
+        DamageRuleset ruleset,
+        string woundDescription)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(wounds);
+        ArgumentNullException.ThrowIfNull(damage);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentException.ThrowIfNullOrWhiteSpace(woundDescription);
+
+        if (damage.LandedGrade == LandedGrade.Miss)
+        {
+            return new DamageApplicationResult(0, target.CurrentHitPoints, ClassifyHitPoints(target.CurrentHitPoints, ruleset), Wound: null);
+        }
+
+        return Apply(target, wounds, damage.DamageDealt, ruleset, new Wound(woundDescription));
+    }
+
+    /// <summary>
+    /// Resolves a declared knockout attack (Ch 7: Spot Rules, "Knockout Attacks", p.174). The
+    /// caller is responsible for the parts of that spot rule outside this piece's scope: that
+    /// the attack was declared at the start of the round, rolled as a Difficult attack against a
+    /// target with a clearly defined head, and that <paramref name="outcome"/> already reflects
+    /// that roll's success or failure -- this method only turns a landed
+    /// <see cref="AttackDefenseOutcome"/> into the knockout branch it resolves to.
+    /// </summary>
+    /// <param name="outcome">Piece C's outcome for the (already Difficult) attack roll.</param>
+    /// <param name="weapon">The attacker's weapon.</param>
+    /// <param name="damageBonus">The attacker's damage bonus expression, or <see langword="null"/>.</param>
+    /// <param name="armorValue">
+    /// The applicable armor value. Ch 7, p.174: "Armor defends normally in all cases" -- this
+    /// resolver applies <paramref name="outcome"/>'s ordinary per-grade armor treatment (still
+    /// ignored on a Critical), not a knockout-specific rule.
+    /// </param>
+    /// <param name="target">The target, whose <see cref="AbilitySet.MajorWoundLevel"/> (Ch 2,
+    /// p.14) supplies the half-total-hit-points threshold this rule compares against.</param>
+    /// <param name="ruleset">Supplies the knockout duration dice.</param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    public static KnockoutOutcome ResolveKnockoutAttack(
+        AttackDefenseOutcome outcome,
+        WeaponDefinition weapon,
+        DiceExpression? damageBonus,
+        int armorValue,
+        AbilitySet target,
+        DamageRuleset ruleset,
+        IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        ArgumentNullException.ThrowIfNull(weapon);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var roll = RollDamage(outcome.LandedGrade, outcome.ArmorTreatment, weapon, damageBonus, armorValue, entropy);
+
+        if (outcome.LandedGrade == LandedGrade.Miss)
+        {
+            return new KnockoutOutcome(KnockedOut: false, DamageDealt: 0, DurationRounds: null, DurationRoll: null, roll);
+        }
+
+        // Ch 6, p.156: "equal to or more than half the character's total hit points" is a major
+        // wound -- reuse the already-tested Layer 1 figure rather than a second copy of the
+        // fraction (see DamageRuleset's remarks).
+        var isMajorWound = roll.DamageDealt >= target.MajorWoundLevel;
+        if (!isMajorWound)
+        {
+            // Ch 7, p.174: "the original damage rolled is ignored and the target is dealt the
+            // minimum damage for the weapon (after armor) but is not knocked out."
+            var ignoreArmor = outcome.ArmorTreatment is ArmorTreatment.Bypassed or ArmorTreatment.DoesNotApply;
+            var weaponMinimum = weapon.Damage.MinimumPossible();
+            var minorDamage = ignoreArmor ? Math.Max(0, weaponMinimum) : Math.Max(0, weaponMinimum - armorValue);
+            return new KnockoutOutcome(KnockedOut: false, minorDamage, DurationRounds: null, DurationRoll: null, roll);
+        }
+
+        // Ch 7, p.174: "the target takes 1 damage and is knocked out for 1D10+10 rounds."
+        var durationRoll = ruleset.KnockoutDuration.Roll(entropy);
+        return new KnockoutOutcome(KnockedOut: true, DamageDealt: 1, durationRoll.Total, durationRoll, roll);
+    }
+
+    /// <summary>
+    /// Applies a knockout attack's resolved damage to <paramref name="target"/>'s hit points,
+    /// mirroring <see cref="ApplyDamage"/> for the knockout-specific outcome shape. Records no
+    /// wound if the attack missed.
+    /// </summary>
+    public static DamageApplicationResult ApplyKnockoutAttack(
+        AbilitySet target,
+        WoundTrack wounds,
+        KnockoutOutcome knockout,
+        DamageRuleset ruleset,
+        string woundDescription)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(wounds);
+        ArgumentNullException.ThrowIfNull(knockout);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentException.ThrowIfNullOrWhiteSpace(woundDescription);
+
+        if (knockout.UnderlyingRoll.LandedGrade == LandedGrade.Miss)
+        {
+            return new DamageApplicationResult(0, target.CurrentHitPoints, ClassifyHitPoints(target.CurrentHitPoints, ruleset), Wound: null);
+        }
+
+        return Apply(target, wounds, knockout.DamageDealt, ruleset, new Wound(woundDescription));
+    }
+
+    /// <summary>
+    /// The seam for the timing Ch 2 p.13 and Ch 6 p.156 both describe: "if their hit points
+    /// reach 0, they die at the end of the following round." This resolver does not track combat
+    /// rounds itself (that is piece B's <c>CombatRound</c>, and the First Aid window that can
+    /// still save a fatally wounded character is piece E) -- a caller re-checks hit points at
+    /// the actual end of the following round and calls this to decide whether death resolves.
+    /// </summary>
+    /// <param name="hitPointsAtEndOfFollowingRound">
+    /// The target's hit points as of the end of the round following the one the fatal wound was
+    /// suffered in -- after any First Aid or other intervention piece E might apply.
+    /// </param>
+    /// <param name="ruleset">Supplies <see cref="DamageRuleset.DeadHitPointLevel"/>.</param>
+    public static bool ResolvesToDeath(int hitPointsAtEndOfFollowingRound, DamageRuleset ruleset)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        return hitPointsAtEndOfFollowingRound <= ruleset.DeadHitPointLevel;
+    }
+
+    private static DamageApplicationResult Apply(
+        AbilitySet target, WoundTrack wounds, int damageDealt, DamageRuleset ruleset, Wound wound)
+    {
+        var resultingHitPoints = target.CurrentHitPoints - damageDealt;
+        target.SetCurrentHitPoints(resultingHitPoints);
+        wounds.Add(wound);
+        return new DamageApplicationResult(damageDealt, resultingHitPoints, ClassifyHitPoints(resultingHitPoints, ruleset), wound);
+    }
+
+    private static HitPointCondition ClassifyHitPoints(int hitPoints, DamageRuleset ruleset)
+    {
+        if (hitPoints <= ruleset.DeadHitPointLevel)
+        {
+            return HitPointCondition.FatallyWounded;
+        }
+
+        return hitPoints <= ruleset.UnconsciousHitPointLevel
+            ? HitPointCondition.Unconscious
+            : HitPointCondition.Unaffected;
+    }
+
+    private static (int Value, DiceRoll? Roll) RollDamageBonus(
+        WeaponDefinition weapon, DiceExpression? damageBonus, IEntropySource entropy)
+    {
+        if (!weapon.ApplyDamageBonus || damageBonus is null)
+        {
+            return (0, null);
+        }
+
+        // Thrown weapons take half db, rounded up (Ch 6, p.147 note on missile weapons carried
+        // over from Ch 3, p.47) -- no thrown weapon exists in the gear ruleset yet (#42's
+        // hand-picked subset), so WeaponDefinition.ApplyDamageBonus stays a boolean and this is
+        // the seam a future thrown-weapon addition would extend, not a rule implemented here.
+        var roll = damageBonus.Roll(entropy);
+        return (roll.RawTotal, roll);
+    }
+}

--- a/src/Brp.Rules/Combat/DamageRoll.cs
+++ b/src/Brp.Rules/Combat/DamageRoll.cs
@@ -1,4 +1,5 @@
 using Brp.Core.Dice;
+using Brp.Rules.Gear;
 
 namespace Brp.Rules.Combat;
 
@@ -8,16 +9,25 @@ namespace Brp.Rules.Combat;
 /// test can show its work. See <c>docs/decisions/0017-damage.md</c>.
 /// </summary>
 /// <param name="LandedGrade">The grade of hit this damage was rolled for.</param>
-/// <param name="WeaponRoll">
-/// The weapon dice roll for a Normal or Special hit (Ch 6, p.146-147: special repeats the
-/// normal dice, it does not add the weapon's maximum -- see <see cref="DamageResolver"/>'s
-/// remarks). <see langword="null"/> for Critical (which uses <see cref="WeaponMaximum"/>
-/// instead of rolling) and for Miss (no damage rolled at all).
+/// <param name="SpecialDamageTypeApplied">
+/// The weapon's special-success damage type, present only when <paramref name="LandedGrade"/> is
+/// <see cref="Combat.LandedGrade.Special"/> -- kept for citation, since it determines which of
+/// the type-dependent formulas in <see cref="DamageResolver"/> ran.
 /// </param>
-/// <param name="DamageBonusRoll">
-/// The damage bonus (db) roll, present only when the weapon's <c>ApplyDamageBonus</c> flag is
-/// set and a damage bonus expression was supplied. Ch 6, p.147 footnote **: "Damage modifier,
-/// in all cases, is rolled separately and added afterwards."
+/// <param name="WeaponRolls">
+/// The weapon dice roll(s). One roll for a Normal hit or a Special hit of a type that does not
+/// change the damage number (Bleeding/Entangling/Knockback -- Ch 6, pp.149-151); <em>two</em>
+/// independent rolls of the same weapon dice for an Impaling special (Ch 6, p.150: "doubles the
+/// dice and modifier" -- summing two independent rolls of the same expression has the identical
+/// distribution to doubling its dice count and constant, see <c>docs/decisions/0017-damage.md</c>).
+/// Empty for a Critical (which uses <see cref="WeaponMaximum"/> instead) and for a Miss.
+/// </param>
+/// <param name="DamageBonusRolls">
+/// The damage bonus (db) roll(s), present only when the weapon's <c>ApplyDamageBonus</c> flag is
+/// set and a damage bonus expression was supplied (or, for a Crushing special with no damage
+/// bonus at all, the ruleset's flat substitute -- Ch 6, p.149). Zero entries when no db applies;
+/// one entry for a normal db application; two entries for a Crushing special's doubled positive
+/// db (rolled twice and summed, same technique as <see cref="WeaponRolls"/>'s doubling).
 /// </param>
 /// <param name="WeaponMaximum">
 /// The weapon's maximum possible damage, used only for a Critical hit. Ch 6, "Critical
@@ -31,8 +41,9 @@ namespace Brp.Rules.Combat;
 /// <param name="SourceText">The printed rule this computation followed, for citation.</param>
 public sealed record DamageRoll(
     LandedGrade LandedGrade,
-    DiceRoll? WeaponRoll,
-    DiceRoll? DamageBonusRoll,
+    SpecialDamageType? SpecialDamageTypeApplied,
+    IReadOnlyList<DiceRoll> WeaponRolls,
+    IReadOnlyList<DiceRoll> DamageBonusRolls,
     int? WeaponMaximum,
     int ArmorApplied,
     int DamageDealt,

--- a/src/Brp.Rules/Combat/DamageRoll.cs
+++ b/src/Brp.Rules/Combat/DamageRoll.cs
@@ -1,0 +1,39 @@
+using Brp.Core.Dice;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The result of rolling damage for one landed (or missed) hit -- <see cref="DamageResolver"/>'s
+/// primary output. Carries the full breakdown, not just the final number, so a replay log or a
+/// test can show its work. See <c>docs/decisions/0017-damage.md</c>.
+/// </summary>
+/// <param name="LandedGrade">The grade of hit this damage was rolled for.</param>
+/// <param name="WeaponRoll">
+/// The weapon dice roll for a Normal or Special hit (Ch 6, p.146-147: special repeats the
+/// normal dice, it does not add the weapon's maximum -- see <see cref="DamageResolver"/>'s
+/// remarks). <see langword="null"/> for Critical (which uses <see cref="WeaponMaximum"/>
+/// instead of rolling) and for Miss (no damage rolled at all).
+/// </param>
+/// <param name="DamageBonusRoll">
+/// The damage bonus (db) roll, present only when the weapon's <c>ApplyDamageBonus</c> flag is
+/// set and a damage bonus expression was supplied. Ch 6, p.147 footnote **: "Damage modifier,
+/// in all cases, is rolled separately and added afterwards."
+/// </param>
+/// <param name="WeaponMaximum">
+/// The weapon's maximum possible damage, used only for a Critical hit. Ch 6, "Critical
+/// Success" (p.146): "the maximum possible damage for the weapon used."
+/// </param>
+/// <param name="ArmorApplied">
+/// The armor points actually subtracted (0 for a Critical hit, whose armor treatment is always
+/// ignore -- Ch 6, p.146: "a critical attack result always ignores armor").
+/// </param>
+/// <param name="DamageDealt">The final damage total, floored at zero, after armor.</param>
+/// <param name="SourceText">The printed rule this computation followed, for citation.</param>
+public sealed record DamageRoll(
+    LandedGrade LandedGrade,
+    DiceRoll? WeaponRoll,
+    DiceRoll? DamageBonusRoll,
+    int? WeaponMaximum,
+    int ArmorApplied,
+    int DamageDealt,
+    string SourceText);

--- a/src/Brp.Rules/Combat/DamageRuleset.cs
+++ b/src/Brp.Rules/Combat/DamageRuleset.cs
@@ -1,0 +1,54 @@
+using Brp.Core.Dice;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The data-defined thresholds and parameters <see cref="DamageResolver"/> reads (AGENTS.md
+/// invariant 7: rules values are data, not constants). Loaded from
+/// <c>damage-ruleset.json</c> by <c>Brp.Data.NoirDamageRuleset.Load()</c>. See
+/// <c>docs/decisions/0017-damage.md</c>.
+/// <para>
+/// Deliberately does <em>not</em> carry a "half of maximum HP" fraction for major-wound
+/// classification: that figure already exists, tested, at Layer 1 as
+/// <see cref="Core.Abilities.AbilitySet.MajorWoundLevel"/> (Ch 2, p.14, rounded up), which this
+/// resolver reuses directly rather than re-deriving the same figure a second time from a second
+/// piece of ruleset data.
+/// </para>
+/// </summary>
+public sealed class DamageRuleset
+{
+    /// <summary>Creates a damage ruleset from data-defined values.</summary>
+    public DamageRuleset(int unconsciousHitPointLevel, int deadHitPointLevel, DiceExpression knockoutDuration)
+    {
+        ArgumentNullException.ThrowIfNull(knockoutDuration);
+        if (unconsciousHitPointLevel < deadHitPointLevel)
+        {
+            throw new ArgumentException(
+                "The unconscious threshold must not be below the dead threshold.", nameof(unconsciousHitPointLevel));
+        }
+
+        UnconsciousHitPointLevel = unconsciousHitPointLevel;
+        DeadHitPointLevel = deadHitPointLevel;
+        KnockoutDuration = knockoutDuration;
+    }
+
+    /// <summary>
+    /// Ch 2: Characters, "Hit Points" (p.13): "Your character loses consciousness when their
+    /// hit points are reduced to 2 or less." A character at or below this level (but above
+    /// <see cref="DeadHitPointLevel"/>) is unconscious.
+    /// </summary>
+    public int UnconsciousHitPointLevel { get; }
+
+    /// <summary>
+    /// Ch 2: Characters, "Hit Points" (p.13) / Ch 6: Combat, "Fatal Wound" (p.156): a character
+    /// at or below this level has suffered a fatal wound and dies at the end of the following
+    /// round unless restored above it in time -- see
+    /// <see cref="DamageResolver.ResolvesToDeath"/> for the timing seam this resolver models.
+    /// </summary>
+    public int DeadHitPointLevel { get; }
+
+    /// <summary>
+    /// Ch 7: Spot Rules, "Knockout Attacks" (p.174): "knocked out for 1D10+10 rounds."
+    /// </summary>
+    public DiceExpression KnockoutDuration { get; }
+}

--- a/src/Brp.Rules/Combat/DamageRuleset.cs
+++ b/src/Brp.Rules/Combat/DamageRuleset.cs
@@ -18,9 +18,14 @@ namespace Brp.Rules.Combat;
 public sealed class DamageRuleset
 {
     /// <summary>Creates a damage ruleset from data-defined values.</summary>
-    public DamageRuleset(int unconsciousHitPointLevel, int deadHitPointLevel, DiceExpression knockoutDuration)
+    public DamageRuleset(
+        int unconsciousHitPointLevel,
+        int deadHitPointLevel,
+        DiceExpression knockoutDuration,
+        DiceExpression crushingNoModifierBonus)
     {
         ArgumentNullException.ThrowIfNull(knockoutDuration);
+        ArgumentNullException.ThrowIfNull(crushingNoModifierBonus);
         if (unconsciousHitPointLevel < deadHitPointLevel)
         {
             throw new ArgumentException(
@@ -30,6 +35,7 @@ public sealed class DamageRuleset
         UnconsciousHitPointLevel = unconsciousHitPointLevel;
         DeadHitPointLevel = deadHitPointLevel;
         KnockoutDuration = knockoutDuration;
+        CrushingNoModifierBonus = crushingNoModifierBonus;
     }
 
     /// <summary>
@@ -51,4 +57,11 @@ public sealed class DamageRuleset
     /// Ch 7: Spot Rules, "Knockout Attacks" (p.174): "knocked out for 1D10+10 rounds."
     /// </summary>
     public DiceExpression KnockoutDuration { get; }
+
+    /// <summary>
+    /// Ch 6: Combat, "Crushing" (p.149): "if there is no damage modifier, it becomes +1D4" --
+    /// the flat bonus a Crushing special success uses in place of a doubled damage modifier when
+    /// the attacker has none.
+    /// </summary>
+    public DiceExpression CrushingNoModifierBonus { get; }
 }

--- a/src/Brp.Rules/Combat/HitPointCondition.cs
+++ b/src/Brp.Rules/Combat/HitPointCondition.cs
@@ -1,0 +1,27 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// A target's condition after hit points change, per the thresholds in
+/// <see cref="DamageRuleset"/>. Ch 2: Characters, "Hit Points" (p.13); Ch 6: Combat, "Fatal
+/// Wound" (p.156).
+/// </summary>
+public enum HitPointCondition
+{
+    /// <summary>Above the unconscious threshold -- no condition change from hit points alone.</summary>
+    Unaffected,
+
+    /// <summary>
+    /// At or below <see cref="DamageRuleset.UnconsciousHitPointLevel"/> but above
+    /// <see cref="DamageRuleset.DeadHitPointLevel"/>.
+    /// </summary>
+    Unconscious,
+
+    /// <summary>
+    /// At or below <see cref="DamageRuleset.DeadHitPointLevel"/>. Ch 6, p.156: "Your character
+    /// is immediately knocked prone but unable to take any action of any type" -- this is the
+    /// <em>pending</em> flag, not resolved death. Whether the character actually dies is decided
+    /// at the end of the following round by <see cref="DamageResolver.ResolvesToDeath"/>, once
+    /// piece E's First Aid window (out of scope here) has had its chance to intervene.
+    /// </summary>
+    FatallyWounded,
+}

--- a/src/Brp.Rules/Combat/KnockoutOutcome.cs
+++ b/src/Brp.Rules/Combat/KnockoutOutcome.cs
@@ -1,0 +1,32 @@
+using Brp.Core.Dice;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The result of a declared knockout attack (Ch 7: Spot Rules, "Knockout Attacks", p.174) --
+/// <see cref="DamageResolver.ResolveKnockoutAttack"/>'s output.
+/// </summary>
+/// <param name="KnockedOut">
+/// <see langword="true"/> only on the major-wound branch: the rolled damage (after armor) was
+/// equivalent to a major wound, so the target takes 1 damage and is knocked out.
+/// </param>
+/// <param name="DamageDealt">
+/// The damage actually applied: 1 on the knockout branch; the weapon's minimum damage (after
+/// armor) on the non-knockout "equivalent to a minor wound" branch; 0 if the attack missed.
+/// </param>
+/// <param name="DurationRounds">
+/// The rolled knockout duration in rounds, present only when <see cref="KnockedOut"/> is
+/// <see langword="true"/>.
+/// </param>
+/// <param name="DurationRoll">The underlying dice roll behind <see cref="DurationRounds"/>.</param>
+/// <param name="UnderlyingRoll">
+/// The damage roll used to determine minor-vs-major wound equivalence, kept for citation --
+/// this is the roll Ch 7 p.174 means by "damage is rolled to determine the potential for a
+/// knockout," not damage that was itself applied verbatim.
+/// </param>
+public sealed record KnockoutOutcome(
+    bool KnockedOut,
+    int DamageDealt,
+    int? DurationRounds,
+    DiceRoll? DurationRoll,
+    DamageRoll UnderlyingRoll);

--- a/src/Brp.Rules/Gear/SpecialDamageType.cs
+++ b/src/Brp.Rules/Gear/SpecialDamageType.cs
@@ -1,0 +1,54 @@
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// The special-success damage type a weapon inflicts, per Ch 6: Combat, "Special Successes and
+/// Damage" (pp.148-149), which lists these five types and what causes each: "Different types of
+/// weapons do different types of damage upon special successes." Which type a weapon has
+/// determines both its special-success damage <em>number</em> (only <see cref="Impaling"/> and
+/// <see cref="Crushing"/> change the arithmetic -- see <c>Brp.Rules.Combat.DamageResolver</c>)
+/// and its special-success <em>effect</em> (bleeding, entangling, knockback -- deferred, see
+/// <c>docs/decisions/0017-damage.md</c>).
+/// </summary>
+public enum SpecialDamageType
+{
+    /// <summary>
+    /// Ch 6, p.148: "A wound resulting in a deep tissue cut into arteries or major organs.
+    /// Weapons with a sharp edge inflict bleeding damage." No weapon in the hand-picked subset
+    /// uses this type (no edged slashing weapon, e.g. a sword, is in scope); base damage is
+    /// normal (weapon dice + db), the ongoing 1 HP/round bleeding effect (p.149) is deferred.
+    /// </summary>
+    Bleeding,
+
+    /// <summary>
+    /// Ch 6, p.148: "A wound involving a blunt trauma to the victim, often breaking bones and
+    /// stunning the target. Clubs, unarmed strikes, and other blunt weapons can cause crushing
+    /// damage." Doubles the damage modifier on a special success (p.149) -- see
+    /// <c>Brp.Rules.Combat.DamageResolver</c>; the stunning effect is deferred.
+    /// </summary>
+    Crushing,
+
+    /// <summary>
+    /// Ch 6, p.148: "Pinning or otherwise ensnaring the target's limbs or body. Flexible
+    /// weapons, nets, ropes, and those with short, jagged points inflict entangling attacks." No
+    /// weapon in the hand-picked subset uses this type. Base damage is normal; the entangling
+    /// effect (p.151) is deferred.
+    /// </summary>
+    Entangling,
+
+    /// <summary>
+    /// Ch 6, p.148: "A deep wound piercing vital organs or passing entirely through the body of
+    /// the target. Firearms, arrows, and other pointed weapons inflict impaling damage." Doubles
+    /// the weapon's whole damage expression (dice and any fixed modifier) on a special success
+    /// (p.150) -- see <c>Brp.Rules.Combat.DamageResolver</c>; the lodged-weapon/extraction
+    /// mechanics are deferred.
+    /// </summary>
+    Impaling,
+
+    /// <summary>
+    /// Ch 6, p.148: "A wound that unbalances and possibly sends the target sprawling backwards.
+    /// Some forms of unarmed attacks and shield attacks cause knockback." No weapon in the
+    /// hand-picked subset uses this type. Base damage is normal; the knockback effect (p.151) is
+    /// deferred.
+    /// </summary>
+    Knockback,
+}

--- a/src/Brp.Rules/Gear/WeaponDefinition.cs
+++ b/src/Brp.Rules/Gear/WeaponDefinition.cs
@@ -37,6 +37,12 @@ namespace Brp.Rules.Gear;
 /// Firearm-only stats (range, malfunction number, ammo capacity/rate, printed base chance).
 /// <see langword="null"/> for melee and brawl weapons.
 /// </param>
+/// <param name="SpecialDamageType">
+/// The special-success damage type this weapon inflicts (Ch 6, "Special Successes and Damage",
+/// pp.148-149) -- e.g. firearms and pointed knives are <see cref="Gear.SpecialDamageType.Impaling"/>
+/// (p.150), clubs and brass knuckles are <see cref="Gear.SpecialDamageType.Crushing"/> (p.149).
+/// Read by <c>Brp.Rules.Combat.DamageResolver</c> to compute special-success damage.
+/// </param>
 /// <param name="Source">The book table (and any note) this entry was transcribed from.</param>
 public sealed record WeaponDefinition(
     WeaponId Id,
@@ -47,6 +53,7 @@ public sealed record WeaponDefinition(
     bool ApplyDamageBonus,
     IReadOnlyList<RangeIncrementDamage> DamageByRange,
     FirearmProfile? Firearm,
+    SpecialDamageType SpecialDamageType,
     string Source)
 {
     /// <summary>True for weapons with <see cref="Firearm"/> data; false for melee/brawl weapons.</summary>

--- a/tests/Brp.Core.Tests/Dice/DiceExpressionTests.cs
+++ b/tests/Brp.Core.Tests/Dice/DiceExpressionTests.cs
@@ -350,4 +350,40 @@ public class DiceExpressionTests
         var expression = DiceExpression.Parse("1D6");
         Assert.Throws<ArgumentNullException>(() => expression.Roll(null!));
     }
+
+    // Ch 6: Combat, "Critical Success" (p.146): "the maximum possible damage for the weapon
+    // used (6 for 1D6, 9 for 1D8+1, etc.)" -- the book's own two worked examples, plus enough
+    // additional notation shapes to pin the general min/max arithmetic (multi-die, multi-term,
+    // and negative-signed terms).
+    public static TheoryData<string, int, int> MaximumAndMinimumPossible => new()
+    {
+        { "1D6", 1, 6 }, // book example: max 6 for 1D6
+        { "1D8+1", 2, 9 }, // book example: max 9 for 1D8+1
+        { "2D8", 2, 16 },
+        { "1D10+2", 3, 12 },
+        { "2D6+4", 6, 16 },
+        { "1D10+1D4", 2, 14 },
+        { "1D6-2", -1, 4 }, // pre-floor: MinimumPossible is not the Roll()-floored value
+    };
+
+    [Theory]
+    [MemberData(nameof(MaximumAndMinimumPossible))]
+    public void MaximumPossible_and_MinimumPossible_match_the_expression_bounds(string notation, int min, int max)
+    {
+        var expression = DiceExpression.Parse(notation);
+
+        Assert.Equal(min, expression.MinimumPossible());
+        Assert.Equal(max, expression.MaximumPossible());
+    }
+
+    [Theory]
+    [InlineData("1D8+DB")]
+    [InlineData("DB/2")]
+    public void MaximumPossible_and_MinimumPossible_reject_damage_bonus_terms(string notation)
+    {
+        var expression = DiceExpression.Parse(notation);
+
+        Assert.Throws<NotSupportedException>(() => expression.MaximumPossible());
+        Assert.Throws<NotSupportedException>(() => expression.MinimumPossible());
+    }
 }

--- a/tests/Brp.Data.Tests/NoirDamageRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirDamageRulesetTests.cs
@@ -1,0 +1,29 @@
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped damage ruleset data loads and carries the thresholds and knockout
+/// duration cited in Ch 2 (p.13), Ch 6 (pp.154-156), and Ch 7 (p.174). See
+/// <c>docs/decisions/0017-damage.md</c>.
+/// </summary>
+public class NoirDamageRulesetTests
+{
+    [Fact]
+    public void Load_returns_the_printed_unconscious_and_dead_thresholds()
+    {
+        var ruleset = NoirDamageRuleset.Load();
+
+        // Ch 2, p.13: "Your character loses consciousness when their hit points are reduced to
+        // 2 or less, and if their hit points reach 0, they die at the end of the following round."
+        Assert.Equal(2, ruleset.UnconsciousHitPointLevel);
+        Assert.Equal(0, ruleset.DeadHitPointLevel);
+    }
+
+    [Fact]
+    public void Load_returns_the_printed_knockout_duration_dice()
+    {
+        // Ch 7, p.174: "knocked out for 1D10+10 rounds."
+        var ruleset = NoirDamageRuleset.Load();
+
+        Assert.Equal("1D10+10", ruleset.KnockoutDuration.Notation);
+    }
+}

--- a/tests/Brp.Data.Tests/NoirDamageRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirDamageRulesetTests.cs
@@ -26,4 +26,13 @@ public class NoirDamageRulesetTests
 
         Assert.Equal("1D10+10", ruleset.KnockoutDuration.Notation);
     }
+
+    [Fact]
+    public void Load_returns_the_printed_crushing_no_modifier_fallback_dice()
+    {
+        // Ch 6, p.149: "if there is no damage modifier, it becomes +1D4."
+        var ruleset = NoirDamageRuleset.Load();
+
+        Assert.Equal("1D4", ruleset.CrushingNoModifierBonus.Notation);
+    }
 }

--- a/tests/Brp.Data.Tests/NoirGearRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirGearRulesetTests.cs
@@ -151,6 +151,51 @@ public class NoirGearRulesetTests
         Assert.Equal("1 or 2", firearm.AmmoCapacity);
     }
 
+    public static TheoryData<string, SpecialDamageType> SpecialDamageTypesByWeapon => new()
+    {
+        // Ch 6, p.150: "Firearms, arrows, and other pointed weapons inflict impaling damage."
+        { "knifeButcher", SpecialDamageType.Impaling },
+        { "knifePocket", SpecialDamageType.Impaling },
+        { "knifeSwitchblade", SpecialDamageType.Impaling },
+        { "pistolDerringer", SpecialDamageType.Impaling },
+        { "pistolLight", SpecialDamageType.Impaling },
+        { "pistolMedium", SpecialDamageType.Impaling },
+        { "pistolHeavy", SpecialDamageType.Impaling },
+        { "revolverLight", SpecialDamageType.Impaling },
+        { "revolverMedium", SpecialDamageType.Impaling },
+        { "revolverHeavy", SpecialDamageType.Impaling },
+        { "rifleBoltAction", SpecialDamageType.Impaling },
+        { "rifleSniper", SpecialDamageType.Impaling },
+        { "shotgunDoubleBarreled", SpecialDamageType.Impaling },
+        { "shotgunSawedOff", SpecialDamageType.Impaling },
+        { "gunSubmachine", SpecialDamageType.Impaling },
+        // Ch 6, p.149: "Clubs, unarmed strikes, and other blunt weapons can cause crushing damage."
+        { "brassKnuckles", SpecialDamageType.Crushing },
+        { "clubHeavy", SpecialDamageType.Crushing },
+        { "clubLight", SpecialDamageType.Crushing },
+    };
+
+    [Theory]
+    [MemberData(nameof(SpecialDamageTypesByWeapon))]
+    public void Every_weapon_has_the_printed_special_damage_type(string id, SpecialDamageType expected)
+    {
+        var registry = NoirGearRuleset.Load();
+
+        var weapon = registry.WeaponById(new WeaponId(id));
+
+        Assert.Equal(expected, weapon.SpecialDamageType);
+    }
+
+    [Fact]
+    public void The_special_damage_type_table_covers_every_shipped_weapon_exactly_once()
+    {
+        var registry = NoirGearRuleset.Load();
+        var allIds = registry.Weapons.Keys.Select(id => id.Value).OrderBy(id => id, StringComparer.Ordinal).ToList();
+        var coveredIds = SpecialDamageTypesByWeapon.Select(row => (string)row[0]!).OrderBy(id => id, StringComparer.Ordinal).ToList();
+
+        Assert.Equal(allIds, coveredIds);
+    }
+
     private static void AssertIncrement(RangeIncrementDamage increment, int range, string damage)
     {
         Assert.Equal(range, increment.Range);

--- a/tests/Brp.Rules.Tests/Combat/DamageResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/DamageResolverTests.cs
@@ -10,16 +10,17 @@ namespace Brp.Rules.Tests.Combat;
 
 /// <summary>
 /// Layer 4 piece D (#52): <see cref="DamageResolver"/>. Ch 6: Combat, pp.146-156; Ch 7: Spot
-/// Rules, "Knockout Attacks", p.174. See <c>docs/decisions/0017-damage.md</c> for the
-/// correction this piece made against the initial "special = weaponMax + normalRoll + db"
-/// transcription -- <see cref="Special_success_uses_the_same_dice_arithmetic_as_a_normal_hit_not_weaponMax_plus_a_fresh_roll"/>
-/// pins the corrected behavior precisely so a reversion is a failing test, not a silent regression.
+/// Rules, "Knockout Attacks", p.174. See <c>docs/decisions/0017-damage.md</c> for the two
+/// corrections made against, first, the initial ruleset transcription's "weaponMax + normalRoll"
+/// special formula, and, second, this piece's own first (still wrong) correction to a uniform
+/// "special = normal" formula -- both falsified independently by rules-conformance and Codex.
 /// </summary>
 public class DamageResolverTests
 {
     private static readonly DamageRuleset Ruleset = NoirDamageRuleset.Load();
 
-    private static WeaponDefinition MakeWeapon(string damage, bool applyDamageBonus) => new(
+    private static WeaponDefinition MakeWeapon(
+        string damage, bool applyDamageBonus, SpecialDamageType specialDamageType = SpecialDamageType.Bleeding) => new(
         Id: new WeaponId("test-weapon"),
         Name: "Test Weapon",
         SkillId: new SkillId("Melee Weapons"),
@@ -28,6 +29,7 @@ public class DamageResolverTests
         ApplyDamageBonus: applyDamageBonus,
         DamageByRange: [],
         Firearm: null,
+        SpecialDamageType: specialDamageType,
         Source: "Test fixture, not from the book.");
 
     private static AbilitySet MakeTarget(int con, int siz)
@@ -47,35 +49,150 @@ public class DamageResolverTests
         var entropy = new FixedEntropySource(3, 2); // weapon die 3 (+2 constant = 5), db die 2
 
         var roll = DamageResolver.RollDamage(
-            LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 2, entropy);
+            LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 2, Ruleset, entropy);
 
-        Assert.Equal(5, roll.WeaponRoll!.RawTotal); // 3 + 2
-        Assert.Equal(2, roll.DamageBonusRoll!.RawTotal);
+        Assert.Equal(5, Assert.Single(roll.WeaponRolls).RawTotal); // 3 + 2
+        Assert.Equal(2, Assert.Single(roll.DamageBonusRolls).RawTotal);
         Assert.Equal(2, roll.ArmorApplied);
         Assert.Equal(5, roll.DamageDealt); // (5 + 2) - 2 = 5
     }
 
     [Fact]
-    public void Special_success_uses_the_same_dice_arithmetic_as_a_normal_hit_not_weaponMax_plus_a_fresh_roll()
+    public void Special_success_with_a_non_damage_changing_type_uses_the_same_arithmetic_as_a_normal_hit()
     {
-        // Ch 6, p.147 footnote **: "For a greatsword, full damage is 2D8 on a normal success,
-        // 2D8 bleeding damage on a special success" -- identical dice both times. Feeding the
-        // Special path the exact same scripted entropy as the Normal test above must produce the
-        // exact same damage; anyone who "fixes" this back to weaponMax + normalRoll + db makes
-        // this test fail because it would consume an extra entropy draw for the weapon maximum
-        // and double the weapon-dice contribution.
-        var weapon = MakeWeapon("1D6+2", applyDamageBonus: true);
+        // Ch 6, pp.149-151: Bleeding/Entangling/Knockback layer a deferred EFFECT on top of
+        // unchanged damage; only Impaling and Crushing change the damage number (see the other
+        // tests below). No shipped weapon uses these three types, but the formula is still
+        // modeled for a future one.
+        var weapon = MakeWeapon("1D6+2", applyDamageBonus: true, SpecialDamageType.Bleeding);
         var damageBonus = DiceExpression.Parse("1D4");
         var entropy = new FixedEntropySource(3, 2);
 
         var roll = DamageResolver.RollDamage(
-            LandedGrade.Special, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 2, entropy);
+            LandedGrade.Special, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 2, Ruleset, entropy);
 
         Assert.Null(roll.WeaponMaximum);
-        Assert.Equal(5, roll.WeaponRoll!.RawTotal);
+        Assert.Equal(5, Assert.Single(roll.WeaponRolls).RawTotal);
         Assert.Equal(2, roll.ArmorApplied);
         Assert.Equal(5, roll.DamageDealt);
         Assert.Equal(2, entropy.DrawCount); // exactly one weapon die and one db die, no third draw
+    }
+
+    [Fact]
+    public void Impaling_special_doubles_the_whole_weapon_damage_expression_and_adds_an_undoubled_damage_bonus()
+    {
+        // Ch 6, p.150: "An impale doubles the dice and modifier for the weapon's normal rolled
+        // damage... a short sword ... 1D6+1 ... does twice that, or 2D6+2." Firearms and pointed
+        // knives are Impaling (p.150: "Firearms, arrows, and other pointed weapons").
+        var weapon = MakeWeapon("1D8+1", applyDamageBonus: true, SpecialDamageType.Impaling);
+        var damageBonus = DiceExpression.Parse("1D4");
+        var entropy = new FixedEntropySource(5, 3, 2); // two weapon dice (5, 3), then one db die (2)
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Special, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 1, Ruleset, entropy);
+
+        Assert.Equal(2, roll.WeaponRolls.Count);
+        Assert.Equal(6, roll.WeaponRolls[0].RawTotal); // 5 + 1
+        Assert.Equal(4, roll.WeaponRolls[1].RawTotal); // 3 + 1
+        Assert.Equal(2, Assert.Single(roll.DamageBonusRolls).RawTotal); // db rolled once, undoubled
+        Assert.Equal(1, roll.ArmorApplied);
+        Assert.Equal(11, roll.DamageDealt); // (6 + 4 + 2) - 1 = 11
+        Assert.Equal(3, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void Medium_pistol_special_success_doubles_1D8_not_a_single_1D8_roll()
+    {
+        // The coordinator's own worked example: a Medium Pistol (1D8, no damage bonus) special
+        // success must roll 2D8 worth of dice, not 1D8.
+        var pistol = MakeWeapon("1D8", applyDamageBonus: false, SpecialDamageType.Impaling);
+        var entropy = new FixedEntropySource(6, 7); // two independent d8 draws
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Special, ArmorTreatment.Subtracted, pistol, damageBonus: null, armorValue: 0, Ruleset, entropy);
+
+        Assert.Equal(2, roll.WeaponRolls.Count);
+        Assert.Empty(roll.DamageBonusRolls); // firearm: no damage bonus at all
+        Assert.Equal(13, roll.DamageDealt); // 6 + 7, no armor
+        Assert.Equal(2, entropy.DrawCount); // exactly two dice, not one
+    }
+
+    [Fact]
+    public void Crushing_special_rolls_normal_weapon_dice_but_doubles_a_positive_damage_bonus()
+    {
+        // Ch 6, p.149: "A crushing special success doubles the damage modifier... The weapon's
+        // damage is rolled normally, but the damage modifier is increased." Clubs and brass
+        // knuckles are Crushing (p.149: "Clubs, unarmed strikes, and other blunt weapons").
+        var club = MakeWeapon("1D8", applyDamageBonus: true, SpecialDamageType.Crushing);
+        var damageBonus = DiceExpression.Parse("1D4");
+        var entropy = new FixedEntropySource(5, 3, 2); // one weapon die, then two db dice (doubled)
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Special, ArmorTreatment.Subtracted, club, damageBonus, armorValue: 0, Ruleset, entropy);
+
+        Assert.Equal(5, Assert.Single(roll.WeaponRolls).RawTotal); // normal, single roll
+        Assert.Equal(2, roll.DamageBonusRolls.Count); // db doubled: rolled twice
+        Assert.Equal(3, roll.DamageBonusRolls[0].RawTotal);
+        Assert.Equal(2, roll.DamageBonusRolls[1].RawTotal);
+        Assert.Equal(10, roll.DamageDealt); // 5 + (3 + 2)
+        Assert.Equal(3, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void Crushing_special_with_no_damage_bonus_substitutes_a_flat_1D4()
+    {
+        // Ch 6, p.149: "if there is no damage modifier, it becomes +1D4."
+        var club = MakeWeapon("1D8", applyDamageBonus: true, SpecialDamageType.Crushing);
+        var entropy = new FixedEntropySource(5, 4); // weapon die, then the +1D4 fallback die
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Special, ArmorTreatment.Subtracted, club, damageBonus: null, armorValue: 0, Ruleset, entropy);
+
+        Assert.Equal(5, Assert.Single(roll.WeaponRolls).RawTotal);
+        Assert.Equal(4, Assert.Single(roll.DamageBonusRolls).RawTotal); // the +1D4 fallback, rolled once
+        Assert.Equal(9, roll.DamageDealt); // 5 + 4
+    }
+
+    [Fact]
+    public void Crushing_special_with_a_negative_damage_bonus_collapses_to_no_modifier_rather_than_doubling_it()
+    {
+        // Ch 6, p.149: "If the attacker has a negative damage modifier, this becomes no damage
+        // modifier" -- not a doubled (more negative) modifier.
+        var club = MakeWeapon("1D8", applyDamageBonus: true, SpecialDamageType.Crushing);
+        var negativeDamageBonus = DiceExpression.Parse("-1D4");
+        var entropy = new FixedEntropySource(5); // only the weapon die -- no db roll at all
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Special, ArmorTreatment.Subtracted, club, negativeDamageBonus, armorValue: 0, Ruleset, entropy);
+
+        Assert.Empty(roll.DamageBonusRolls);
+        Assert.Equal(5, roll.DamageDealt);
+        Assert.Equal(1, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void A_special_hit_deals_more_than_a_normal_hit_for_every_shipped_special_damage_type()
+    {
+        // Every shipped weapon is Impaling or Crushing (weapon-ruleset.json); both change the
+        // damage number upward relative to Normal. Uses generous, non-random entropy so the
+        // "more than" comparison holds deterministically for both types.
+        foreach (var (type, weapon) in new[]
+        {
+            (SpecialDamageType.Impaling, MakeWeapon("1D8+1", applyDamageBonus: true, SpecialDamageType.Impaling)),
+            (SpecialDamageType.Crushing, MakeWeapon("1D8", applyDamageBonus: true, SpecialDamageType.Crushing)),
+        })
+        {
+            var damageBonus = DiceExpression.Parse("1D4");
+            var normalEntropy = new FixedEntropySource(4, 2); // weapon die 4, db die 2
+            var specialEntropy = new FixedEntropySource(4, 4, 2, 2); // same weapon/db draws, doubled
+
+            var normal = DamageResolver.RollDamage(
+                LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 0, Ruleset, normalEntropy);
+            var special = DamageResolver.RollDamage(
+                LandedGrade.Special, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 0, Ruleset, specialEntropy);
+
+            Assert.True(special.DamageDealt > normal.DamageDealt, $"{type} special ({special.DamageDealt}) was not greater than normal ({normal.DamageDealt}).");
+        }
     }
 
     [Theory]
@@ -89,11 +206,11 @@ public class DamageResolverTests
         var entropy = new FixedEntropySource(2); // only the db die is rolled
 
         var roll = DamageResolver.RollDamage(
-            LandedGrade.Critical, armorTreatment, weapon, damageBonus, armorValue: 100, entropy);
+            LandedGrade.Critical, armorTreatment, weapon, damageBonus, armorValue: 100, Ruleset, entropy);
 
-        Assert.Null(roll.WeaponRoll);
+        Assert.Empty(roll.WeaponRolls);
         Assert.Equal(8, roll.WeaponMaximum);
-        Assert.Equal(2, roll.DamageBonusRoll!.RawTotal);
+        Assert.Equal(2, Assert.Single(roll.DamageBonusRolls).RawTotal);
         Assert.Equal(0, roll.ArmorApplied);
         Assert.Equal(10, roll.DamageDealt); // 8 + 2, armor (100) ignored entirely
         Assert.Equal(1, entropy.DrawCount);
@@ -107,9 +224,9 @@ public class DamageResolverTests
         var entropy = new FixedEntropySource(5); // only the weapon die -- db must not be drawn
 
         var roll = DamageResolver.RollDamage(
-            LandedGrade.Normal, ArmorTreatment.Subtracted, firearm, damageBonus, armorValue: 1, entropy);
+            LandedGrade.Normal, ArmorTreatment.Subtracted, firearm, damageBonus, armorValue: 1, Ruleset, entropy);
 
-        Assert.Null(roll.DamageBonusRoll);
+        Assert.Empty(roll.DamageBonusRolls);
         Assert.Equal(4, roll.DamageDealt); // 5 - 1 armor, no db
         Assert.Equal(1, entropy.DrawCount);
     }
@@ -121,7 +238,7 @@ public class DamageResolverTests
         var entropy = new FixedEntropySource(); // throws if anything is drawn
 
         var roll = DamageResolver.RollDamage(
-            LandedGrade.Miss, ArmorTreatment.NotApplicable, weapon, DiceExpression.Parse("1D4"), armorValue: 0, entropy);
+            LandedGrade.Miss, ArmorTreatment.NotApplicable, weapon, DiceExpression.Parse("1D4"), armorValue: 0, Ruleset, entropy);
 
         Assert.Equal(0, roll.DamageDealt);
         Assert.Equal(0, entropy.DrawCount);
@@ -134,7 +251,7 @@ public class DamageResolverTests
         var entropy = new FixedEntropySource(3);
 
         Assert.Throws<ArgumentException>(() => DamageResolver.RollDamage(
-            LandedGrade.Normal, ArmorTreatment.NotApplicable, weapon, null, armorValue: 0, entropy));
+            LandedGrade.Normal, ArmorTreatment.NotApplicable, weapon, null, armorValue: 0, Ruleset, entropy));
     }
 
     [Fact]
@@ -144,7 +261,7 @@ public class DamageResolverTests
         var wounds = new WoundTrack();
         var weapon = MakeWeapon("1D6", applyDamageBonus: false);
         var entropy = new FixedEntropySource(4);
-        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, entropy);
+        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, Ruleset, entropy);
         var before = target.CurrentHitPoints;
 
         var result = DamageResolver.ApplyDamage(target, wounds, roll, Ruleset, "Struck by a test weapon.");
@@ -164,7 +281,7 @@ public class DamageResolverTests
         var wounds = new WoundTrack();
         var weapon = MakeWeapon("1D6", applyDamageBonus: false);
         var entropy = new FixedEntropySource();
-        var roll = DamageResolver.RollDamage(LandedGrade.Miss, ArmorTreatment.NotApplicable, weapon, null, armorValue: 0, entropy);
+        var roll = DamageResolver.RollDamage(LandedGrade.Miss, ArmorTreatment.NotApplicable, weapon, null, armorValue: 0, Ruleset, entropy);
         var before = target.CurrentHitPoints;
 
         var result = DamageResolver.ApplyDamage(target, wounds, roll, Ruleset, "Missed.");
@@ -186,7 +303,7 @@ public class DamageResolverTests
         var wounds = new WoundTrack();
         var weapon = MakeWeapon("1", applyDamageBonus: false); // flat 1 damage, no entropy needed
         var entropy = new FixedEntropySource();
-        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, entropy);
+        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, Ruleset, entropy);
 
         var result = DamageResolver.ApplyDamage(target, wounds, roll, Ruleset, "Grazed.");
 
@@ -202,7 +319,7 @@ public class DamageResolverTests
         var wounds = new WoundTrack();
         var weapon = MakeWeapon("10", applyDamageBonus: false); // a large flat hit
         var entropy = new FixedEntropySource();
-        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, entropy);
+        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, Ruleset, entropy);
 
         var result = DamageResolver.ApplyDamage(target, wounds, roll, Ruleset, "Shot.");
 
@@ -302,6 +419,28 @@ public class DamageResolverTests
         Assert.True(knockout.KnockedOut); // 6 >= major wound level 3
         Assert.Equal(1, knockout.DamageDealt);
         Assert.Equal(19, knockout.DurationRounds); // 9 + 10
+    }
+
+    [Fact]
+    public void Knockout_attack_with_an_impaling_special_uses_the_doubled_damage_for_the_major_wound_determination()
+    {
+        // Ch 7, p.174: "The effects of special or critical successes (such as extra damage or
+        // bypassing armor) apply in all cases." A knife (Impaling) special success rolling
+        // 1D6+1D6 = would be a minor wound undoubled, but the doubled Impaling total pushes it
+        // into major-wound territory and triggers the knockout.
+        var target = MakeTarget(con: 3, siz: 8); // major wound level 3
+        var knife = MakeWeapon("1D6", applyDamageBonus: false, SpecialDamageType.Impaling);
+        var outcome = new AttackDefenseOutcome(
+            LandedGrade.Special, ArmorTreatment.Subtracted, ParryWeaponDamage: null,
+            DefenderRollsOnFumbleTable: false, AttackerRollsOnFumbleTable: false, SourceText: "test");
+        var entropy = new FixedEntropySource(2, 2, 6); // two weapon dice (2+2=4, undoubled would be 2), then duration die
+
+        var knockout = DamageResolver.ResolveKnockoutAttack(outcome, knife, null, armorValue: 0, target, Ruleset, entropy);
+
+        Assert.Equal(4, knockout.UnderlyingRoll.DamageDealt); // 2 + 2, doubled dice -- not just 2
+        Assert.True(knockout.KnockedOut); // 4 >= major wound level 3 only because of the doubling
+        Assert.Equal(1, knockout.DamageDealt);
+        Assert.Equal(16, knockout.DurationRounds); // 6 + 10
     }
 
     [Fact]

--- a/tests/Brp.Rules.Tests/Combat/DamageResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/DamageResolverTests.cs
@@ -1,0 +1,326 @@
+using Brp.Core.Abilities;
+using Brp.Core.Dice;
+using Brp.Core.Skills;
+using Brp.Data;
+using Brp.Rules.Characters;
+using Brp.Rules.Combat;
+using Brp.Rules.Gear;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Layer 4 piece D (#52): <see cref="DamageResolver"/>. Ch 6: Combat, pp.146-156; Ch 7: Spot
+/// Rules, "Knockout Attacks", p.174. See <c>docs/decisions/0017-damage.md</c> for the
+/// correction this piece made against the initial "special = weaponMax + normalRoll + db"
+/// transcription -- <see cref="Special_success_uses_the_same_dice_arithmetic_as_a_normal_hit_not_weaponMax_plus_a_fresh_roll"/>
+/// pins the corrected behavior precisely so a reversion is a failing test, not a silent regression.
+/// </summary>
+public class DamageResolverTests
+{
+    private static readonly DamageRuleset Ruleset = NoirDamageRuleset.Load();
+
+    private static WeaponDefinition MakeWeapon(string damage, bool applyDamageBonus) => new(
+        Id: new WeaponId("test-weapon"),
+        Name: "Test Weapon",
+        SkillId: new SkillId("Melee Weapons"),
+        WeaponClass: WeaponClass.Club,
+        Damage: DiceExpression.Parse(damage),
+        ApplyDamageBonus: applyDamageBonus,
+        DamageByRange: [],
+        Firearm: null,
+        Source: "Test fixture, not from the book.");
+
+    private static AbilitySet MakeTarget(int con, int siz)
+    {
+        var abilityRuleset = NoirAbilityRuleset.Load();
+        var values = abilityRuleset.Characteristics.Keys.ToDictionary(id => id, _ => 10);
+        values[new CharacteristicId("CON")] = con;
+        values[new CharacteristicId("SIZ")] = siz;
+        return new AbilitySet(abilityRuleset, values);
+    }
+
+    [Fact]
+    public void Normal_hit_rolls_weapon_dice_plus_damage_bonus_minus_armor()
+    {
+        var weapon = MakeWeapon("1D6+2", applyDamageBonus: true);
+        var damageBonus = DiceExpression.Parse("1D4");
+        var entropy = new FixedEntropySource(3, 2); // weapon die 3 (+2 constant = 5), db die 2
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 2, entropy);
+
+        Assert.Equal(5, roll.WeaponRoll!.RawTotal); // 3 + 2
+        Assert.Equal(2, roll.DamageBonusRoll!.RawTotal);
+        Assert.Equal(2, roll.ArmorApplied);
+        Assert.Equal(5, roll.DamageDealt); // (5 + 2) - 2 = 5
+    }
+
+    [Fact]
+    public void Special_success_uses_the_same_dice_arithmetic_as_a_normal_hit_not_weaponMax_plus_a_fresh_roll()
+    {
+        // Ch 6, p.147 footnote **: "For a greatsword, full damage is 2D8 on a normal success,
+        // 2D8 bleeding damage on a special success" -- identical dice both times. Feeding the
+        // Special path the exact same scripted entropy as the Normal test above must produce the
+        // exact same damage; anyone who "fixes" this back to weaponMax + normalRoll + db makes
+        // this test fail because it would consume an extra entropy draw for the weapon maximum
+        // and double the weapon-dice contribution.
+        var weapon = MakeWeapon("1D6+2", applyDamageBonus: true);
+        var damageBonus = DiceExpression.Parse("1D4");
+        var entropy = new FixedEntropySource(3, 2);
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Special, ArmorTreatment.Subtracted, weapon, damageBonus, armorValue: 2, entropy);
+
+        Assert.Null(roll.WeaponMaximum);
+        Assert.Equal(5, roll.WeaponRoll!.RawTotal);
+        Assert.Equal(2, roll.ArmorApplied);
+        Assert.Equal(5, roll.DamageDealt);
+        Assert.Equal(2, entropy.DrawCount); // exactly one weapon die and one db die, no third draw
+    }
+
+    [Theory]
+    [InlineData(ArmorTreatment.Bypassed)]
+    [InlineData(ArmorTreatment.DoesNotApply)]
+    public void Critical_success_uses_weapon_maximum_plus_damage_bonus_and_ignores_armor_under_either_collapsed_treatment(
+        ArmorTreatment armorTreatment)
+    {
+        var weapon = MakeWeapon("1D6+2", applyDamageBonus: true); // max = 6 + 2 = 8
+        var damageBonus = DiceExpression.Parse("1D4");
+        var entropy = new FixedEntropySource(2); // only the db die is rolled
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Critical, armorTreatment, weapon, damageBonus, armorValue: 100, entropy);
+
+        Assert.Null(roll.WeaponRoll);
+        Assert.Equal(8, roll.WeaponMaximum);
+        Assert.Equal(2, roll.DamageBonusRoll!.RawTotal);
+        Assert.Equal(0, roll.ArmorApplied);
+        Assert.Equal(10, roll.DamageDealt); // 8 + 2, armor (100) ignored entirely
+        Assert.Equal(1, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void Damage_bonus_is_not_applied_when_the_weapon_does_not_use_it()
+    {
+        var firearm = MakeWeapon("1D8", applyDamageBonus: false);
+        var damageBonus = DiceExpression.Parse("1D4");
+        var entropy = new FixedEntropySource(5); // only the weapon die -- db must not be drawn
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Normal, ArmorTreatment.Subtracted, firearm, damageBonus, armorValue: 1, entropy);
+
+        Assert.Null(roll.DamageBonusRoll);
+        Assert.Equal(4, roll.DamageDealt); // 5 - 1 armor, no db
+        Assert.Equal(1, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void Miss_deals_no_damage_and_consumes_no_entropy()
+    {
+        var weapon = MakeWeapon("1D6", applyDamageBonus: true);
+        var entropy = new FixedEntropySource(); // throws if anything is drawn
+
+        var roll = DamageResolver.RollDamage(
+            LandedGrade.Miss, ArmorTreatment.NotApplicable, weapon, DiceExpression.Parse("1D4"), armorValue: 0, entropy);
+
+        Assert.Equal(0, roll.DamageDealt);
+        Assert.Equal(0, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void RollDamage_rejects_an_inconsistent_armor_treatment_for_a_landed_hit()
+    {
+        var weapon = MakeWeapon("1D6", applyDamageBonus: false);
+        var entropy = new FixedEntropySource(3);
+
+        Assert.Throws<ArgumentException>(() => DamageResolver.RollDamage(
+            LandedGrade.Normal, ArmorTreatment.NotApplicable, weapon, null, armorValue: 0, entropy));
+    }
+
+    [Fact]
+    public void ApplyDamage_reduces_hit_points_and_records_a_wound()
+    {
+        var target = MakeTarget(con: 12, siz: 12);
+        var wounds = new WoundTrack();
+        var weapon = MakeWeapon("1D6", applyDamageBonus: false);
+        var entropy = new FixedEntropySource(4);
+        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, entropy);
+        var before = target.CurrentHitPoints;
+
+        var result = DamageResolver.ApplyDamage(target, wounds, roll, Ruleset, "Struck by a test weapon.");
+
+        Assert.Equal(4, result.DamageDealt);
+        Assert.Equal(before - 4, target.CurrentHitPoints);
+        Assert.Equal(target.CurrentHitPoints, result.ResultingHitPoints);
+        Assert.Single(wounds.Wounds);
+        Assert.Equal("Struck by a test weapon.", wounds.Wounds[0].Description);
+        Assert.Same(wounds.Wounds[0], result.Wound);
+    }
+
+    [Fact]
+    public void ApplyDamage_on_a_miss_changes_nothing_and_records_no_wound()
+    {
+        var target = MakeTarget(con: 12, siz: 12);
+        var wounds = new WoundTrack();
+        var weapon = MakeWeapon("1D6", applyDamageBonus: false);
+        var entropy = new FixedEntropySource();
+        var roll = DamageResolver.RollDamage(LandedGrade.Miss, ArmorTreatment.NotApplicable, weapon, null, armorValue: 0, entropy);
+        var before = target.CurrentHitPoints;
+
+        var result = DamageResolver.ApplyDamage(target, wounds, roll, Ruleset, "Missed.");
+
+        Assert.Equal(0, result.DamageDealt);
+        Assert.Equal(before, target.CurrentHitPoints);
+        Assert.Empty(wounds.Wounds);
+        Assert.Null(result.Wound);
+        Assert.Equal(HitPointCondition.Unaffected, result.Condition);
+    }
+
+    [Fact]
+    public void Target_is_unconscious_at_or_below_the_ruleset_threshold()
+    {
+        // Ch 2, p.13: "Your character loses consciousness when their hit points are reduced to
+        // 2 or less." Read from the loaded ruleset, not hardcoded, per AGENTS.md invariant 7.
+        var target = MakeTarget(con: 21, siz: 21); // plenty of headroom above the threshold
+        target.SetCurrentHitPoints(Ruleset.UnconsciousHitPointLevel + 1);
+        var wounds = new WoundTrack();
+        var weapon = MakeWeapon("1", applyDamageBonus: false); // flat 1 damage, no entropy needed
+        var entropy = new FixedEntropySource();
+        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, entropy);
+
+        var result = DamageResolver.ApplyDamage(target, wounds, roll, Ruleset, "Grazed.");
+
+        Assert.Equal(Ruleset.UnconsciousHitPointLevel, result.ResultingHitPoints);
+        Assert.Equal(HitPointCondition.Unconscious, result.Condition);
+    }
+
+    [Fact]
+    public void Target_is_fatally_wounded_at_or_below_the_dead_threshold_and_negative_hit_points_are_tracked()
+    {
+        var target = MakeTarget(con: 21, siz: 21);
+        target.SetCurrentHitPoints(Ruleset.DeadHitPointLevel + 3);
+        var wounds = new WoundTrack();
+        var weapon = MakeWeapon("10", applyDamageBonus: false); // a large flat hit
+        var entropy = new FixedEntropySource();
+        var roll = DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, null, armorValue: 0, entropy);
+
+        var result = DamageResolver.ApplyDamage(target, wounds, roll, Ruleset, "Shot.");
+
+        Assert.Equal(HitPointCondition.FatallyWounded, result.Condition);
+        Assert.True(result.ResultingHitPoints < Ruleset.DeadHitPointLevel); // negative HP tracked, not floored
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public void ResolvesToDeath_is_true_only_at_or_below_the_dead_threshold(int hitPointsAtEndOfFollowingRound)
+    {
+        Assert.Equal(
+            hitPointsAtEndOfFollowingRound <= Ruleset.DeadHitPointLevel,
+            DamageResolver.ResolvesToDeath(hitPointsAtEndOfFollowingRound, Ruleset));
+    }
+
+    [Fact]
+    public void ResolvesToDeath_is_false_once_hit_points_are_restored_above_the_threshold()
+    {
+        // Models the seam to piece E: a First Aid intervention in the intervening round can
+        // still change the outcome by the time the following round ends.
+        Assert.False(DamageResolver.ResolvesToDeath(Ruleset.DeadHitPointLevel + 1, Ruleset));
+    }
+
+    [Fact]
+    public void Knockout_attack_with_minor_wound_damage_deals_the_weapons_minimum_damage_and_does_not_knock_out()
+    {
+        // CON 3 (minimum) + SIZ 8 (minimum) -> 5.5 hit points, rounded up to 6; major wound
+        // level is half of that, rounded up, i.e. 3.
+        var target = MakeTarget(con: 3, siz: 8);
+        Assert.Equal(6, target.MaximumHitPoints);
+        Assert.Equal(3, target.MajorWoundLevel);
+
+        var weapon = MakeWeapon("1D6", applyDamageBonus: false); // minimum possible damage: 1
+        var outcome = new AttackDefenseOutcome(
+            LandedGrade.Normal, ArmorTreatment.Subtracted, ParryWeaponDamage: null,
+            DefenderRollsOnFumbleTable: false, AttackerRollsOnFumbleTable: false, SourceText: "test");
+        var entropy = new FixedEntropySource(2); // rolled damage 2 < major wound level 3
+
+        var knockout = DamageResolver.ResolveKnockoutAttack(outcome, weapon, null, armorValue: 0, target, Ruleset, entropy);
+
+        Assert.False(knockout.KnockedOut);
+        Assert.Equal(1, knockout.DamageDealt); // the weapon's minimum, not the rolled damage
+        Assert.Null(knockout.DurationRounds);
+        Assert.Equal(1, entropy.DrawCount); // no duration roll consumed
+    }
+
+    [Fact]
+    public void Knockout_attack_with_major_wound_damage_deals_one_point_and_knocks_out_for_1D10_plus_10_rounds()
+    {
+        var target = MakeTarget(con: 3, siz: 8); // major wound level 3, as above
+        var weapon = MakeWeapon("1D6", applyDamageBonus: false);
+        var outcome = new AttackDefenseOutcome(
+            LandedGrade.Normal, ArmorTreatment.Subtracted, ParryWeaponDamage: null,
+            DefenderRollsOnFumbleTable: false, AttackerRollsOnFumbleTable: false, SourceText: "test");
+        var entropy = new FixedEntropySource(5, 7); // rolled damage 5 >= 3, then duration D10 face 7
+
+        var knockout = DamageResolver.ResolveKnockoutAttack(outcome, weapon, null, armorValue: 0, target, Ruleset, entropy);
+
+        Assert.True(knockout.KnockedOut);
+        Assert.Equal(1, knockout.DamageDealt);
+        Assert.Equal(17, knockout.DurationRounds); // 7 + 10
+    }
+
+    [Fact]
+    public void Knockout_attack_that_misses_deals_no_damage_and_does_not_knock_out()
+    {
+        var target = MakeTarget(con: 12, siz: 12);
+        var weapon = MakeWeapon("1D6", applyDamageBonus: false);
+        var outcome = new AttackDefenseOutcome(
+            LandedGrade.Miss, ArmorTreatment.NotApplicable, ParryWeaponDamage: null,
+            DefenderRollsOnFumbleTable: false, AttackerRollsOnFumbleTable: false, SourceText: "test");
+        var entropy = new FixedEntropySource();
+
+        var knockout = DamageResolver.ResolveKnockoutAttack(outcome, weapon, null, armorValue: 0, target, Ruleset, entropy);
+
+        Assert.False(knockout.KnockedOut);
+        Assert.Equal(0, knockout.DamageDealt);
+    }
+
+    [Fact]
+    public void Critical_knockout_attack_ignores_armor_for_the_underlying_roll_per_the_special_or_critical_effects_still_applying()
+    {
+        // Ch 7, p.174: "The effects of special or critical successes (such as extra damage or
+        // bypassing armor) apply in all cases" to a knockout attempt.
+        var target = MakeTarget(con: 3, siz: 8); // major wound level 3
+        var weapon = MakeWeapon("1D6", applyDamageBonus: false); // critical max = 6
+        var outcome = new AttackDefenseOutcome(
+            LandedGrade.Critical, ArmorTreatment.Bypassed, ParryWeaponDamage: null,
+            DefenderRollsOnFumbleTable: false, AttackerRollsOnFumbleTable: false, SourceText: "test");
+        var entropy = new FixedEntropySource(9); // duration roll only -- critical needs no weapon-dice draw
+
+        var knockout = DamageResolver.ResolveKnockoutAttack(outcome, weapon, null, armorValue: 1000, target, Ruleset, entropy);
+
+        Assert.Equal(6, knockout.UnderlyingRoll.DamageDealt); // armor (1000) ignored, matches a plain critical
+        Assert.True(knockout.KnockedOut); // 6 >= major wound level 3
+        Assert.Equal(1, knockout.DamageDealt);
+        Assert.Equal(19, knockout.DurationRounds); // 9 + 10
+    }
+
+    [Fact]
+    public void ApplyKnockoutAttack_applies_the_resolved_damage_and_records_a_wound()
+    {
+        var target = MakeTarget(con: 3, siz: 8);
+        var wounds = new WoundTrack();
+        var weapon = MakeWeapon("1D6", applyDamageBonus: false);
+        var outcome = new AttackDefenseOutcome(
+            LandedGrade.Normal, ArmorTreatment.Subtracted, ParryWeaponDamage: null,
+            DefenderRollsOnFumbleTable: false, AttackerRollsOnFumbleTable: false, SourceText: "test");
+        var entropy = new FixedEntropySource(5, 7);
+        var knockout = DamageResolver.ResolveKnockoutAttack(outcome, weapon, null, armorValue: 0, target, Ruleset, entropy);
+        var before = target.CurrentHitPoints;
+
+        var result = DamageResolver.ApplyKnockoutAttack(target, wounds, knockout, Ruleset, "Knockout blow.");
+
+        Assert.Equal(1, result.DamageDealt);
+        Assert.Equal(before - 1, target.CurrentHitPoints);
+        Assert.Single(wounds.Wounds);
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/FixedEntropySource.cs
+++ b/tests/Brp.Rules.Tests/Combat/FixedEntropySource.cs
@@ -1,0 +1,40 @@
+using Brp.Core.Randomness;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// A test double that serves a pre-scripted sequence of die faces instead of generating them,
+/// so a damage roll's exact outcome can be pinned. Mirrors
+/// <c>Brp.Core.Tests.Dice.FixedEntropySource</c>.
+/// </summary>
+internal sealed class FixedEntropySource : IEntropySource
+{
+    private readonly Queue<int> _values;
+
+    public FixedEntropySource(params int[] values) => _values = new Queue<int>(values);
+
+    public long DrawCount { get; private set; }
+
+    public int NextDie(int sides)
+    {
+        if (_values.Count == 0)
+        {
+            throw new InvalidOperationException("FixedEntropySource has no more scripted values.");
+        }
+
+        DrawCount++;
+        var value = _values.Dequeue();
+        if (value < 1 || value > sides)
+        {
+            throw new InvalidOperationException($"Scripted value {value} is out of range for a d{sides}.");
+        }
+
+        return value;
+    }
+
+    public int NextD100() => NextDie(100);
+
+    public EntropyState Capture() => new(0, 0, 0, 0, DrawCount);
+
+    public void Restore(EntropyState state) => DrawCount = state.DrawCount;
+}


### PR DESCRIPTION
Implements Layer 4 piece **D** — damage. Closes #52. A landed blow now hurts: the numeric half of combat the whole stack was building toward.

## What this delivers (`Brp.Rules.Combat.DamageResolver`)

- **Damage by landed grade** (from piece C's `AttackDefenseOutcome`):
  - **Normal** — weapon dice + db − armor.
  - **Special — weapon-type-dependent** (the crux, see below): **impaling** doubles the weapon's whole damage expression (1D6+1 → 2D6+2), db added once; **crushing** rolls normal dice + doubled db (or +1D4 if none, negative-db → 0); bleeding/entangling/knockback = normal base + a deferred effect.
  - **Critical** — weapon maximum + db, armor ignored (`Bypassed`/`DoesNotApply` collapsed).
- **HP application** — reduces HP (negative tracked), records the blow as a wound (Layer 3 container).
- **Conditions** — unconscious (≤2 HP), dead (0 HP resolved at end of the following round, modeled as a pending flag + predicate seam), and the full **knockout-attack** rule (Ch 7 p.174): minor-wound → weapon minimum, no KO; major-wound (≥½ total HP) → 1 damage + KO for 1D10+10 rounds.
- New `specialDamageType` on every weapon (15 impaling, 3 crushing), cited to the book. All thresholds/durations are `Brp.Data`; `Brp.Rules` no engine dependency.

## Verification — the full gate, and it earned it

This piece exposed a real defect that the layered team caught in stages:
- The plan's special formula (`weaponMax + normalRoll + db`) was **wrong** (overcounts); the first build's correction (`special = normal`) was **also wrong** (undercounts — a special hit dealt identical damage to a normal hit for **all 18 shipped weapons**).
- **`rules-conformance` (opus)** and **Codex (GPT, cross-vendor)** independently converged on the actual rule — special damage is **weapon-type-dependent** — and the fix was re-confirmed closed by **both**.
- **`scope-warden`** — clean; only damage *magnitude* implemented, all five special *effects* (bleed/stun/entangle/lodge/knockback) deferred with the type carried forward for a future effect layer.

**Tests:** 1972 passed, 0 failed (impaling/crushing worked examples pinned; a special now deals more than a normal hit for every weapon). `-warnaserror` and `dotnet format --verify-no-changes` clean. ADR: `docs/decisions/0017-damage.md`.

## Seams left for later pieces

First Aid / Major-Wound effect (piece E), the injury/environmental spot rules (falling/poison/disease), hit-location rolling, the special-effect mechanics, and the round-loop that resolves end-of-following-round death — all documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
