### PR TITLE
Auto-dispatch verification gates from CI

### DIFF
--- a/.github/workflows/dispatch-gates.yml
+++ b/.github/workflows/dispatch-gates.yml
@@ -37,16 +37,23 @@ jobs:
           # merge-base in dispatch-gates.sh needs full history.
           fetch-depth: 0
 
-      # Skip cleanly (no red X) until the owner has added the three secrets.
+      # Skip cleanly (no red X) until the owner has added the secrets. The claude
+      # CLI credential can be EITHER a subscription token from `claude setup-token`
+      # (CLAUDE_CODE_OAUTH_TOKEN) or a pay-as-you-go console key (ANTHROPIC_API_KEY);
+      # one of the two is enough.
       - name: Check gate-poster secrets
         id: guard
         env:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -z "$GH_APP_ID" ] || [ -z "$GH_APP_PRIVATE_KEY" ] || [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "::warning title=dispatch-gates::Secrets not configured (GH_APP_ID / GH_APP_PRIVATE_KEY / ANTHROPIC_API_KEY) — skipping gate dispatch. See docs/orchestration/auto-dispatch.md."
+          if [ -z "$GH_APP_ID" ] || [ -z "$GH_APP_PRIVATE_KEY" ]; then
+            echo "::warning title=dispatch-gates::App secrets not configured (GH_APP_ID / GH_APP_PRIVATE_KEY) — skipping gate dispatch. See docs/orchestration/auto-dispatch.md."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::warning title=dispatch-gates::No claude credential (set CLAUDE_CODE_OAUTH_TOKEN from 'claude setup-token', or ANTHROPIC_API_KEY) — skipping gate dispatch. See docs/orchestration/auto-dispatch.md."
             echo "run=false" >> "$GITHUB_OUTPUT"
           else
             echo "run=true" >> "$GITHUB_OUTPUT"
@@ -70,6 +77,9 @@ jobs:
           # The gate-poster App identity used by tools/gate-check.py.
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          # Auth for the `claude -p` gate agents.
+          # Auth for the `claude -p` gate agents. The CLI uses whichever is set;
+          # CLAUDE_CODE_OAUTH_TOKEN (a Pro/Max subscription token from
+          # `claude setup-token`) is preferred over a console ANTHROPIC_API_KEY.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: tools/dispatch-gates.sh "${{ github.event.pull_request.number }}"

--- a/.github/workflows/dispatch-gates.yml
+++ b/.github/workflows/dispatch-gates.yml
@@ -1,0 +1,75 @@
+name: dispatch-gates
+
+# Runs the routing state machine's verification gates for a PR and posts each
+# result as a check-run through the gate-poster App, so `gates-satisfied`
+# (aggregated by route-gates) reflects real per-PR verification instead of
+# hanging in_progress forever.
+#
+# The original design ran these agents in a separate self-hosted orchestrator,
+# not in Actions (docs/orchestration/auto-dispatch.md). This workflow is the
+# owner's decision to run them in CI instead, so the loop closes without a
+# standing orchestrator host. The gate-poster App remains the publishing
+# identity — check-runs are posted with its short-lived installation token
+# (via tools/gate-check.py), never with this workflow's GITHUB_TOKEN.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+# Do not cancel a run mid-dispatch: a cancelled run could leave a gate posted
+# while a sibling gate never posts. Let each dispatch finish.
+concurrency:
+  group: dispatch-gates-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+# This workflow needs only to read the repo and the PR; it does NOT post checks
+# itself. gate-check.py mints an App installation token for that.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dispatch-gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # merge-base in dispatch-gates.sh needs full history.
+          fetch-depth: 0
+
+      # Skip cleanly (no red X) until the owner has added the three secrets.
+      - name: Check gate-poster secrets
+        id: guard
+        env:
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$GH_APP_ID" ] || [ -z "$GH_APP_PRIVATE_KEY" ] || [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::warning title=dispatch-gates::Secrets not configured (GH_APP_ID / GH_APP_PRIVATE_KEY / ANTHROPIC_API_KEY) — skipping gate dispatch. See docs/orchestration/auto-dispatch.md."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node (for the claude CLI)
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install the claude CLI
+        if: steps.guard.outputs.run == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Dispatch verification gates
+        if: steps.guard.outputs.run == 'true'
+        env:
+          # `gh` inside dispatch-gates.sh authenticates with this.
+          GH_TOKEN: ${{ github.token }}
+          # The gate-poster App identity used by tools/gate-check.py.
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          # Auth for the `claude -p` gate agents.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: tools/dispatch-gates.sh "${{ github.event.pull_request.number }}"

--- a/docs/orchestration/auto-dispatch.md
+++ b/docs/orchestration/auto-dispatch.md
@@ -32,9 +32,32 @@ DRY_RUN=1 tools/dispatch-gates.sh 76      # print what would run; post nothing
 ## Requirements for a live run
 
 - **App env** for posting: `GH_APP_ID`, `GH_APP_PRIVATE_KEY` (see [github-app.md](github-app.md)).
-- **Authenticated runners on the host**: the `claude` CLI logged in, and `codex-agent.sh`
-  configured (`CODEX_BIN`). These run where the orchestrator runs, not in Actions.
+- **Authenticated runners**: the `claude` CLI logged in (or `ANTHROPIC_API_KEY` set), and
+  `codex-agent.sh` configured (`CODEX_BIN`) for the Codex gate.
 - `DRY_RUN=1` needs none of the above — it prints the plan and posts nothing.
+
+## Running in GitHub Actions
+
+The dispatcher runs automatically in CI via
+[`.github/workflows/dispatch-gates.yml`](../../.github/workflows/dispatch-gates.yml),
+which fires on every `pull_request` event, installs the `claude` CLI, and runs
+`tools/dispatch-gates.sh <pr>`. This is a deliberate change from the original
+off-Actions design: the gates run in CI so the loop closes without a standing
+self-hosted orchestrator host. The gate-poster App is still the publishing
+identity — check-runs are posted with its installation token, not the workflow's
+`GITHUB_TOKEN`.
+
+It needs three repository **secrets**; without them the workflow skips cleanly
+(a warning, no failure):
+
+| Secret | Purpose |
+|---|---|
+| `GH_APP_ID` | the gate-poster App id |
+| `GH_APP_PRIVATE_KEY` | the App private-key PEM contents |
+| `ANTHROPIC_API_KEY` | auth for the `claude` gate agents |
+
+`codex-conformance` (formulas route) still needs the Codex CLI, which is not
+installed in this workflow; until it is, that gate reports `neutral` in CI.
 
 ## Closing the loop (phase-2 enforcement)
 

--- a/docs/orchestration/auto-dispatch.md
+++ b/docs/orchestration/auto-dispatch.md
@@ -47,14 +47,20 @@ self-hosted orchestrator host. The gate-poster App is still the publishing
 identity — check-runs are posted with its installation token, not the workflow's
 `GITHUB_TOKEN`.
 
-It needs three repository **secrets**; without them the workflow skips cleanly
+It needs repository **secrets**; without them the workflow skips cleanly
 (a warning, no failure):
 
 | Secret | Purpose |
 |---|---|
 | `GH_APP_ID` | the gate-poster App id |
 | `GH_APP_PRIVATE_KEY` | the App private-key PEM contents |
-| `ANTHROPIC_API_KEY` | auth for the `claude` gate agents |
+| `CLAUDE_CODE_OAUTH_TOKEN` *or* `ANTHROPIC_API_KEY` | auth for the `claude` gate agents (see below) |
+
+The `claude` CLI credential can be **either**: a subscription token from
+`claude setup-token` (run it where you are already logged into Claude Code on a
+Pro/Max plan) stored as `CLAUDE_CODE_OAUTH_TOKEN` — no Anthropic Console account
+needed — **or** a pay-as-you-go `ANTHROPIC_API_KEY` from the Console. Set one; the
+token is preferred if both are present.
 
 `codex-conformance` (formulas route) still needs the Codex CLI, which is not
 installed in this workflow; until it is, that gate reports `neutral` in CI.


### PR DESCRIPTION
## Linked Issue

Closes #85

## Exact behavioral claim

Verification gates now dispatch automatically in CI: on every `pull_request` event a new
workflow runs `tools/dispatch-gates.sh <pr>`, which runs each route-required gate agent
and posts its result as a check-run via the gate-poster App — so `gates-satisfied` can go
green instead of hanging `in_progress` forever. This prevents the standing failure where
no gate check-run was ever posted on any PR because nothing invoked the dispatcher.

## Scope

Adds `.github/workflows/dispatch-gates.yml` and documents it in
`docs/orchestration/auto-dispatch.md`. No application code, no rules, no tests changed. The
existing dispatcher/poster/aggregator scripts are unchanged — this only *invokes* them. A
guard step skips the run cleanly when the secrets are absent, so the workflow does not go
red before the owner adds them.

## Rules conformance

N/A — CI/orchestration config and docs only; no files under `src/Brp.*` are touched.

## Tests and evidence

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dispatch-gates.yml'))"` → parses; one job `dispatch-gates`, trigger `pull_request`.
- `DRY_RUN=1 tools/dispatch-gates.sh 83` → `route tooling  gates: ci scope-warden` (the dispatcher resolves the same gate the workflow will run).
- Verified against the poster contract: `tools/gate-check.py` posts as the App (JWT from `GH_APP_ID` + `GH_APP_PRIVATE_KEY`), so the workflow needs no `checks: write` on its own token.
- Root cause confirmed empirically: no PR in repo history (`#66`, `#68`, `#69`, `#78`, `#80`) has a `scope-warden` check-run on its head commit — only the CI-side checks — so the gate path had never run.

## Decisions and tradeoffs

Runs the gate agents in Actions, reversing the original "gates run off-Actions" note. Chosen
by the repo owner to close the loop without standing up a self-hosted orchestrator. Tradeoff:
the App private key lives as an Actions secret rather than only on an orchestrator host, and
model calls happen in CI. The App stays read-only on contents, so it still cannot edit code.

## Known limitations

- `codex-conformance` (formulas route) needs the Codex CLI, which this workflow does not
  install; until it is added, that gate reports `neutral` in CI (which the aggregator treats
  as non-blocking). Called out in the doc and issue as a follow-up.
- If a `claude` gate run errors, its verdict parses as `neutral` (non-blocking) rather than
  failing closed. Acceptable for first cut; a stricter fail-closed policy is a later change.
- `gates-satisfied` is still reported-only; making it a required check on `main` is the
  separate phase-2 step, to be done only after this posts reliably.

## Agent provenance

Implemented by Claude (Opus 4.8) via Claude Code, at the repository owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
