### PR TITLE
setup-project: use built-in Status field, not custom Stage (#60 follow-up)

### DIFF
--- a/docs/orchestration/dependency-graph.md
+++ b/docs/orchestration/dependency-graph.md
@@ -58,9 +58,12 @@ tools/setup-project.sh
 
 `setup-project.sh` creates the project (idempotently) with these fields:
 
+Workflow state uses GitHub's **built-in `Status`** field (Todo · In Progress · Done),
+because the default project workflows maintain it automatically — a custom field
+would not be touched by them. `setup-project.sh` adds these extra fields:
+
 | Field | Type | Values |
 |---|---|---|
-| Stage | single-select | Backlog · Specified · Ready · Implementing · PR/Verifying · Merged |
 | Layer | single-select | L0–L4 · Orchestration |
 | Subsystem | text | — |
 | Risk | single-select | low · medium · high |
@@ -68,16 +71,16 @@ tools/setup-project.sh
 | Agent Role | single-select | engine-dev · case-author · scope-warden · rules-conformance · design-critic · rules-extractor · codex |
 | Source-Conformance Required | single-select | yes · no |
 
-and adds the epic plus its children.
+then adds the epic plus its children and sets `Status = Done` on the already-closed
+ones (the close-event workflow does not fire retroactively).
 
-### Automations (enable once, in the Project UI → Workflows)
+### Automations
 
-Built-in Project automations finish the loop without code:
+The default Project workflows are **already enabled** and act on `Status`, so the
+loop is maintained without code: **item closed → Done**, **pull request merged →
+Done**, **item added → Todo**, and **sub-issues auto-added** to the board.
 
-- **Auto-add to project** — repo issues/PRs labelled `orchestration`.
-- **Item closed** → Stage = Merged.
-- **Item reopened** → Stage = Implementing.
-- **Pull request merged** → Stage = Merged.
-
-`Backlog → Specified → Ready → Implementing → PR/Verifying → Merged` then tracks work
-without manual bookkeeping, and `BLOCKED` comes from the native dependency state above.
+One workflow the Projects v2 API cannot configure (UI-only, and optional): **Project
+→ ⋯ → Workflows → Auto-add to project**, filtered to repo items labelled
+`orchestration` — needed only for orchestration issues that are not sub-issues of the
+epic (those already auto-add). `BLOCKED` comes from the native dependency state above.

--- a/tools/setup-project.sh
+++ b/tools/setup-project.sh
@@ -34,9 +34,11 @@ mkfield() { # name  datatype  [comma,options]
   echo "  + field: $name"
 }
 
-# Workflow states from #60; Status is GitHub's built-in, so we add "Stage" to avoid
-# fighting it. Verification Route mirrors tools/route.sh; Agent Role mirrors the roster.
-mkfield "Stage"                       SINGLE_SELECT "Backlog,Specified,Ready,Implementing,PR/Verifying,Merged"
+# Workflow state lives in GitHub's built-in Status field (Todo/In Progress/Done),
+# which the default project workflows maintain automatically (item closed / PR
+# merged -> Done). We do NOT add a custom "Stage" field — a second workflow field
+# the automations would not touch. Verification Route mirrors tools/route.sh;
+# Agent Role mirrors the roster.
 mkfield "Layer"                       SINGLE_SELECT "L0,L1,L2,L3,L4,Orchestration"
 mkfield "Subsystem"                   TEXT
 mkfield "Risk"                        SINGLE_SELECT "low,medium,high"
@@ -53,11 +55,28 @@ for n in 53 54 55 56 57 58 59 60 61 62 63 65 73; do
   fi
 done
 
+# Bootstrap Status. The default "Item closed -> Done" workflow fires on the close
+# EVENT and so does not retroactively touch items added while already closed; set
+# those to Done here. Open items keep the "Item added -> Todo" default.
+echo "setting Status for already-closed items:"
+pid="$(gh project view "$num" --owner "$OWNER" --format json --jq .id)"
+sid="$(gh project field-list "$num" --owner "$OWNER" --format json --jq '.fields[] | select(.name=="Status") | .id')"
+done_opt="$(gh project field-list "$num" --owner "$OWNER" --format json \
+  --jq '.fields[] | select(.name=="Status") | .options[] | select(.name=="Done") | .id')"
+gh project item-list "$num" --owner "$OWNER" --format json \
+  --jq '.items[] | [.id, (.content.number|tostring)] | @tsv' | while IFS=$'\t' read -r iid inum; do
+  [ -z "$inum" ] && continue
+  if [ "$(gh issue view "$inum" --json state --jq .state 2>/dev/null)" = "CLOSED" ]; then
+    gh project item-edit --id "$iid" --project-id "$pid" --field-id "$sid" --single-select-option-id "$done_opt" >/dev/null 2>&1 \
+      && echo "  #$inum -> Done"
+  fi
+done
+
 echo
 echo "Project: https://github.com/users/$OWNER/projects/$num"
 echo
-echo "Finish in the UI (Project -> ... -> Workflows), enabling the built-in automations:"
-echo "  - Auto-add to project: repo items with label 'orchestration'."
-echo "  - Item closed        -> set Stage = Merged."
-echo "  - Item reopened      -> set Stage = Implementing."
-echo "  - Pull request merged -> set Stage = Merged."
+echo "Already-enabled default workflows maintain Status going forward (item closed /"
+echo "PR merged -> Done; item added -> Todo). One optional UI-only step remains, since"
+echo "the Projects v2 API cannot configure workflows:"
+echo "  - Project -> ... -> Workflows -> 'Auto-add to project': repo items with label"
+echo "    'orchestration' (sub-issues of the epic already auto-add)."


### PR DESCRIPTION
## Linked Issue

Follow-up to #60 (Project setup). No separate issue.

## Exact behavioral claim

`tools/setup-project.sh` now configures the Project to use GitHub's built-in `Status` field for workflow state instead of a custom `Stage` field. This prevents a stale, unmaintained column: the default project workflows (item closed / PR merged → Done; item added → Todo) act on `Status`, and a custom `Stage` field they never touch would silently drift.

## Scope

Edits `tools/setup-project.sh` and `docs/orchestration/dependency-graph.md`. No source/build/rules changes.

## Rules conformance

N/A — orchestration tooling.

## Tests and evidence

- `bash -n tools/setup-project.sh` → clean.
- The live project (#1) was already migrated to `Status` by hand (Done ×11, In Progress ×1, Todo ×1) and the custom `Stage` field deleted; this change makes the script reproduce that instead of re-creating `Stage` on a future run.
- Script now bootstraps `Status = Done` for already-closed items (the close-event workflow does not fire retroactively) and prints the one UI-only step (label-based auto-add).

## Decisions and tradeoffs

- **Built-in `Status` over custom `Stage`**: the automations maintain `Status` for free; coarser (Todo/In Progress/Done) but self-maintaining, which is the point.
- Kept the other custom fields (Layer, Verification Route, Risk, Agent Role, Subsystem, Source-Conformance Required).

## Known limitations

- The label-based "Auto-add to project" workflow remains UI-only (no Projects v2 API to configure workflows); documented.

## Agent provenance

Claude (Opus 4.8), epic #53. Route: tooling → ci + scope-warden.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
