### PR TITLE
Add gate auto-dispatcher: run + post per-PR gates (#73)

### DIFF
--- a/docs/orchestration/auto-dispatch.md
+++ b/docs/orchestration/auto-dispatch.md
@@ -1,0 +1,52 @@
+# Auto-dispatching verification gates
+
+`tools/dispatch-gates.sh <pr>` is the piece that turns the routing state machine
+from advisory into enforcing: for a PR it derives the route's required gates, runs
+each gate's agent, and posts the result as a check-run via the gate-poster App —
+so [`gates-satisfied`](routing.md) reflects real per-PR verification with no human
+in the loop.
+
+```bash
+tools/dispatch-gates.sh 76
+DRY_RUN=1 tools/dispatch-gates.sh 76      # print what would run; post nothing
+```
+
+## What it does
+
+1. Resolves the PR head/base and derives the route via `tools/route.sh`.
+2. Assembles the review packet once (via [`agent-brief`](agent-brief.md); falls back
+   to a minimal title+route+diff packet if agent-brief is absent).
+3. Runs each required non-`ci` gate, **cheap-first**, stopping on the first FAIL
+   (the same cheap-before-expensive principle as the model routing):
+
+   | Gate | Runner | Model |
+   |---|---|---|
+   | `scope-warden` | `claude -p` | Haiku |
+   | `rules-conformance` | `claude -p` | Opus |
+   | `codex-conformance` | `tools/codex-agent.sh conformance` | Codex (cross-vendor) |
+   | `architecture-review` | `claude -p` | Opus (design-critic lens) |
+
+4. Parses the agent's trailing `VERDICT: PASS|FAIL` and posts a check-run named
+   after the gate via `tools/gate-check.py` (success / failure / neutral).
+
+## Requirements for a live run
+
+- **App env** for posting: `GH_APP_ID`, `GH_APP_PRIVATE_KEY` (see [github-app.md](github-app.md)).
+- **Authenticated runners on the host**: the `claude` CLI logged in, and `codex-agent.sh`
+  configured (`CODEX_BIN`). These run where the orchestrator runs, not in Actions.
+- `DRY_RUN=1` needs none of the above — it prints the plan and posts nothing.
+
+## Closing the loop (phase-2 enforcement)
+
+Once this dispatcher posts gate results reliably on every PR, make `gates-satisfied`
+a **required** status check on `main` (it is currently reported-only) so a PR cannot
+merge until its route's gates are green:
+
+```bash
+# add gates-satisfied alongside build-and-test in the main ruleset
+gh api repos/{owner}/{repo}/rulesets/21893600 --jq '.rules[] | select(.type=="required_status_checks")'
+# then PUT the ruleset with {"context":"gates-satisfied"} added to required_status_checks
+```
+
+At that point the loop is fully closed: Issue ready → PR → route → gates dispatched →
+posted → aggregated → auto-merge, with the human only setting product intent.

--- a/tools/dispatch-gates.sh
+++ b/tools/dispatch-gates.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# tools/dispatch-gates.sh <pr-number>
+#
+# The auto-dispatcher (#73): for a PR, derive the route's required verification
+# gates, run each one's agent briefed with the #59 review packet, and post the
+# result as a check-run via the gate-poster App (#65) — so the #62 aggregator's
+# `gates-satisfied` reflects real per-PR verification with no human in the loop.
+#
+# Gates run cheap-first (scope-warden -> rules-conformance -> codex-conformance ->
+# architecture-review); a FAIL stops the run before the more expensive gates, the
+# same cheap-before-expensive principle the model routing uses.
+#
+#   tools/dispatch-gates.sh 76
+#   DRY_RUN=1 tools/dispatch-gates.sh 76     # print what would run; post nothing
+#
+# Live runs need the App env (GH_APP_ID, GH_APP_PRIVATE_KEY) for posting, and the
+# agent runners on PATH (`claude`; `codex-agent.sh` for the Codex gate).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+PR="${1:?usage: dispatch-gates.sh <pr-number>}"
+DRY="${DRY_RUN:-0}"
+
+HEAD="$(gh pr view "$PR" --json headRefOid --jq .headRefOid)"
+BASE_BRANCH="$(gh pr view "$PR" --json baseRefName --jq .baseRefName)"
+git fetch --no-tags -q origin "refs/pull/$PR/head" "$BASE_BRANCH" 2>/dev/null || true
+BASE="$(git merge-base "origin/$BASE_BRANCH" "$HEAD" 2>/dev/null || echo "origin/$BASE_BRANCH")"
+
+ROUTE_JSON="$(tools/route.sh --base "$BASE" --json)"
+GATES="$(printf '%s' "$ROUTE_JSON" | python3 -c "import sys,json; print(' '.join(json.load(sys.stdin).get('gates',[])))")"
+echo "PR #$PR  head ${HEAD:0:10}  route $(printf '%s' "$ROUTE_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("route"))')  gates: $GATES"
+
+# Review packet — assembled once, shared as context by every gate. Prefer the
+# rich packet from agent-brief (#59); fall back to a minimal one if it is absent.
+if [ -x tools/agent-brief.py ]; then
+  PACKET="$(tools/agent-brief.py review "$PR")"
+else
+  PACKET="$(printf '# REVIEW — PR #%s\nRoute: %s\n\n## DIFF (git diff -U1)\n```diff\n%s\n```\n' \
+    "$PR" "$(printf '%s' "$ROUTE_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("route"))')" \
+    "$(git diff -U1 "$BASE"...HEAD)")"
+fi
+
+# Gate lenses (kept in sync with tools/agent-brief.py GATE_REVIEW).
+lens_for() {
+  case "$1" in
+    scope-warden) echo "Check the diff against orc-scope-filter.md and docs/source-handling.md: no out-of-scope content, correct source, modern-era baselines, seeded randomness." ;;
+    rules-conformance) echo "Verify every implemented value against the printed table in the cited ORC section. Assume wrong until each row proves out." ;;
+    codex-conformance) echo "Independently RE-DERIVE each formula/threshold from the source text; do not reuse the implementer's reasoning." ;;
+    architecture-review) echo "Review the new subsystem boundary and project references: layering holds, Brp.Core/Brp.Rules take no game-engine dependency." ;;
+  esac
+}
+
+prompt_for() {
+  printf '%s\n\n## YOUR GATE: %s\n%s\n\nEnd your reply with exactly one line `VERDICT: PASS` or `VERDICT: FAIL`, then a one-line summary.\n' \
+    "$PACKET" "$1" "$(lens_for "$1")"
+}
+
+run_claude() { # model prompt
+  if [ "$DRY" = 1 ]; then echo "[dry] claude -p --model $1 <briefed gate prompt>"; return 0; fi
+  claude -p --model "$1" "$2" 2>/dev/null || true
+}
+
+run_gate() { # gate
+  local gate="$1" out verdict summary conclusion
+  echo; echo "== gate: $gate =="
+  local prompt; prompt="$(prompt_for "$gate")"
+  case "$gate" in
+    scope-warden)        out="$(run_claude claude-haiku-4-5-20251001 "$prompt")" ;;
+    rules-conformance)   out="$(run_claude claude-opus-4-8 "$prompt")" ;;
+    architecture-review) out="$(run_claude claude-opus-4-8 "$prompt")" ;;
+    codex-conformance)
+      if [ "$DRY" = 1 ]; then echo "[dry] BASE=$BASE tools/codex-agent.sh conformance <briefed gate prompt>"; out=""; else
+        out="$(BASE="$BASE" tools/codex-agent.sh conformance "$prompt" 2>/dev/null || true)"; fi ;;
+    *) echo "unknown gate: $gate" >&2; return 0 ;;
+  esac
+  [ "$DRY" = 1 ] && return 0
+
+  verdict="$(printf '%s' "$out" | grep -ioE 'VERDICT:[[:space:]]*(PASS|FAIL)' | tail -1 | grep -ioE 'PASS|FAIL' | tr 'A-Z' 'a-z')"
+  summary="$(printf '%s' "$out" | grep -iA1 'VERDICT:' | tail -1 | cut -c1-280)"
+  [ -z "$summary" ] && summary="$gate: see agent output"
+  case "$verdict" in
+    pass) conclusion=success ;;
+    fail) conclusion=failure ;;
+    *)    conclusion=neutral; summary="no explicit verdict parsed; $summary" ;;
+  esac
+  echo "verdict: ${verdict:-none} -> $conclusion"
+  tools/gate-check.py --gate "$gate" --sha "$HEAD" --conclusion "$conclusion" --summary "$summary"
+  [ "$conclusion" = failure ] && return 1 || return 0
+}
+
+# Cheap-first order; only run gates the route actually requires; stop on first FAIL.
+for gate in scope-warden rules-conformance codex-conformance architecture-review; do
+  case " $GATES " in *" $gate "*) ;; *) continue ;; esac
+  if ! run_gate "$gate"; then
+    echo; echo "STOP: $gate failed — skipping the remaining (more expensive) gates."
+    exit 1
+  fi
+done
+echo; echo "all required gates dispatched for PR #$PR"


