### PR TITLE
Add machine-readable risk/route metadata schema (#54)

### DIFF
--- a/.github/route-map
+++ b/.github/route-map
@@ -1,0 +1,38 @@
+# NoiRPG route map — maps a changed path to a coarse verification route.
+#
+# Format:  <glob>  <route>        (one rule per line; "#" starts a comment)
+# Routes:  docs | tooling | rules | formulas | architecture
+# Matching: CODEOWNERS-style — LAST matching rule wins for a given file.
+# Globs:   *  matches within one path segment; **  matches across segments;
+#          **/ matches zero or more leading directories.
+#
+# This is the SIMPLE, deterministic baseline. A separate CONTENT escalation
+# (in tools/route.sh) promotes a `rules` change to `formulas` when the diff
+# actually touches numeric tables / thresholds. See docs/orchestration/routing.md
+# for the route -> required-gates table and the escalation patterns.
+
+# Catch-all: anything unmatched routes to tooling (CI + scope-warden).
+*                          tooling
+
+# Documentation
+**/*.md                    docs
+docs/**                    docs
+LICENSE                    docs
+
+# Tooling / infrastructure
+.github/**                 tooling
+tools/**                   tooling
+*.sln                      tooling
+global.json                tooling
+
+# Rules engine (ordinary implementation)
+src/Brp.Core/**            rules
+src/Brp.Rules/**           rules
+
+# Formula / threshold data — ruleset JSON is printed numeric tables
+src/Brp.Data/**            formulas
+
+# Architecture — project boundaries and references (last, so they win for these
+# files even under src/**). Adds architecture-review on top of normal gates.
+Directory.Build.props      architecture
+**/*.csproj                architecture

--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -1,0 +1,78 @@
+# Verification routing
+
+Every change acquires a **route** from what it touches, and the route determines
+the **required gate set** — the reviewers that must pass before it can merge. This
+is the machine-readable form of the pipeline in
+[`docs/agent-team.md`](../agent-team.md): the orchestrator no longer remembers
+which reviewers a change needs; it asks [`tools/route.sh`](../../tools/route.sh).
+
+This is the source of truth consumed by the routing state machine (issue #62).
+
+## How a route is derived
+
+1. **Path baseline (simple, deterministic).** [`.github/route-map`](../../.github/route-map)
+   maps each changed path to a coarse route, CODEOWNERS-style — the *last* matching
+   rule wins for a given file. Across all changed files, the highest-precedence
+   route is taken (`docs` < `tooling` < `rules` < `formulas`), and any file that
+   maps to `architecture` adds an architecture review on top.
+2. **Content escalation (precise, where it matters).** A `rules` change is promoted
+   to `formulas` when the diff actually touches numeric tables or thresholds — so the
+   expensive independent cross-check fires when a *value* could be wrong, not merely
+   because a rules file was edited.
+
+## Routes and required gates
+
+| Route | What triggers it | Required gates |
+|---|---|---|
+| `docs` | `*.md`, `docs/**` | `ci`, `scope-warden` |
+| `tooling` | `.github/**`, `tools/**`, `*.sln`, `global.json`, anything unmatched | `ci`, `scope-warden` |
+| `rules` | `src/Brp.Core/**`, `src/Brp.Rules/**` (ordinary implementation) | `ci`, `scope-warden`, `rules-conformance` |
+| `formulas` | `src/Brp.Data/**` ruleset JSON, **or** a `rules` change whose diff touches numeric tables/thresholds | `ci`, `scope-warden`, `rules-conformance`, `codex-conformance` |
+| `architecture` | `**/*.csproj`, `Directory.Build.props` (project boundaries/refs) | *(above, per the other files)* **+** `architecture-review` |
+
+`formulas` is a strict superset of `rules`. `architecture` composes with whatever
+else applies — it adds `architecture-review` (dispatched to the `design-critic`
+agent) without removing the normal gates. Escalation only ever *raises* the gate
+set, never lowers it.
+
+## Content-escalation patterns
+
+A changed line (added or removed) in a `rules`/`formulas` file promotes the change
+to `formulas` when it matches any of these table/threshold shapes. Keeping the set
+explicit keeps the decision deterministic:
+
+| Shape | Matches | Example |
+|---|---|---|
+| switch-arm / lambda to a number | `=> -?N` | `Grade.Special => 2` |
+| JSON / property numeric value | `: -?N` | `"baseRange": 30` |
+| numeric array / indexer | `[ -?N` | `[ 1, 3, 6 ]` |
+| threshold comparison | `>= <= > <` followed by `-?N` | `roll <= skill / 5` |
+| number in a list | `, -?N` | `Steps(1, 2, 4, 8)` |
+
+The match is intentionally line-level and slightly over-inclusive: a false escalation
+costs one extra (independent) verification pass; a false *de*-escalation would let a
+wrong printed value merge unchecked. When in doubt, escalate.
+
+## Usage
+
+```bash
+# Classify the current working-tree change
+tools/route.sh
+
+# Classify a change relative to a base ref (e.g. a PR)
+tools/route.sh --base origin/main
+
+# Classify specific paths
+tools/route.sh src/Brp.Data/damage-ruleset.json
+
+# Machine-readable, for the orchestrator / state machine
+tools/route.sh --json --base origin/main
+```
+
+`--json` emits `{ "route", "architecture", "escalated", "gates": [...], "files": [...] }`.
+
+## Labels
+
+The derived route is surfaced on issues/PRs as a `route:*` label
+(`route:docs`, `route:tooling`, `route:rules`, `route:formulas`,
+`route:architecture`) so the route is visible without running the tool.

--- a/tools/route.sh
+++ b/tools/route.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# tools/route.sh — derive the verification route and required gates for a change.
+#
+# The single source of truth for "which reviewers does this change need" so the
+# orchestrator (and #62's state machine) never has to remember it. Reads
+# .github/route-map for the coarse path baseline, then applies a content
+# escalation that promotes a `rules` change to `formulas` when the diff actually
+# touches numeric tables / thresholds.
+#
+# Usage:
+#   tools/route.sh [--base <ref>] [--json] [file ...]
+#
+# File selection (first that applies):
+#   explicit [file ...]   classify exactly those paths
+#   --base <ref>          git diff --name-only <ref>...HEAD
+#   (neither)             git diff --name-only HEAD   (working tree + staged)
+#
+# Output (text): the route and the ordered required gate set.
+# Output (--json): {"route","architecture","escalated","gates":[...],"files":[...]}
+#
+# See docs/orchestration/routing.md for the route -> gates table.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAP="$ROOT/.github/route-map"
+[ -f "$MAP" ] || { echo "route-map not found: $MAP" >&2; exit 2; }
+
+JSON=0
+BASE=""
+FILES=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json) JSON=1; shift ;;
+    --base) BASE="${2:-}"; shift 2 ;;
+    --)     shift; while [ $# -gt 0 ]; do FILES+=("$1"); shift; done ;;
+    -*)     echo "unknown option: $1" >&2; exit 2 ;;
+    *)      FILES+=("$1"); shift ;;
+  esac
+done
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  if [ -n "$BASE" ]; then
+    mapfile -t FILES < <(git -C "$ROOT" diff --name-only "$BASE"...HEAD)
+  else
+    mapfile -t FILES < <(git -C "$ROOT" diff --name-only HEAD)
+  fi
+fi
+
+# Convert a glob to an anchored ERE. '*' stays within a segment; '**' crosses
+# segments; '**/' matches zero or more leading directories; other metacharacters
+# are escaped literally.
+glob_to_regex() {
+  local g="$1"
+  local i c out="" n
+  n=${#g}
+  if [ "$g" = "*" ]; then printf '^.*$'; return; fi
+  for ((i = 0; i < n; i++)); do
+    c=${g:i:1}
+    if [ "$c" = "*" ]; then
+      if [ "${g:i+1:1}" = "*" ]; then
+        if [ "${g:i+2:1}" = "/" ]; then out+='(.*/)?'; i=$((i + 2));
+        else out+='.*'; i=$((i + 1)); fi
+      else
+        out+='[^/]*'
+      fi
+    else
+      case "$c" in
+        [a-zA-Z0-9_/-]) out+="$c" ;;
+        *) out+="\\$c" ;;
+      esac
+    fi
+  done
+  printf '^%s$' "$out"
+}
+
+# Last matching route-map rule wins for a file.
+route_for_file() {
+  local f="$1" raw pat rt re matched=""
+  while IFS= read -r raw || [ -n "$raw" ]; do
+    raw="${raw%%#*}"
+    read -r pat rt <<< "$raw" || true
+    [ -z "${pat:-}" ] && continue
+    [ -z "${rt:-}" ] && continue
+    re="$(glob_to_regex "$pat")"
+    [[ "$f" =~ $re ]] && matched="$rt"
+  done < "$MAP"
+  printf '%s' "$matched"
+}
+
+prec() { case "$1" in docs) echo 1 ;; tooling) echo 2 ;; rules) echo 3 ;; formulas) echo 4 ;; *) echo 0 ;; esac; }
+
+base="tooling"; basep=0; arch=0
+for f in "${FILES[@]}"; do
+  [ -z "$f" ] && continue
+  r="$(route_for_file "$f")"; [ -z "$r" ] && r="tooling"
+  if [ "$r" = "architecture" ]; then arch=1; continue; fi
+  p="$(prec "$r")"
+  if [ "$p" -gt "$basep" ]; then basep="$p"; base="$r"; fi
+done
+
+# Content escalation: a `rules` change that touches numeric tables / thresholds
+# becomes `formulas`. A changed line counts if it adds/removes a value in a
+# table/threshold shape — see docs/orchestration/routing.md for the exact set.
+escalated=0
+if [ "$base" = "rules" ]; then
+  rf=()
+  for f in "${FILES[@]}"; do
+    [ -z "$f" ] && continue
+    r="$(route_for_file "$f")"
+    { [ "$r" = "rules" ] || [ "$r" = "formulas" ]; } && rf+=("$f")
+  done
+  if [ ${#rf[@]} -gt 0 ]; then
+    if [ -n "$BASE" ]; then
+      d="$(git -C "$ROOT" diff --unified=0 "$BASE"...HEAD -- "${rf[@]}" 2>/dev/null || true)"
+    else
+      d="$(git -C "$ROOT" diff --unified=0 HEAD -- "${rf[@]}" 2>/dev/null || true)"
+    fi
+    if printf '%s' "$d" | grep -Eq '^[+-][^+-].*(=>[[:space:]]*-?[0-9]|:[[:space:]]*-?[0-9]+|\[[[:space:]]*-?[0-9]|(>=|<=|>|<)[[:space:]]*-?[0-9]|,[[:space:]]*-?[0-9]+)'; then
+      base="formulas"; escalated=1
+    fi
+  fi
+fi
+
+case "$base" in
+  docs | tooling) gates="ci scope-warden" ;;
+  rules)          gates="ci scope-warden rules-conformance" ;;
+  formulas)       gates="ci scope-warden rules-conformance codex-conformance" ;;
+esac
+[ "$arch" = 1 ] && gates="$gates architecture-review"
+
+if [ "$JSON" = 1 ]; then
+  gj=""; for x in $gates; do gj+="\"$x\","; done; gj="${gj%,}"
+  fj=""; for x in "${FILES[@]}"; do [ -z "$x" ] && continue; fj+="\"$x\","; done; fj="${fj%,}"
+  printf '{"route":"%s","architecture":%s,"escalated":%s,"gates":[%s],"files":[%s]}\n' \
+    "$base" "$([ "$arch" = 1 ] && echo true || echo false)" \
+    "$([ "$escalated" = 1 ] && echo true || echo false)" "$gj" "$fj"
+else
+  suffix=""; [ "$arch" = 1 ] && suffix=" (+architecture)"; [ "$escalated" = 1 ] && suffix="$suffix (content-escalated)"
+  echo "route: ${base}${suffix}"
+  echo "gates: ${gates// /, }"
+fi


