### PR TITLE
Ignore Python bytecode artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ artifacts/
 TestResults/
 *.trx
 
+# Python (tools/*.py, .github/workflows/*.py)
+__pycache__/
+*.py[cod]
+
 # Editors
 .vs/
 .vscode/


### PR DESCRIPTION
## Linked Issue

Closes #93

## Exact behavioral claim

Running any of the repo's Python tools no longer leaves committable bytecode behind:
`__pycache__/` and `*.py[cod]` are now ignored, so a tool run can't dirty the working tree
or slip compiled files into a commit (as nearly happened during #91's cleanup).

## Scope

Adds a Python section to `.gitignore`. Nothing else.

## Rules conformance

N/A — repo config only; no files under `src/Brp.*` are touched.

## Tests and evidence

- `python3 -c "import py_compile; py_compile.compile('tools/agent-brief.py')"` then `git status --porcelain tools/` → empty output (the generated `__pycache__` is ignored).

## Decisions and tradeoffs

Used `*.py[cod]` (covers `.pyc`/`.pyo`/`.pyd`) plus `__pycache__/`, the standard set, rather
than only `.pyc`.

## Known limitations

None.

## Agent provenance

Implemented by Claude (Opus 4.8) via Claude Code, at the repository owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
