### PR TITLE
Add gate-poster GitHub App scaffold (#65)

### DIFF
--- a/.github/github-app-manifest.json
+++ b/.github/github-app-manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "NoiRPG Gate Poster",
+  "url": "https://github.com/brandonifco/NoiRPG",
+  "hook_attributes": {
+    "active": false
+  },
+  "public": false,
+  "default_permissions": {
+    "checks": "write",
+    "contents": "read",
+    "pull_requests": "write"
+  },
+  "default_events": []
+}

--- a/docs/orchestration/github-app.md
+++ b/docs/orchestration/github-app.md
@@ -1,0 +1,77 @@
+# The gate-poster GitHub App
+
+The routing state machine (#62) blocks a PR until each required verification gate
+(`scope-warden`, `rules-conformance`, `codex-conformance`, `architecture-review`)
+has reported. Those gates run in the local/self-hosted orchestrator, not in
+Actions, so they need an identity to publish results back to GitHub as check-runs.
+That identity is a **GitHub App**, chosen over a personal token for scoped,
+revocable, clearly-attributed check-runs.
+
+[`tools/gate-check.py`](../../tools/gate-check.py) is the poster. The one thing that
+cannot be scripted from here is the App **registration** — that is a web-UI action
+on your account. Steps below (~5 minutes, once).
+
+## 1. Register the App
+
+Settings → Developer settings → **GitHub Apps** → **New GitHub App**.
+
+- **Name:** `NoiRPG Gate Poster` (any unique name)
+- **Homepage URL:** the repo URL
+- **Webhook:** uncheck **Active** (this App is polled/pushed to, it receives nothing)
+- **Repository permissions:**
+  - **Checks:** Read and write
+  - **Contents:** Read-only
+  - **Pull requests:** Read and write
+- **Where can this App be installed:** Only on this account
+
+Values mirror [`.github/github-app-manifest.json`](../../.github/github-app-manifest.json),
+which you can also feed to the App-manifest creation flow if you prefer.
+
+## 2. Generate a private key
+
+On the App's page → **Private keys** → **Generate a private key**. A `.pem`
+downloads. Store it where the orchestrator runs, outside the repo — e.g.
+`~/.config/noirpg/gate-poster.pem`, `chmod 600`. **Never commit it.**
+
+## 3. Install the App on the repo
+
+App page → **Install App** → install on `brandonifco/NoiRPG`.
+
+## 4. Wire the orchestrator's environment
+
+```bash
+export GH_APP_ID=<the App id shown on its page>
+export GH_APP_PRIVATE_KEY=~/.config/noirpg/gate-poster.pem   # path or PEM contents
+# GH_APP_INSTALLATION_ID is optional — discovered from the repo if unset.
+```
+
+## 5. Post a gate result
+
+```bash
+tools/gate-check.py \
+  --gate scope-warden --sha "$(git rev-parse HEAD)" \
+  --conclusion success --summary "No out-of-scope content; source ok."
+```
+
+`--dry-run` mints the JWT and prints the check-run payload without calling GitHub —
+use it to confirm the key and App id are wired before going live. Valid
+`--conclusion` values: `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
+`action_required`.
+
+## How it works
+
+1. Mint a short-lived RS256 JWT signed by the App private key (via `openssl`).
+2. Exchange it for an installation access token scoped to the repo.
+3. `POST /repos/{owner}/{repo}/check-runs` with `name = <gate>`, `head_sha`,
+   `conclusion`, and an output summary.
+
+The check-run name is the gate name, so #62's aggregator can find it on the PR
+head commit. Dependency-light: Python stdlib + the `openssl` binary, no pip.
+
+## Security posture
+
+- Least privilege: three repository permissions, no webhook, no org scope.
+- The private key stays on the orchestrator host; GitHub only ever sees short-lived
+  installation tokens.
+- The App cannot edit code (Contents is read-only) — it can only report checks and
+  read PRs, so it can never "fix" what a gate is judging.

--- a/tools/gate-check.py
+++ b/tools/gate-check.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""gate-check — post a verification gate result to a PR head commit as a check-run.
+
+This is the identity through which the local/self-hosted orchestrator publishes
+agent gate results (scope-warden, rules-conformance, codex-conformance,
+architecture-review) back to GitHub, using a GitHub App rather than a personal
+token. See docs/orchestration/github-app.md for registering the App.
+
+Dependency-light: Python stdlib + the `openssl` binary for RS256 signing. No pip.
+
+Usage:
+    tools/gate-check.py \
+        --gate scope-warden --sha <head-sha> \
+        --conclusion success --title "scope-warden" \
+        --summary "No out-of-scope content; source ok."
+
+Env:
+    GH_APP_ID                 GitHub App id (integer).
+    GH_APP_PRIVATE_KEY        path to the App private-key .pem (or the PEM itself).
+    GH_APP_INSTALLATION_ID    optional; discovered from the repo if unset.
+    GH_REPO                   owner/name; defaults to --repo or the git remote.
+
+--dry-run mints the JWT and prints the check-run payload without calling GitHub.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+VALID_CONCLUSIONS = {"success", "failure", "neutral", "cancelled", "timed_out", "action_required"}
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _load_key(val: str) -> bytes:
+    if "-----BEGIN" in val:
+        return val.encode()
+    return open(os.path.expanduser(val), "rb").read()
+
+
+def _sign_rs256(private_key: bytes, signing_input: bytes) -> bytes:
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".pem") as kf:
+        kf.write(private_key)
+        kf.flush()
+        proc = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-sign", kf.name],
+            input=signing_input, capture_output=True,
+        )
+    if proc.returncode != 0:
+        raise SystemExit(f"openssl signing failed: {proc.stderr.decode().strip()}")
+    return proc.stdout
+
+
+def jwt_for_app(app_id: str, private_key: bytes) -> str:
+    now = int(time.time())
+    header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload = _b64url(json.dumps({"iat": now - 30, "exp": now + 540, "iss": str(app_id)}).encode())
+    signing_input = f"{header}.{payload}".encode()
+    sig = _b64url(_sign_rs256(private_key, signing_input))
+    return f"{header}.{payload}.{sig}"
+
+
+def api(method: str, path: str, token: str, token_type: str = "Bearer", body: dict | None = None) -> dict:
+    url = path if path.startswith("http") else API + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"{token_type} {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "noirpg-gate-check")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"{method} {url} -> {e.code}: {e.read().decode()[:300]}")
+
+
+def default_repo() -> str | None:
+    for env in ("GH_REPO", "GITHUB_REPOSITORY"):
+        if os.environ.get(env):
+            return os.environ[env]
+    try:
+        url = subprocess.check_output(["git", "remote", "get-url", "origin"], text=True).strip()
+        tail = url.split("github.com")[-1].lstrip(":/").removesuffix(".git")
+        return tail or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gate", required=True, help="gate name, e.g. scope-warden")
+    ap.add_argument("--sha", required=True, help="PR head commit sha")
+    ap.add_argument("--conclusion", required=True, choices=sorted(VALID_CONCLUSIONS))
+    ap.add_argument("--title", default=None)
+    ap.add_argument("--summary", default="")
+    ap.add_argument("--details-url", default=None)
+    ap.add_argument("--repo", default=None)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    repo = args.repo or default_repo()
+    if not repo:
+        return _fail("cannot determine repo (set GH_REPO or --repo)")
+
+    payload = {
+        "name": args.gate,
+        "head_sha": args.sha,
+        "status": "completed",
+        "conclusion": args.conclusion,
+        "output": {"title": args.title or args.gate, "summary": args.summary or f"{args.gate}: {args.conclusion}"},
+    }
+    if args.details_url:
+        payload["details_url"] = args.details_url
+
+    app_id = os.environ.get("GH_APP_ID")
+    key_val = os.environ.get("GH_APP_PRIVATE_KEY")
+    if not (app_id and key_val):
+        if args.dry_run:
+            print("[dry-run] no App creds; would POST check-run:")
+            print(json.dumps(payload, indent=2))
+            return 0
+        return _fail("GH_APP_ID and GH_APP_PRIVATE_KEY must be set")
+
+    jwt = jwt_for_app(app_id, _load_key(key_val))
+    if args.dry_run:
+        print(f"[dry-run] minted JWT (len={len(jwt)}); would POST check-run to {repo}:")
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    inst = os.environ.get("GH_APP_INSTALLATION_ID")
+    if not inst:
+        inst = str(api("GET", f"/repos/{repo}/installation", jwt)["id"])
+    tok = api("POST", f"/app/installations/{inst}/access_tokens", jwt)["token"]
+    res = api("POST", f"/repos/{repo}/check-runs", tok, token_type="token", body=payload)
+    print(f"posted check-run '{args.gate}' = {args.conclusion} on {args.sha[:10]} (id {res.get('id')})")
+    return 0
+
+
+def _fail(msg: str) -> int:
+    print(f"gate-check: {msg}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Linked Issue

Closes #65

## Exact behavioral claim

The orchestrator can now publish a verification gate result to a PR head commit as a GitHub check-run, authenticating as a scoped GitHub App rather than a personal token. This gives #62 a way to record `scope-warden` / `rules-conformance` / `codex-conformance` / `architecture-review` outcomes that GitHub can gate a merge on, with clear provenance and no code-write access.

## Scope

Adds the poster and its scaffolding; does **not** register the App (a web-UI action on the account — documented for you to do once). Files: `tools/gate-check.py`, `.github/github-app-manifest.json`, `docs/orchestration/github-app.md`. No source/build/rules changes.

## Rules conformance

N/A — orchestration tooling, no rules-engine mechanics.

## Tests and evidence

- `python3 -c "import ast; ast.parse(...)"` on `gate-check.py` → syntax ok; manifest is valid JSON.
- `tools/gate-check.py --gate scope-warden --sha abc123 --conclusion success --dry-run` (no creds) → prints the check-run payload, exit 0.
- Generated a throwaway 2048-bit RSA key, minted a JWT via `jwt_for_app`, and **verified the RS256 signature with `openssl dgst -verify`** → `Verified OK`; header `{alg:RS256,typ:JWT}`, `iss` correct, 9-minute expiry.
- Live posting is gated on the App registration (manual step in `docs/orchestration/github-app.md`); it is intentionally not exercised in CI.

## Decisions and tradeoffs

- **App over PAT** (locked on #65): scoped (checks:write, contents:read, pull_requests:write), revocable, its own identity on checks. Contents is read-only so the poster can never edit what a gate is judging.
- **Dependency-light**: Python stdlib + the `openssl` binary for RS256, no pip — matches the repo's no-extra-dependency posture.
- Installation id is auto-discovered from the repo when `GH_APP_INSTALLATION_ID` is unset.

## Known limitations

- The App must be registered, key generated, and installed by you before live posting works — see `docs/orchestration/github-app.md`. Until then #62's aggregator will show gates as pending.
- No webhook receiver here; the App only posts.

## Agent provenance

Implemented by Claude (Opus 4.8) under orchestration epic #53. Route: `tooling` → ci + scope-warden.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
