### PR TITLE
Add Dependabot config: weekly grouped NuGet + Actions updates (#57)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Dependabot version updates for NoiRPG.
+# Weekly and grouped so updates arrive as one PR per ecosystem rather than
+# one per package. These PRs flow through the same CI gates as any other change.
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      nuget:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Linked Issue

Closes #57

## Exact behavioral claim

NuGet and GitHub Actions dependencies are now tracked by Dependabot on a weekly, grouped schedule. This prevents silent dependency drift and the security/compatibility debt that accrues when nothing watches for updates — without the PR spam that per-package updates cause.

## Scope

Adds `.github/dependabot.yml` only. No source, build, or CI behavior changes. Grouping (`patterns: ["*"]` per ecosystem) means at most one PR per ecosystem per weekly run.

## Rules conformance

N/A — infrastructure/tooling, no rules-engine code.

## Tests and evidence

- `.github/dependabot.yml` is valid Dependabot v2 syntax (version 2; `nuget` + `github-actions` ecosystems; weekly; grouped).
- No code paths touched; CI (`build-and-test`) exercises the unchanged build/test/format on this branch.
- First Dependabot run will confirm end-to-end once merged (Dependabot reads the config from the default branch).

## Decisions and tradeoffs

- **Grouped, weekly** rather than per-package/daily: keeps noise low for a solo-maintained repo. `open-pull-requests-limit: 5` is a backstop.
- Both `nuget` and `github-actions` at repo root (`/`).

## Known limitations

Dependabot only activates once this config is on the default branch. Security updates (as opposed to version updates) are a separate GitHub setting not configured here.

## Agent provenance

Implemented by Claude (Opus 4.8) under the orchestration epic (#53). Tooling route → CI + scope-warden per #54's routing table; scope-warden not yet automated (that is #62).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
