### PR TITLE
Add orchestration-policy instant CI gate (#55)

### DIFF
--- a/.github/authoritative-source.sha256
+++ b/.github/authoritative-source.sha256
@@ -1,0 +1,1 @@
+d38af1fc2c27326b0ee8e42af0579684220ccf30809b195275d9daf29cedbb28  BasicRoleplaying-ORC-Content-Document.pdf

--- a/.github/workflows/orchestration-policy.yml
+++ b/.github/workflows/orchestration-policy.yml
@@ -1,0 +1,25 @@
+name: orchestration-policy
+
+# The instant-policy tier (#61): fast, mechanical guardrails from AGENTS.md with
+# no build or restore. Complements build-and-test (BannedApiAnalyzers, tests) and
+# scope-warden. Runs in parallel with CI on every PR.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: orchestration-policy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  orchestration-policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run policy checks
+        run: bash tools/orchestration-policy.sh

--- a/tools/orchestration-policy.sh
+++ b/tools/orchestration-policy.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# tools/orchestration-policy.sh — the mechanical guardrails from AGENTS.md as an
+# instant CI gate. Fast (no build, no restore). It enforces the invariants that
+# are cheaply and deterministically checkable, and it *guards the guardrails* the
+# build already has, so nobody can silently remove them.
+#
+# Deliberately NOT duplicated here (already enforced elsewhere):
+#   - randomness/ambient-clock bans   -> build -warnaserror + BannedApiAnalyzers
+#     (this script instead checks that wiring is still present).
+#   - determinism / table completeness -> the dotnet test suite (build-and-test).
+#   - scope filter, rules-as-data judgment -> scope-warden / rules-conformance.
+#     (AGENTS.md #7 is a judgment call; a naive magic-number grep would be noise.)
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+fail=0
+ok()      { printf '  ok   %s\n' "$1"; }
+bad()     { printf 'FAIL   %s\n' "$1"; fail=1; }
+section() { printf '\n== %s ==\n' "$1"; }
+
+# 1. Authoritative source pinned (AGENTS.md: the ORC document is the rules).
+section "authoritative source hash"
+PIN=.github/authoritative-source.sha256
+if [ ! -f "$PIN" ]; then
+  bad "missing $PIN"
+elif sha256sum -c --status "$PIN" 2>/dev/null; then
+  ok "ORC Content Document matches pinned SHA-256"
+else
+  bad "AUTHORITATIVE SOURCE CHANGED — the pinned ORC document hash does not match"
+  echo "    expected: $(cut -d' ' -f1 "$PIN")"
+  echo "    actual:   $(sha256sum BasicRoleplaying-ORC-Content-Document.pdf 2>/dev/null | cut -d' ' -f1 || echo '<file missing>')"
+fi
+
+# 2. Superseded source never committed (AGENTS.md #1: BRP SRD 1.0.2 is not our source).
+section "forbidden source"
+srd="$(git ls-files | grep -iE 'brp.?srd|srd.?1[._]?0[._]?2' || true)"
+if [ -n "$srd" ]; then bad "superseded SRD is tracked in git: $srd"; else ok "no superseded SRD file tracked"; fi
+if grep -qi 'SRD 1.0.2' .gitignore 2>/dev/null; then ok ".gitignore still excludes the SRD"; else bad ".gitignore no longer excludes 'BRP SRD 1.0.2.pdf'"; fi
+
+# 3. Seeded-randomness / no-ambient-clock guardrail intact (AGENTS.md #5).
+section "seeded-randomness guardrail (BannedApiAnalyzers)"
+BS=src/Brp.Core/BannedSymbols.txt
+if [ ! -f "$BS" ]; then
+  bad "missing $BS"
+else
+  miss=""
+  for sym in 'System.Random' 'System.DateTime.Now' 'System.DateTime.UtcNow' 'System.DateTimeOffset.Now' 'System.DateTimeOffset.UtcNow'; do
+    grep -q "$sym" "$BS" || miss="$miss $sym"
+  done
+  if [ -z "$miss" ]; then ok "BannedSymbols.txt bans Random + ambient clock"; else bad "BannedSymbols.txt no longer bans:$miss"; fi
+fi
+for proj in src/Brp.Core/Brp.Core.csproj src/Brp.Rules/Brp.Rules.csproj; do
+  if grep -q 'BannedApiAnalyzers' "$proj" && grep -q 'BannedSymbols.txt' "$proj"; then
+    ok "$(basename "$proj") wires the analyzer + banned list"
+  else
+    bad "$(basename "$proj") no longer references BannedApiAnalyzers + BannedSymbols.txt"
+  fi
+done
+
+# 4. No game-engine dependency in Brp.Core / Brp.Rules (AGENTS.md #6).
+section "no game-engine dependency in Brp.Core / Brp.Rules"
+engine='Godot|UnityEngine|Unity\.|MonoGame|Microsoft\.Xna'
+refs="$(grep -rInE "Include=\"[^\"]*($engine)" src/Brp.Core src/Brp.Rules --include='*.csproj' 2>/dev/null || true)"
+usings="$(grep -rInE "^using +(Godot|UnityEngine|MonoGame|Microsoft\.Xna)" src/Brp.Core src/Brp.Rules --include='*.cs' 2>/dev/null || true)"
+if [ -z "$refs$usings" ]; then
+  ok "no Unity/Godot/MonoGame references"
+else
+  bad "game-engine reference found in Core/Rules:"
+  printf '%s\n' "$refs" "$usings" | sed '/^$/d;s/^/       /'
+fi
+
+section "result"
+if [ "$fail" = 0 ]; then echo "orchestration-policy: PASS"; else echo "orchestration-policy: FAIL"; fi
+exit "$fail"