### PR DESCRIPTION
## Linked Issue

Closes #73

## Exact behavioral claim

There is now a dispatcher that runs a PR's required verification gates and posts each result as a check-run, so `gates-satisfied` reflects real per-PR verification with no human running gates by hand. This is the missing link between the App (which can post) and enforcement (making `gates-satisfied` required): the thing that actually runs `scope-warden`/`rules-conformance`/`codex-conformance`/`architecture-review` per PR and posts them.

## Scope

Adds `tools/dispatch-gates.sh` and `docs/orchestration/auto-dispatch.md`. No source/build/rules changes. Reuses `route.sh` (#54), `agent-brief` (#59), `codex-agent.sh`, and `gate-check.py` (#65).

## Rules conformance

N/A — orchestration tooling, no rules-engine mechanics.

## Tests and evidence

- `bash -n tools/dispatch-gates.sh` → clean.
- **Route/gate derivation + cheap-first order** (DRY_RUN):
  - `DRY_RUN=1 tools/dispatch-gates.sh 76` → route `tooling`, gates `scope-warden` only.
  - `DRY_RUN=1 tools/dispatch-gates.sh 64` → route `formulas`, gates in order `scope-warden → rules-conformance → codex-conformance → architecture-review`; codex wired to `BASE=… tools/codex-agent.sh conformance`.
- **Verdict parsing** verified on canned outputs: `VERDICT: PASS` → success (summary = next line), `VERDICT: FAIL` → failure, no verdict → neutral.
- **Fallback packet**: with `agent-brief` absent (not yet on main), the dispatcher builds a minimal title+route+diff packet instead of failing.
- **Runner mechanism**: the Claude gates use `claude -p --model …`; a live run needs the `claude` CLI logged in on the orchestrator host (in this sandbox it reports "Not logged in", as expected — runners authenticate where the orchestrator runs, not in Actions). Posting is already proven end-to-end (App → `gates-satisfied` flips green).

## Decisions and tradeoffs

- **Cheap-first with early stop**: a `scope-warden` FAIL stops the run before the expensive gates — the same principle as the model routing; the failed gate + a still-pending `gates-satisfied` make the block visible.
- **Two runners**: Claude gates via `claude -p` (per-gate model from the roster), the independent gate via the existing `codex-agent.sh` (different-vendor verification).
- **Graceful degradation** when `agent-brief` (#59) isn't present yet, so this isn't hard-blocked on merge ordering.
- **DRY_RUN** mirrors `codex-agent.sh` — validate the plan with no agent cost and no posting.

## Known limitations

- Live agent runs require the `claude` and Codex runners authenticated on the orchestrator host, plus the App env (`GH_APP_ID`/`GH_APP_PRIVATE_KEY`) for posting — documented.
- The rich review packet needs #59 merged; until then the fallback packet is used.
- Verdict parsing relies on the agent ending with `VERDICT: PASS|FAIL`; an unparseable reply posts `neutral` (does not silently pass).
- Making `gates-satisfied` a required check (full enforcement) is the documented phase-2 switch, to be flipped once this posts reliably.

## Agent provenance

Implemented by Claude (Opus 4.8) under orchestration epic #53. Route: `tooling` → ci + scope-warden. Depends on #62, #65 (merged); uses #59.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
