### PR TITLE
Add native dependency graph + scheduler + Project setup (#60)

### DIFF
--- a/docs/orchestration/dependency-graph.md
+++ b/docs/orchestration/dependency-graph.md
@@ -1,0 +1,83 @@
+# Dependency graph and the NoiRPG Project
+
+Issue dependencies are a **native GitHub graph**, not prose. The orchestrator can
+therefore ask a deterministic scheduling question — *which open issues have no
+unresolved blockers?* — and those are the only candidates it may start. This is what
+makes several agents actual parallel engineering instead of conflicting workers: the
+scheduler picks independent leaves of the graph.
+
+## The graph
+
+Each issue's blockers are recorded as native **`blocked_by`** dependencies, and the
+epic's children as native **sub-issues**. For epic #53:
+
+```
+#54 route metadata ──┬── #58 pr-policy ──┐
+                     ├── #59 agent-brief │
+                     ├── #60 dep DAG ─────┼── #63 metrics
+                     └──────────┐         │
+#56 protect main ──────────────┼── #62 state machine ──┐
+#65 gate App ──────────────────┘                       ├── #73 auto-post gates
+#55 policy CI ── #61 CI tiering        #62, #65 ────────┘
+#57 dependabot (no deps)
+```
+
+## The scheduler query
+
+```bash
+tools/ready-issues.sh            # classify every open issue READY / blocked
+tools/ready-issues.sh --ready    # just the ready issue numbers, one per line
+```
+
+An issue is **READY** when none of its `blocked_by` dependencies are still open. The
+orchestrator can feed `--ready` straight into work selection; `BLOCKED` is derived
+from the graph, never a manual judgment.
+
+Editing the graph (ids are the REST database id, not the issue number):
+
+```bash
+# add a blocker: <n> is blocked by <m>
+gh api --method POST repos/{owner}/{repo}/issues/<n>/dependencies/blocked_by \
+  -F issue_id="$(gh api repos/{owner}/{repo}/issues/<m> --jq .id)"
+
+# make <n> a sub-issue of epic <e>
+gh api --method POST repos/{owner}/{repo}/issues/<e>/sub_issues \
+  -F sub_issue_id="$(gh api repos/{owner}/{repo}/issues/<n> --jq .id)"
+```
+
+## The NoiRPG Project
+
+A GitHub Project (v2) gives the graph a board with orchestration fields. Creating it
+needs the **`project` write scope**, which the orchestrator's token does not carry
+(read-only), so it is a one-time operator step:
+
+```bash
+gh auth refresh -s project
+tools/setup-project.sh
+```
+
+`setup-project.sh` creates the project (idempotently) with these fields:
+
+| Field | Type | Values |
+|---|---|---|
+| Stage | single-select | Backlog · Specified · Ready · Implementing · PR/Verifying · Merged |
+| Layer | single-select | L0–L4 · Orchestration |
+| Subsystem | text | — |
+| Risk | single-select | low · medium · high |
+| Verification Route | single-select | docs · tooling · rules · formulas · architecture (mirrors `tools/route.sh`) |
+| Agent Role | single-select | engine-dev · case-author · scope-warden · rules-conformance · design-critic · rules-extractor · codex |
+| Source-Conformance Required | single-select | yes · no |
+
+and adds the epic plus its children.
+
+### Automations (enable once, in the Project UI → Workflows)
+
+Built-in Project automations finish the loop without code:
+
+- **Auto-add to project** — repo issues/PRs labelled `orchestration`.
+- **Item closed** → Stage = Merged.
+- **Item reopened** → Stage = Implementing.
+- **Pull request merged** → Stage = Merged.
+
+`Backlog → Specified → Ready → Implementing → PR/Verifying → Merged` then tracks work
+without manual bookkeeping, and `BLOCKED` comes from the native dependency state above.

--- a/tools/ready-issues.sh
+++ b/tools/ready-issues.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# tools/ready-issues.sh — the scheduler query: which open issues have no unresolved
+# blockers (the "ready leaves"). This is the deterministic question the orchestrator
+# asks to pick the next work, now that dependencies are a native GitHub graph rather
+# than prose.
+#
+#   tools/ready-issues.sh           classify every open issue as READY or blocked
+#   tools/ready-issues.sh --ready   print only the ready issue numbers (one per line)
+#
+# An issue is READY when none of its native `blocked_by` dependencies are still open.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+ready_only=0
+[ "${1:-}" = "--ready" ] && ready_only=1
+
+mapfile -t open < <(gh issue list --state open --limit 200 --json number --jq '.[].number' | sort -n)
+
+for n in "${open[@]}"; do
+  open_blockers="$(gh api "repos/{owner}/{repo}/issues/$n/dependencies/blocked_by" \
+    --jq '[.[] | select(.state=="open") | .number] | join(" ")' 2>/dev/null || true)"
+  if [ -z "$open_blockers" ]; then
+    if [ "$ready_only" = 1 ]; then
+      echo "$n"
+    else
+      title="$(gh issue view "$n" --json title --jq .title)"
+      printf 'READY    #%-4s %s\n' "$n" "$title"
+    fi
+  elif [ "$ready_only" = 0 ]; then
+    printf 'blocked  #%-4s waiting on: %s\n' "$n" "$open_blockers"
+  fi
+done

--- a/tools/setup-project.sh
+++ b/tools/setup-project.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# tools/setup-project.sh — create the NoiRPG GitHub Project (v2) with the
+# orchestration fields and add the epic's issues.
+#
+# Requires the 'project' WRITE scope, which the default token does not have:
+#     gh auth refresh -s project
+# (The orchestrator's token has read:project only, so it cannot run this — that is
+# why this is a script you run once, not an API call the tooling makes.)
+#
+# Idempotent: re-running reuses the project and skips fields/items that exist.
+set -euo pipefail
+OWNER=brandonifco
+TITLE="NoiRPG"
+
+num="$(gh project list --owner "$OWNER" --format json \
+  --jq ".projects[] | select(.title==\"$TITLE\") | .number" | head -1)"
+if [ -z "$num" ]; then
+  num="$(gh project create --owner "$OWNER" --title "$TITLE" --format json --jq .number)"
+  echo "created project #$num"
+else
+  echo "reusing existing project #$num"
+fi
+
+mkfield() { # name  datatype  [comma,options]
+  local name="$1" dt="$2" opts="${3:-}"
+  if gh project field-list "$num" --owner "$OWNER" --format json --jq '.fields[].name' | grep -qx "$name"; then
+    echo "  field exists: $name"; return
+  fi
+  if [ -n "$opts" ]; then
+    gh project field-create "$num" --owner "$OWNER" --name "$name" --data-type "$dt" --single-select-options "$opts" >/dev/null
+  else
+    gh project field-create "$num" --owner "$OWNER" --name "$name" --data-type "$dt" >/dev/null
+  fi
+  echo "  + field: $name"
+}
+
+# Workflow states from #60; Status is GitHub's built-in, so we add "Stage" to avoid
+# fighting it. Verification Route mirrors tools/route.sh; Agent Role mirrors the roster.
+mkfield "Stage"                       SINGLE_SELECT "Backlog,Specified,Ready,Implementing,PR/Verifying,Merged"
+mkfield "Layer"                       SINGLE_SELECT "L0,L1,L2,L3,L4,Orchestration"
+mkfield "Subsystem"                   TEXT
+mkfield "Risk"                        SINGLE_SELECT "low,medium,high"
+mkfield "Verification Route"          SINGLE_SELECT "docs,tooling,rules,formulas,architecture"
+mkfield "Agent Role"                  SINGLE_SELECT "engine-dev,case-author,scope-warden,rules-conformance,design-critic,rules-extractor,codex"
+mkfield "Source-Conformance Required" SINGLE_SELECT "yes,no"
+
+echo "adding items:"
+for n in 53 54 55 56 57 58 59 60 61 62 63 65 73; do
+  if gh project item-add "$num" --owner "$OWNER" --url "https://github.com/$OWNER/NoiRPG/issues/$n" >/dev/null 2>&1; then
+    echo "  + #$n"
+  else
+    echo "  #$n (already present)"
+  fi
+done
+
+echo
+echo "Project: https://github.com/users/$OWNER/projects/$num"
+echo
+echo "Finish in the UI (Project -> ... -> Workflows), enabling the built-in automations:"
+echo "  - Auto-add to project: repo items with label 'orchestration'."
+echo "  - Item closed        -> set Stage = Merged."
+echo "  - Item reopened      -> set Stage = Implementing."
+echo "  - Pull request merged -> set Stage = Merged."


### PR DESCRIPTION
## Linked Issue

Closes #60

## Exact behavioral claim

Issue dependencies are now a native GitHub graph, not prose, and the orchestrator can ask a deterministic scheduling question — which open issues have no unresolved blockers — and get the ready leaves. This is what lets several agents work in parallel without conflicting: the scheduler picks independent leaves instead of a human reading "Relationship to other work" sections.

## Scope

Encodes the epic #53 DAG natively (via the REST sub_issues + dependencies APIs — done, not in this diff), and adds three files: `tools/ready-issues.sh`, `tools/setup-project.sh`, `docs/orchestration/dependency-graph.md`. No source/build/rules changes. The GitHub Project itself is created by the operator script (needs a scope the orchestrator token lacks).

## Rules conformance

N/A — orchestration tooling, no rules-engine mechanics.

## Tests and evidence

- **DAG encoded and verified**: all 12 children are native sub-issues of #53; every `blocked_by` edge set (#58←#54; #59←#54; #60←#54; #61←#55; #62←#54,#56,#58,#65; #63←#58,#60; #73←#62,#65). Verified by read-back, e.g. `gh api repos/{owner}/{repo}/issues/73/dependencies/blocked_by` → #62, #65 (both closed).
- **Scheduler runs live**: `tools/ready-issues.sh` classified every open issue; `--ready` returned `50 53 55 59 60 73` — correctly surfacing #73 as ready (its blockers #62/#65 are closed) and #61/#63 as blocked (waiting on #55/#60). It even surfaced backlog #50 as ready.
- `bash -n` clean on both scripts.
- `setup-project.sh` is syntax-checked but not executed here — it needs `gh auth refresh -s project` (the orchestrator token is `read:project` only), so it is an operator step by design.

## Decisions and tradeoffs

- **Native graph over prose**: `blocked_by` dependencies + sub-issues, so `BLOCKED` is derived, never a manual judgment.
- **Project creation is a script, not tooling-internal**, because Projects v2 writes need the `project` scope the automation token deliberately does not hold. `setup-project.sh` is idempotent and documents the exact fields + UI automations.
- **"Stage" single-select** carries the `Backlog→…→Merged` workflow rather than fighting GitHub's built-in Status.
- `ready-issues.sh` makes one dependency API call per open issue (fine at this scale); a GraphQL batch is a later optimization.

## Known limitations

- The Project board and its built-in automations must be created/enabled by the operator (`tools/setup-project.sh` + a few UI toggles) — documented in `dependency-graph.md`.
- Per-issue API calls in the scheduler are O(open issues); not a concern at current volume.

## Agent provenance

Implemented by Claude (Opus 4.8) under orchestration epic #53. Route: `tooling` → ci + scope-warden.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