### PR DESCRIPTION
## Linked Issue

Closes #55

## Exact behavioral claim

The mechanically-checkable AGENTS.md invariants are now an executable CI gate (`orchestration-policy`) that runs in seconds with no build. It fails the moment someone changes the authoritative ORC document, commits the superseded SRD, removes the seeded-randomness guardrail, or adds a game-engine dependency to `Brp.Core`/`Brp.Rules` — converting "the agent must remember X" into "the repository rejects ¬X".

## Scope

Adds `tools/orchestration-policy.sh`, `.github/workflows/orchestration-policy.yml`, and `.github/authoritative-source.sha256` (the pinned ORC hash). No source/build/rules changes.

Deliberately **not** re-implemented here (already enforced, and re-checking would only add noise or false positives):
- randomness/ambient-clock bans → `build -warnaserror` + BannedApiAnalyzers (`BannedSymbols.txt`); this gate instead verifies that wiring is still present.
- determinism / table completeness → the dotnet test suite (`build-and-test`).
- scope filter and rules-as-data judgment (AGENTS.md #3, #7) → scope-warden / rules-conformance; a magic-number grep would be noise.

## Rules conformance

N/A — orchestration tooling, no rules-engine mechanics.

## Tests and evidence

- `bash tools/orchestration-policy.sh` on clean `main` → all checks `ok`, `PASS`, exit 0.
- Each check verified to **fail** on its violation, then the tree restored to PASS:
  - corrupt the pinned hash → `AUTHORITATIVE SOURCE CHANGED` (exit 1).
  - remove the SRD line from `.gitignore` → `.gitignore no longer excludes 'BRP SRD 1.0.2.pdf'`.
  - drop `System.Random` from `BannedSymbols.txt` → `no longer bans: System.Random`.
  - inject a `GodotSharp` PackageReference into `Brp.Core.csproj` → `game-engine reference found`.
- `sha256sum -c .github/authoritative-source.sha256` verifies against the real PDF.
- `yaml.safe_load` on the workflow → valid.

## Decisions and tradeoffs

- **Guard the guardrails**, don't duplicate them: for the randomness/time invariant the build already fails via BannedApiAnalyzers, so the fragile-to-grep part is checked by asserting `BannedSymbols.txt` + the analyzer references still exist.
- **Pin format** is `sha256sum -c`-compatible so the check is a one-liner and the expected/actual are easy to print on failure.
- **Separate fast workflow** (not a job in `ci.yml`) so it is the instant-policy tier for #61 and runs in parallel with the build.
- Left AGENTS.md #7 (rules-as-data) to human/agent review rather than a noisy heuristic.

## Known limitations

- Not yet added to the `main` required-checks set — I'll add `orchestration-policy` to the ruleset after it runs green on `main` (safe: the checks are self-contained and deterministic, unlike `gates-satisfied`).
- `__pycache__` from local Python runs is intentionally not committed.

## Agent provenance

Implemented by Claude (Opus 4.8) under orchestration epic #53. Route: `tooling` → ci + scope-warden.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
