### PR TITLE
Add routing state machine: route-gates + gates-satisfied (#62)

### DIFF
--- a/.github/workflows/route-gates.yml
+++ b/.github/workflows/route-gates.yml
@@ -1,0 +1,35 @@
+name: route-gates
+
+# The routing state machine (phase 1: evidence verification). Derives the route,
+# labels the PR, and upserts a single `gates-satisfied` check-run that is green
+# only when every required non-CI gate has a passing check-run on the head commit.
+# Individual gate results are posted by the orchestrator via the gate-poster App
+# (#65); this job aggregates them.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  check_run:
+    types: [completed, rerequested]
+
+concurrency:
+  group: route-gates-${{ github.event.pull_request.number || github.event.check_run.head_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  route-gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive route and update gates-satisfied
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 .github/workflows/route_gates.py

--- a/.github/workflows/route_gates.py
+++ b/.github/workflows/route_gates.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""route-gates — the routing state machine (phase 1: evidence verification).
+
+On a PR (and whenever a check-run lands), derive the verification route via
+tools/route.sh, label the PR with it, and upsert a single `gates-satisfied`
+check-run that is green only when every required non-CI gate has a passing
+check-run on the PR head commit. The individual gate results are posted by the
+orchestrator through the App (#65); this job only aggregates them.
+
+Runs in Actions with the default GITHUB_TOKEN (checks: write, pull-requests:
+write). Pure-stdlib. The evaluate/route helpers are unit-tested offline.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+API = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+GATE_CHECK_NAME = "gates-satisfied"
+
+
+def api(method: str, path: str, token: str, body: dict | None = None) -> dict:
+    url = path if path.startswith("http") else f"{API}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "noirpg-route-gates")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        print(f"::warning::{method} {url} -> {e.code}: {e.read().decode()[:200]}")
+        raise
+
+
+def latest_by_name(check_runs: list[dict]) -> dict[str, dict]:
+    """Keep the most recent check-run per name."""
+    out: dict[str, dict] = {}
+    for r in check_runs:
+        prev = out.get(r["name"])
+        if prev is None or (r.get("started_at") or "") >= (prev.get("started_at") or ""):
+            out[r["name"]] = r
+    return out
+
+
+def evaluate(required_gates: list[str], latest: dict[str, dict]) -> tuple[str | None, str, list[str]]:
+    """Return (conclusion|None, title, outstanding/failed detail lines).
+
+    conclusion None means still in progress. 'ci' is excluded — build-and-test is
+    a separately-required status check.
+    """
+    gate_names = [g for g in required_gates if g != "ci"]
+    outstanding, failed = [], []
+    for g in gate_names:
+        r = latest.get(g)
+        if r is None or r.get("status") != "completed":
+            outstanding.append(g)
+        elif r.get("conclusion") not in ("success", "neutral"):
+            failed.append(g)
+    if failed:
+        return "failure", f"{len(failed)} gate(s) failed", [f"Failed: {', '.join(failed)}"]
+    if outstanding:
+        return None, f"Waiting on {len(outstanding)} gate(s)", [f"Pending: {', '.join(outstanding)}"]
+    return "success", "All required gates satisfied", []
+
+
+def run_route(base: str) -> dict:
+    out = subprocess.check_output(["bash", "tools/route.sh", "--base", base, "--json"], text=True)
+    return json.loads(out.strip().splitlines()[-1])
+
+
+def main() -> int:
+    token = os.environ["GITHUB_TOKEN"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    ev = json.loads(open(os.environ["GITHUB_EVENT_PATH"]).read())
+
+    # Never react to our own check-run (avoids an event loop).
+    if event_name == "check_run" and ev.get("check_run", {}).get("name") == GATE_CHECK_NAME:
+        print("own check_run event; skipping")
+        return 0
+
+    # Resolve the PR + head/base shas.
+    if event_name == "pull_request":
+        pr = ev["pull_request"]
+        pr_number, head_sha, base_sha = pr["number"], pr["head"]["sha"], pr["base"]["sha"]
+    elif event_name == "check_run":
+        head_sha = ev["check_run"]["head_sha"]
+        prs = ev["check_run"].get("pull_requests") or []
+        if prs:
+            pr_number = prs[0]["number"]
+        else:
+            assoc = api("GET", f"/repos/{repo}/commits/{head_sha}/pulls", token)
+            if not assoc:
+                print("no PR associated with commit; skipping")
+                return 0
+            pr_number = assoc[0]["number"]
+        pr = api("GET", f"/repos/{repo}/pulls/{pr_number}", token)
+        base_sha, head_sha = pr["base"]["sha"], pr["head"]["sha"]
+    else:
+        print(f"unsupported event {event_name}; skipping")
+        return 0
+
+    # Fetch both endpoints and classify.
+    subprocess.run(["git", "fetch", "--no-tags", "origin", base_sha, head_sha], check=False)
+    subprocess.run(["git", "checkout", "-q", head_sha], check=False)
+    route = run_route(base_sha)
+    gates = route.get("gates", [])
+
+    # Apply the route:<x> label; remove any other route:* labels.
+    want = f"route:{route.get('route')}"
+    cur = api("GET", f"/repos/{repo}/issues/{pr_number}/labels", token)
+    have = {l["name"] for l in cur}
+    for name in have:
+        if name.startswith("route:") and name != want:
+            try:
+                api("DELETE", f"/repos/{repo}/issues/{pr_number}/labels/{name}", token)
+            except urllib.error.HTTPError:
+                pass
+    if route.get("route") and want not in have:
+        try:
+            api("POST", f"/repos/{repo}/issues/{pr_number}/labels", token, {"labels": [want]})
+        except urllib.error.HTTPError:
+            pass
+
+    # Evaluate posted gate check-runs on the head commit.
+    runs = api("GET", f"/repos/{repo}/commits/{head_sha}/check-runs?per_page=100", token)
+    latest = latest_by_name(runs.get("check_runs", []))
+    conclusion, title, detail = evaluate(gates, latest)
+
+    summary = [
+        f"Route: `{route.get('route')}`" + (" (content-escalated)" if route.get("escalated") else ""),
+        f"Required gates: {', '.join('`' + g + '`' for g in gates) or '—'}",
+        *detail,
+        "",
+        "_Individual gate results are posted by the orchestrator via the gate-poster App (#65)._",
+    ]
+    body = {
+        "name": GATE_CHECK_NAME,
+        "head_sha": head_sha,
+        "output": {"title": title, "summary": "\n".join(summary)},
+    }
+    if conclusion:
+        body["status"], body["conclusion"] = "completed", conclusion
+    else:
+        body["status"] = "in_progress"
+
+    existing = latest.get(GATE_CHECK_NAME)
+    if existing:
+        api("PATCH", f"/repos/{repo}/check-runs/{existing['id']}", token, body)
+    else:
+        api("POST", f"/repos/{repo}/check-runs", token, body)
+
+    print(f"{GATE_CHECK_NAME}: {conclusion or 'in_progress'} — {title} (route={route.get('route')})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -75,4 +75,32 @@ tools/route.sh --json --base origin/main
 
 The derived route is surfaced on issues/PRs as a `route:*` label
 (`route:docs`, `route:tooling`, `route:rules`, `route:formulas`,
-`route:architecture`) so the route is visible without running the tool.
+`route:architecture`) so the route is visible without running the tool. The
+`route-gates` workflow applies the label automatically on each PR.
+
+## Enforcement — the `gates-satisfied` check
+
+The `route-gates` workflow (`.github/workflows/route-gates.py`) is the routing
+state machine. On every PR event — and whenever a check-run lands — it:
+
+1. derives the route and labels the PR;
+2. reads the check-runs on the PR **head commit**;
+3. upserts a single `gates-satisfied` check-run that is:
+   - **success** when every required non-`ci` gate has a passing check-run,
+   - **failure** when any required gate failed,
+   - **in progress** while any required gate has not reported.
+
+`ci` maps to `build-and-test`, which is already a required status check, so it is
+evaluated separately. The individual gate check-runs (`scope-warden`,
+`rules-conformance`, `codex-conformance`, `architecture-review`) are posted by the
+orchestrator through the gate-poster App — see
+[`github-app.md`](github-app.md).
+
+### Making it block merges (phase-2 switch)
+
+`gates-satisfied` is **reported but not yet a required check**, so it cannot
+deadlock a PR before the App is posting gate results. Once the App is registered
+and the orchestrator posts at least one real gate result end-to-end, add
+`gates-satisfied` to the `main` ruleset's required status checks (alongside
+`build-and-test`). From then on a PR cannot merge until its route's gates are green.
+


### PR DESCRIPTION
## Linked Issue

Closes #62

## Exact behavioral claim

A PR now automatically acquires its verification route and a single aggregate gate check. On every PR event (and whenever a check-run lands), `route-gates` derives the route via `tools/route.sh`, applies the `route:<x>` label, and upserts a `gates-satisfied` check-run that is green only when every required non-`ci` gate has a passing check-run on the head commit — failure if any failed, in progress while any is unreported. The orchestrator no longer has to remember which reviewers a change needs; GitHub derives and tracks it.

## Scope

Adds `.github/workflows/route-gates.yml` + `route_gates.py`, and documents the enforcement model in `docs/orchestration/routing.md`. Phase 1 = evidence verification: this job *aggregates* gate results; it does not run the agents. `gates-satisfied` is reported but **not** added to the required-checks set (avoids a merge deadlock before the App posts results); the one-line ruleset switch to make it blocking is documented.

## Rules conformance

N/A — orchestration tooling, no rules-engine mechanics.

## Tests and evidence

- `ast.parse` on `route_gates.py` → ok; `yaml.safe_load` on `route-gates.yml` → valid.
- Offline unit tests of the pure logic (`evaluate`, `latest_by_name`):
  - `latest_by_name` keeps the most recent run per name.
  - tooling (gates ci+scope-warden), none posted → `in_progress` / "Waiting on 1".
  - scope-warden success → `success` / "All required gates satisfied".
  - formulas (4 gates), partial → `in_progress` / "Pending: codex-conformance".
  - formulas, one failed → `failure` / "Failed: rules-conformance".
  - formulas, all green → `success`.
  - architecture gate included → `in_progress` when unposted.
- End-to-end on this PR: the `route-gates` job runs, applies `route:tooling`, and creates `gates-satisfied` (in progress — `scope-warden` not posted yet, expected). See the checks on this PR.

## Decisions and tradeoffs

- **Python + default GITHUB_TOKEN** (not inline github-script JS) so the logic is syntax-checkable and unit-testable without a node runtime; the token has `checks: write` / `pull-requests: write`.
- **Reported, not required, in phase 1** — turning it into a blocking check waits until #65's App posts a real gate result end-to-end, so no PR can be deadlocked in the meantime.
- **Loop-safe**: the job ignores its own `gates-satisfied` check_run events.
- `ci` (`build-and-test`) is evaluated separately since it is already a required status check.

## Known limitations

- Not yet enforcing merges (see the phase-2 switch in `routing.md`).
- With the strict up-to-date rule, PRs may need a branch update before merge (no merge queue on this plan).
- `check_run`-triggered runs use the workflow version on `main`, so cross-PR aggregation is live only after this merges.

## Agent provenance

Implemented by Claude (Opus 4.8) under orchestration epic #53. Route: `tooling` → ci + scope-warden. Depends on #54 (route helper), #58 (evidence), #65 (gate-poster App).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