### PR DESCRIPTION
## Linked Issue

Closes #54

## Exact behavioral claim

There is now one machine-readable source of truth for **which verification gates a change requires**. Given a set of changed paths (or a base ref), `tools/route.sh` deterministically prints the route and the ordered required gate set. This prevents the orchestrator from having to remember the routing rules per-change — the failure mode where a formula change silently skips its independent cross-check.

## Scope

Adds three files and five labels. No source, build, or CI behavior changes; nothing in `src/**` is touched.

- `.github/route-map` — CODEOWNERS-style `path -> route`, last match wins.
- `tools/route.sh` — route + gate derivation (path baseline + content escalation), `--base` and `--json`.
- `docs/orchestration/routing.md` — the route -> gates table and escalation patterns (source of truth for #62).
- `route:{docs,tooling,rules,formulas,architecture}` labels.

Deliberately unchanged: no gate is *run* here (that is #62), and no CI wiring is added.

## Rules conformance

N/A — orchestration tooling, no rules-engine mechanics. (Its own route is `tooling`.)

## Tests and evidence

Ran `tools/route.sh` against real repo paths:

| Input | route | gates |
|---|---|---|
| `docs/agent-team.md` | docs | ci, scope-warden |
| `src/Brp.Rules/Combat/DamageRoll.cs` | rules | + rules-conformance |
| `src/Brp.Data/damage-ruleset.json` | formulas | + codex-conformance |
| `src/Brp.Rules/Brp.Rules.csproj` | tooling (+architecture) | + architecture-review |
| `README.md .github/workflows/ci.yml` | tooling | ci, scope-warden |

Content escalation verified with a throwaway edit (then reverted, working tree clean):
- prose-only change to a rules `.cs` → stays `rules`.
- numeric-threshold line (`value >= 3`) in the same file → escalates to `formulas (content-escalated)`.

`--json` output confirmed: `{"route":"formulas","architecture":true,"escalated":false,"gates":[...],"files":[...]}`.

## Decisions and tradeoffs

- **Hybrid routing** (path baseline + content escalation), per the locked decision on #54: simple and deterministic by default, precise where formula correctness is at stake.
- **Escalation is intentionally over-inclusive** — a false escalation costs one extra independent pass; a false de-escalation would let a wrong printed value merge unchecked. Patterns are documented so the rule stays deterministic.
- **`architecture` composes** rather than replacing: `**/*.csproj` / `Directory.Build.props` add `architecture-review` (→ `design-critic`) on top of normal gates.
- Pure Bash, no new dependency; not covered by the dotnet CI suite (tooling), so verification is the table above.

## Known limitations

- The escalation heuristic is line-level and matches comments/strings containing threshold-shaped numbers; it errs toward escalating. Refine patterns in `routing.md` if noise appears.
- Labels are defined but not auto-applied to PRs yet — that wiring is part of #62.

## Agent provenance

Implemented by Claude (Opus 4.8) under orchestration epic #53. Self-route: `tooling` → ci + scope-warden; scope-warden not yet automated (#62).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
