### PR TITLE
Add situational combat spot rules (Layer 4 piece F)

### DIFF
--- a/docs/decisions/0018-spot-rules.md
+++ b/docs/decisions/0018-spot-rules.md
@@ -84,6 +84,11 @@ Details worth recording:
   convention for rounding a penalty; ADR 0007). For the printed values (−20→−10, −50→−25) the
   rounding is exact and does not bite. Light sources and Powers that offset darkness are out of
   scope (Powers are cut entirely; Light Sources is a separate rule).
+  - **House generalization (marked):** the book frames the detection halving around *complete*
+    darkness ("To detect an opponent **in complete darkness**…", p.169), but the resolver applies
+    the halving to `SemiDarkness` as well when the caller reports the opponent as detected. This is
+    a deliberate, roller-favoring generalization — the printed text does not forbid it and it yields
+    no value the book contradicts — recorded here rather than left as a silent choice.
 
 ### Firing into combat — reconciling ADR 0007 and `AdditiveModifier` — sourced
 

--- a/docs/decisions/0018-spot-rules.md
+++ b/docs/decisions/0018-spot-rules.md
@@ -1,0 +1,167 @@
+# 0018. Situational combat spot rules: five modifier producers, and the named adjudication ports for the book's open calls
+
+## Status
+
+Accepted — 2026-08-31. Resolves #50 (Layer 4 piece F, situational combat spot rules). Piece F was
+explicitly deferred to this work in ADR 0015 and ADR 0016 (0016's "What this piece does not build"
+lists "Spot rules — piece F"). Builds on ADR 0007 (the modifier pipeline) and ADR 0014 (range
+bands), whose firing-into-combat treatment this record reconciles.
+
+## Context
+
+Ch 7: Spot Rules collects a long list of situational combat rules. `orc-scope-filter.md` and the
+issue's acceptance criteria narrow piece F to five in-scope situational *combat* rules — Ambushes,
+Backstabs and Helpless Opponents, Cover, Darkness, and Firing Into Combat — and explicitly exclude
+the rest (see "Out of scope" below).
+
+The book's own foundation for these rules is Ch 5: System, "Modifying Action Rolls" (p.132): every
+one of them adjusts a roll either by a **difficulty grade** (Easy/Difficult) or by a **situational
+percentage**, and Ch 5 fixes the ordering between the two — "any situational modifier is applied
+after a skill is modified due to being Difficult or Easy. This way, the modifiers are not doubled
+or halved." That is exactly ADR 0007's pipeline. So the whole of piece F is a set of **modifier
+producers** feeding the existing pipeline, not a new resolution path.
+
+Ch 7 (pp.162–173) and the Ch 5 Situational Modifiers table (p.133) are the sole sources consulted.
+`engine-implementation-plan.md` is not authoritative for mechanics (AGENTS.md invariant 2); it is
+not used here.
+
+## Decision
+
+### The mechanism — each spot rule is a modifier producer, not a new path — sourced
+
+`SpotRuleResolver` (static, in `Brp.Rules.Combat`) mirrors `RangeBandResolver`: a per-rule method
+returns the rule's `Brp.Core.Modifiers.Modifier` contributions, and `Evaluate` concatenates them
+with a roll's other modifiers and runs `ModifierPipeline.Evaluate`. A rule that makes an action
+Easy or Difficult emits a `DifficultyModifier`, so it takes part in ADR 0007's non-stacking
+collapse (a spot-rule Difficult and a range-band Difficult halve once, not twice; an Easy and a
+Difficult cancel pairwise). A rule that applies a flat percentage emits a **situational**
+`AdditiveModifier`, so its stated weight survives the difficulty stage (Ch 5, p.132). A rule that
+forbids an action emits a `GateModifier` (Impossible). No spot rule needs an exclusive override, so
+unlike range bands the contributions are plain composable modifiers — no `RangeBandOutcome`-style
+closed hierarchy is required.
+
+Per AGENTS.md invariant 7, the book's **percentage** values are data in
+`Brp.Data/spot-rule-ruleset.json` (loaded by `NoirSpotRuleRuleset` into `SpotRuleRuleset`), not C#
+constants. The rules that work purely by difficulty grade carry no per-rule number, because the
+Easy/Difficult multipliers already live as data on `ModifierPolicy` (ADR 0007) — duplicating them
+per rule would be dead configuration, the same mistake ADR 0014 corrected with its removed
+`LongRangeMultiplier` field.
+
+### The five implemented rules
+
+Each rule's book modifier and citation:
+
+| Rule | Book modifier | Citation |
+|---|---|---|
+| **Ambushes** | Attack **Easy** (missile unseen/seen; hand-to-hand vs. unaware target); attack **unmodified** vs. an aware target. Defense **forbidden** (missile unseen), **Difficult** (hand-to-hand vs. unaware target), or normal. | Ch 7, "Ambushes", p.162 — sourced |
+| **Backstabs & Helpless Opponents** | Attack **Easy** (both cases). Unprotected back: defense **Difficult** only if the target made a Difficult Listen/Sense, else none. Helpless: defense **forbidden**. "No additional damage." | Ch 7, "Backstabs and Helpless Opponents", p.164 — sourced |
+| **Cover** | Attack **Difficult** (book worked example: 72% → 36%). | Ch 7, "Cover", p.169 — sourced |
+| **Darkness** | Situational **−20%** (semi-darkness) / **−50%** (pitch black); **halved** when the opponent is detected via a Difficult Sense/Listen roll. | Ch 7, "Darkness", p.169, drawing on the Ch 5 Situational Modifiers "Environment" row, p.133 — sourced |
+| **Firing Into Combat** | **−20%** firing *into* a melee; **Difficult** firing *while engaged*; a point-blank Easy cancels the while-engaged Difficult when both are in close range. | Ch 7, "Firing Into Combat", p.173 — sourced |
+
+Details worth recording:
+
+- **Ambushes (p.162) — sourced.** Modeled as four `AmbushKind` cases, each producing the attacker's
+  attack modifier and the target's defense modifier for the requested role. Only the initial ambush
+  round carries these; after it, "normal combat, no surprise modifiers" resumes. The
+  hand-to-hand-aware target's "cannot retaliate or move until the next combat round" is a
+  turn-economy effect on its *next* action, not a modifier on any roll, and is deliberately **not**
+  emitted as a `Modifier` (a caller that sequences rounds — ADR 0015's `CombatActionRequest` — owns
+  it). Armor "defends normally… unless the attackers are using aimed attacks to bypass armor" is a
+  damage/armor concern (piece D), out of scope here.
+- **Backstabs & Helpless (p.164) — sourced.** Both cases are Easy attacks and, per the book, do
+  **no additional damage** — the Easy grade is the whole benefit, not a damage bonus. The helpless
+  target "cannot make a dodge or parry" regardless of detection; the unprotected-back target may
+  make a Difficult defense only if it detected the attacker.
+- **Cover (p.169) — sourced.** The Difficult attack is the only pre-roll modifier. The "a roll over
+  the adjusted chance but under the normal rating hits the obstacle" band is derivable from the
+  resolved `ModifierChain` (the interval between the Difficult effective chance and the unmodified
+  base) and is not re-encoded as a separate mechanic.
+- **Darkness (p.169; Ch 5 p.133) — sourced.** The rule points at the Situational Modifiers table;
+  the "Environment" row supplies −20% (darkness/semi-darkness) and −50% (pitch black). The detection
+  halving ("reduce the darkness modifier by half") scales the penalty magnitude by the ruleset's
+  1/2 fraction, **rounded toward zero** so the reduced penalty favors the roller (the codebase
+  convention for rounding a penalty; ADR 0007). For the printed values (−20→−10, −50→−25) the
+  rounding is exact and does not bite. Light sources and Powers that offset darkness are out of
+  scope (Powers are cut entirely; Light Sources is a separate rule).
+
+### Firing into combat — reconciling ADR 0007 and `AdditiveModifier` — sourced
+
+Two earlier citations disagreed on this rule: ADR 0007 recorded firing into combat as **Difficult**,
+while `AdditiveModifier`'s own remarks recorded it as **−20%**. The book (p.173) shows both were
+half the rule: "Firing a missile weapon **into** combat is modified by −20%, while firing a missile
+weapon **while engaged** in combat is Difficult. However, if the attacker and the target are both
+within close combat range, the attack is Easy (for Point-blank Range), so the Difficult and Easy
+modifiers cancel one another."
+
+`SpotRuleResolver.FiringIntoCombat` produces the −20% additive for the into-a-melee condition and
+the Difficult grade for the while-engaged condition, independently. It deliberately does **not**
+re-emit the point-blank Easy: that Easy is `RangeBandResolver`'s contribution for
+`RangeBand.PointBlank` (ADR 0014), and when a caller composes it alongside this rule's Difficult,
+ADR 0007's non-stacking collapse cancels the pair automatically. Producing the Easy here as well
+would double-count it. This is the same collapse the existing
+`RangeBandResolverTests.Point_blank_and_a_difficult_condition_cancel_pairwise` (p.173) already
+asserts with a hand-rolled `DifficultyModifier.Difficult("firing into combat")`; that test is left
+untouched and green, and a new
+`SpotRuleResolverTests.Firing_while_engaged_difficult_is_cancelled_by_a_point_blank_easy_when_both_in_close_range`
+shows this resolver produces exactly what that test hand-rolls. No parallel or duplicate mechanic is
+introduced.
+
+The stray-ally risk (a roll between the skill rating and the −20% chance may hit a bystander, chosen
+by Luck rolls; "the attacker is not eligible for an experience check" on such a shot) is a
+post-roll gamemaster call, routed to an adjudication port (below), not a modifier.
+
+### The gamemaster-discretion points become named adjudication ports
+
+Ch 7's spot rules leave several calls "at the gamemaster's discretion." Following the `IAdjudicator`
+precedent (ADR / `engine-implementation-plan.md` decision D5), each becomes a first-class named port
+rather than a silent hardcoded choice: `ISpotRuleAdjudicator` (in `Brp.Core.Contests`) with a
+`SpotRuleDecisionId` enum, canonical kebab-case ids (`SpotRuleDecisionIds.CanonicalId`), and a
+`DefaultSpotRuleAdjudicator` stub whose defaults are the minimal-assumption reading. The port's
+return types are `Brp.Core.Contests` values (not `Brp.Rules.Combat` types) so the port stays within
+`Brp.Core` and does not invert the layer dependency (AGENTS.md invariant 6) — the reason
+`DarknessSeverity` lives beside the port rather than in the combat-rules layer.
+
+| Decision id | What the book leaves open | Timing | Default | Source |
+|---|---|---|---|---|
+| `darkness-severity` | Which darkness tier applies (semi-darkness −20% vs. pitch black −50%) | pre-roll | `SemiDarkness` (asserts the milder condition) | **sourced** — Ch 7 p.169; Ch 5 p.133 |
+| `cover-penetration` | Whether the shot's damage penetrates the cover to reach the target | post-roll | `StoppedByCover` (matches the base rule's own "hits the obstacle" outcome) | **sourced** — Ch 7 p.169 |
+| `cover-extent` | How much of the target the obstacle screens / which hit locations are protected | pre-roll (announced) | `PartiallyProtected` (the rule's own premise) | **sourced** — Ch 7 p.169 |
+| `backstab-helpless-reprieve` | Whether a helpless target gets a POW×1 reprieve that stays the attacker's hand this round | pre-action | `NoReprieve` (the book says the GM *may* allow it) | **sourced** — Ch 7 p.164 |
+| `firing-into-combat-stray-target` | Which bystander (if any) a stray shot hits, via Luck rolls | post-roll | none struck | **sourced** — Ch 7 p.173 |
+
+The decision *ports* are sourced to the book passages that leave the call open; the *default
+answers* are a **house choice** of the most neutral reading (each documented on
+`DefaultSpotRuleAdjudicator`). `cover-penetration` and `cover-extent` carry only coarse outcomes
+because the damage arithmetic and hit-location systems they would feed are deferred pieces, out of
+scope here; the ports exist so those calls are named now rather than silently fixed. Tests drive
+every port with a deterministic stub.
+
+## Out of scope (per `orc-scope-filter.md` and the issue's acceptance criteria)
+
+Not implemented here: falling, poison, and disease (a sibling issue); damage numbers, wounds, and
+hit locations; the fumble tables; fatigue points, dying blows, and aging; and every other Ch 7 spot
+rule outside the five combat rules above (Aimed Attacks, Big and Little Targets, Both Sides
+Surprised, Broken Weapons, Chases, Disarming, Knockback, Fortified Positions, and so on). Light
+Sources and any Power that offsets darkness are likewise out of scope.
+
+## Consequences
+
+- `Brp.Rules.Combat` gains `SpotRuleRuleset`, `SpotRuleResolver`, and the `SpotRuleRole`,
+  `AmbushKind`, and `BackstabKind` enums. `Brp.Data` gains `spot-rule-ruleset.json` and
+  `NoirSpotRuleRuleset`, all data-driven per invariant 7. `Brp.Core.Contests` gains
+  `ISpotRuleAdjudicator`, `SpotRuleDecisionId`/`SpotRuleDecisionIds`, `DefaultSpotRuleAdjudicator`,
+  and the ruling types (`DarknessSeverity`, `CoverPenetrationRuling`, `CoverExtentRuling`,
+  `HelplessReprieveRuling`, `StrayTargetRuling`).
+- The firing-into-combat mechanic now has one home: this resolver produces both the −20% and the
+  Difficult, reconciling ADR 0007 and `AdditiveModifier`'s remarks. The range-band tests' hand-rolled
+  `DifficultyModifier.Difficult("firing into combat")` remains valid and green; a future cleanup
+  could route them through this resolver, but it is not required for correctness.
+- Ambush "cannot retaliate or move," cover's obstacle-hit band, the cover-penetration damage roll,
+  the stray-target Luck rolls, and the helpless reprieve's effect on the round all need caller/round
+  state this pre-roll producer does not hold. The seam mirrors ADR 0015/0016: the spot-rule layer
+  produces modifiers and names the open calls; whichever piece orchestrates a running encounter
+  wires the ports and applies the turn-economy effects.
+- If a later reading finds a distinction that matters for cover penetration or extent (once damage
+  and hit locations exist), the ports already carry the decision points — only the consuming piece,
+  not this producer, would change.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -40,3 +40,4 @@ supersedes it — the original is not edited or deleted.
 | [0015](0015-combat-round.md) | Combat round: three phases, DEX-rank ordering, and the weapon-type tiebreak | Accepted |
 | [0016](0016-attack-defense-matrix.md) | Attack/defense matrix: data-driven cells, the undefended case, and the deferred -30% | Accepted |
 | [0017](0017-damage.md) | Damage: normal/special/critical arithmetic, hit-point conditions, and knockout attacks | Accepted |
+| [0018](0018-spot-rules.md) | Situational combat spot rules: five modifier producers and named adjudication ports | Accepted |

--- a/src/Brp.Core/Contests/ISpotRuleAdjudicator.cs
+++ b/src/Brp.Core/Contests/ISpotRuleAdjudicator.cs
@@ -1,0 +1,274 @@
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// The named gamemaster-adjudication points the Ch 7 situational combat spot rules leave open.
+/// Each member is a decision the source book explicitly hands to the gamemaster ("at the
+/// gamemaster's discretion", "the gamemaster should determine", "the gamemaster may allow")
+/// rather than resolving mechanically. Naming them as first-class ids is the same discipline
+/// <see cref="OpposedRollDecisionId"/> follows: a rules engine that hardcodes these calls
+/// silently is lying about what the book actually settles. The canonical kebab-case id for each
+/// (the string a GM tool, log, or authored policy keys on) is given in its summary and returned
+/// by <see cref="SpotRuleDecisionIds.CanonicalId"/>.
+/// </summary>
+public enum SpotRuleDecisionId
+{
+    /// <summary>
+    /// Canonical id <c>cover-penetration</c>. Ch 7, "Cover" (p.169): when an attack strikes the
+    /// covering obstacle rather than the target, "damage should be rolled to see if it bypasses
+    /// the cover and goes through to the intended target (see Damage to Inanimate Objects). Roll
+    /// damage only when it makes sense." Whether the shot's damage penetrates the cover to reach
+    /// the target is a gamemaster call weighed against the obstacle's armor value and hit points.
+    /// A post-roll ruling: it is consulted only once the attack has landed on the cover, and the
+    /// damage arithmetic it feeds is out of scope for the spot-rule modifier producer (piece D /
+    /// a deferred inanimate-object damage rule owns that). This port names the decision so the
+    /// spot-rule layer does not silently assert "the cover always stops it" or "always lets it
+    /// through."
+    /// </summary>
+    CoverPenetration,
+
+    /// <summary>
+    /// Canonical id <c>cover-extent</c>. Ch 7, "Cover" (p.169): "If hit locations are used, you
+    /// should announce what portions of your character's body are behind cover before the
+    /// gamemaster rolls for an attack, with the gamemaster deciding how much cover the obstacle
+    /// allows." How much of the target the obstacle screens -- and, with hit locations, which
+    /// regions are protected -- is a gamemaster call. Hit locations are a deferred piece and out
+    /// of scope here, so this port carries only the coarse extent (<see cref="CoverExtentRuling"/>)
+    /// rather than a per-location map; it exists so the discretion is named now and can be
+    /// enriched when hit locations land, instead of being silently fixed.
+    /// </summary>
+    CoverExtent,
+
+    /// <summary>
+    /// Canonical id <c>darkness-severity</c>. Ch 7, "Darkness" (p.169): "If your character is
+    /// fighting in darkness, whether semi-darkness or pitch black, see Situational Modifiers for
+    /// modifiers." Which tier of the Ch 5 Situational Modifiers "Environment" row (p.133) applies
+    /// -- <see cref="DarknessSeverity.SemiDarkness"/> (darkness, -20%) or
+    /// <see cref="DarknessSeverity.PitchBlack"/> (pitch black, -50%) -- is the gamemaster's read
+    /// of the scene. This is a pre-roll ruling: its result selects the situational penalty the
+    /// spot-rule resolver then produces.
+    /// </summary>
+    DarknessSeverity,
+
+    /// <summary>
+    /// Canonical id <c>backstab-helpless-reprieve</c>. Ch 7, "Backstabs and Helpless Opponents"
+    /// (p.164): against a helpless target "the gamemaster may allow the target a POW×1 roll to
+    /// determine if some lucky incident occurs that stays the attacker's hand for the duration of
+    /// the combat round." Whether the helpless target gets that reprieve -- and thus whether the
+    /// otherwise-automatic attack happens at all this round -- is a gamemaster call. A pre-action
+    /// ruling: the caller checks it before the attack resolves; when it grants a reprieve, no
+    /// attack roll is made this round.
+    /// </summary>
+    BackstabHelplessReprieve,
+
+    /// <summary>
+    /// Canonical id <c>firing-into-combat-stray-target</c>. Ch 7, "Firing Into Combat" (p.173):
+    /// when a shot into a melee "rolls a number between their skill rating and their modified
+    /// chance (-20%...), the gamemaster should randomly determine which of the other potential
+    /// targets was struck, by having all potential targets make a Luck roll and choosing the
+    /// biggest failure (or most marginal success) as the unlucky target." Which bystander (if
+    /// any) takes the stray shot is a gamemaster call, resolved via Luck rolls the spot-rule layer
+    /// does not own. A post-roll ruling, consulted only when the attack roll lands in that risk
+    /// band; "the attacker is not eligible for an experience check" on such a shot.
+    /// </summary>
+    FiringIntoCombatStrayTarget,
+}
+
+/// <summary>Canonical kebab-case ids for the <see cref="SpotRuleDecisionId"/> ports.</summary>
+public static class SpotRuleDecisionIds
+{
+    /// <summary>
+    /// The canonical kebab-case id for <paramref name="decisionId"/> -- the stable string a GM
+    /// tool, authored policy, or log keys on (e.g. <c>cover-penetration</c>), matching the ids
+    /// named in Issue #50 and ADR 0018.
+    /// </summary>
+    public static string CanonicalId(SpotRuleDecisionId decisionId) => decisionId switch
+    {
+        SpotRuleDecisionId.CoverPenetration => "cover-penetration",
+        SpotRuleDecisionId.CoverExtent => "cover-extent",
+        SpotRuleDecisionId.DarknessSeverity => "darkness-severity",
+        SpotRuleDecisionId.BackstabHelplessReprieve => "backstab-helpless-reprieve",
+        SpotRuleDecisionId.FiringIntoCombatStrayTarget => "firing-into-combat-stray-target",
+        _ => throw new ArgumentOutOfRangeException(nameof(decisionId), decisionId, "Unknown spot-rule decision id."),
+    };
+}
+
+/// <summary>
+/// The severity of darkness a fight takes place in, mapping to a tier of the Ch 5 Situational
+/// Modifiers "Environment" row (p.133) as directed by Ch 7, "Darkness" (p.169). Lives in
+/// <c>Brp.Core.Contests</c> rather than the combat-rules layer because the
+/// <see cref="SpotRuleDecisionId.DarknessSeverity"/> port both produces and consumes it, and a
+/// <c>Brp.Core</c> port cannot depend on <c>Brp.Rules</c> (AGENTS.md invariant 6).
+/// </summary>
+public enum DarknessSeverity
+{
+    /// <summary>
+    /// Semi-darkness -- the Ch 5 Environment tier "Unpleasant or unsanitary conditions, unsteady
+    /// footing, darkness, bad weather, etc." at -20% (p.133).
+    /// </summary>
+    SemiDarkness,
+
+    /// <summary>
+    /// Pitch black -- the Ch 5 Environment tier "Distracting environment, highly unstable ground,
+    /// pitch black, stormy, etc." at -50% (p.133).
+    /// </summary>
+    PitchBlack,
+}
+
+/// <summary>
+/// Whether damage penetrates cover to reach the target, for the
+/// <see cref="SpotRuleDecisionId.CoverPenetration"/> ruling (Ch 7, p.169). Deliberately a coarse
+/// yes/no rather than a damage figure: the damage arithmetic (obstacle armor and hit points, the
+/// deferred "Damage to Inanimate Objects" rule) is out of scope for the spot-rule producer.
+/// </summary>
+public enum CoverPenetrationRuling
+{
+    /// <summary>The obstacle absorbs the shot; nothing reaches the target this attack.</summary>
+    StoppedByCover,
+
+    /// <summary>The shot's damage passes through the cover and reaches the intended target.</summary>
+    PenetratesToTarget,
+}
+
+/// <summary>
+/// How much of the target the obstacle screens, for the
+/// <see cref="SpotRuleDecisionId.CoverExtent"/> ruling (Ch 7, p.169). Coarse rather than a
+/// per-hit-location map because hit locations are a deferred piece and out of scope here.
+/// </summary>
+public enum CoverExtentRuling
+{
+    /// <summary>No effective cover; the target is fully exposed (no Cover spot rule applies).</summary>
+    Exposed,
+
+    /// <summary>The target is partially covered -- the premise of the Ch 7 Cover rule.</summary>
+    PartiallyProtected,
+
+    /// <summary>The obstacle screens the target entirely from this line of attack.</summary>
+    FullyProtected,
+}
+
+/// <summary>
+/// Whether a helpless target receives the Ch 7 (p.164) POW×1 reprieve, for the
+/// <see cref="SpotRuleDecisionId.BackstabHelplessReprieve"/> ruling.
+/// </summary>
+public enum HelplessReprieveRuling
+{
+    /// <summary>No reprieve; the attack against the helpless target proceeds this round.</summary>
+    NoReprieve,
+
+    /// <summary>
+    /// A lucky incident stays the attacker's hand for the duration of the combat round; no attack
+    /// is made this round.
+    /// </summary>
+    ReprievedThisRound,
+}
+
+/// <summary>
+/// Which bystander takes a stray shot fired into a melee, for the
+/// <see cref="SpotRuleDecisionId.FiringIntoCombatStrayTarget"/> ruling (Ch 7, p.173).
+/// </summary>
+/// <param name="StruckBystanderIndex">
+/// The zero-based index of the struck bystander among the potential other targets, or
+/// <see langword="null"/> when no bystander is struck. The book resolves the selection with Luck
+/// rolls the spot-rule layer does not own; this ruling only reports the outcome.
+/// </param>
+public readonly record struct StrayTargetRuling(int? StruckBystanderIndex);
+
+/// <summary>
+/// A gamemaster-discretion port for the Ch 7 situational combat spot rules, modeled -- like
+/// <see cref="IAdjudicator"/> for opposed rolls -- as a first-class interface rather than a set of
+/// silent hardcoded choices. Each method answers one <see cref="SpotRuleDecisionId"/> the book
+/// leaves open. A GM tool can prompt a human; an unattended simulation can supply an authored
+/// policy; tests supply a deterministic stub. See <c>docs/decisions/0018-spot-rules.md</c>.
+/// <para>
+/// The return types are ordinary <c>Brp.Core.Contests</c> values, not <c>Brp.Rules.Combat</c>
+/// types, so this port stays within <c>Brp.Core</c> and does not invert the layer dependency
+/// (AGENTS.md invariant 6). The methods carry minimal context today; richer context (the actual
+/// obstacle, the bystanders' characteristics for the Luck rolls) is a future concern for whichever
+/// piece wires these ports into a running encounter.
+/// </para>
+/// </summary>
+public interface ISpotRuleAdjudicator
+{
+    /// <summary>
+    /// Decides which darkness tier applies to a fight in the dark
+    /// (<see cref="SpotRuleDecisionId.DarknessSeverity"/>). Pre-roll: the result selects the
+    /// situational penalty the Darkness spot rule then produces.
+    /// </summary>
+    DarknessSeverity DecideDarknessSeverity();
+
+    /// <summary>
+    /// Decides whether a shot that struck cover penetrates to the target
+    /// (<see cref="SpotRuleDecisionId.CoverPenetration"/>). Post-roll; the damage it feeds is out
+    /// of scope for the spot-rule producer.
+    /// </summary>
+    CoverPenetrationRuling DecideCoverPenetration();
+
+    /// <summary>
+    /// Decides how much of the target the obstacle screens
+    /// (<see cref="SpotRuleDecisionId.CoverExtent"/>).
+    /// </summary>
+    CoverExtentRuling DecideCoverExtent();
+
+    /// <summary>
+    /// Decides whether a helpless target receives the POW×1 reprieve that stays the attacker's
+    /// hand this round (<see cref="SpotRuleDecisionId.BackstabHelplessReprieve"/>). Pre-action.
+    /// </summary>
+    HelplessReprieveRuling DecideBackstabHelplessReprieve();
+
+    /// <summary>
+    /// Decides which bystander (if any) takes a stray shot fired into a melee
+    /// (<see cref="SpotRuleDecisionId.FiringIntoCombatStrayTarget"/>). Post-roll.
+    /// </summary>
+    /// <param name="bystanderCount">
+    /// The number of other potential targets in or around the melee. A returned index must be in
+    /// <c>[0, bystanderCount)</c>, or the ruling may report no bystander struck.
+    /// </param>
+    StrayTargetRuling DecideFiringIntoCombatStrayTarget(int bystanderCount);
+}
+
+/// <summary>
+/// The documented default policy for every <see cref="SpotRuleDecisionId"/>: the most
+/// minimal-assumption answer to "the book does not say," mirroring how
+/// <see cref="DefaultAdjudicator"/> asserts nothing beyond the book for opposed rolls. Each
+/// default is the conservative reading that adds no fact the book did not state, so an unattended
+/// run is deterministic and neutral; a table with a house rule or a human gamemaster should supply
+/// its own <see cref="ISpotRuleAdjudicator"/> instead.
+/// </summary>
+public sealed class DefaultSpotRuleAdjudicator : ISpotRuleAdjudicator
+{
+    /// <summary>
+    /// Defaults to <see cref="DarknessSeverity.SemiDarkness"/> -- the lesser (-20%) of the two
+    /// tiers. Choosing the milder condition asserts the least: it does not silently treat every
+    /// dark scene as pitch black.
+    /// </summary>
+    public DarknessSeverity DecideDarknessSeverity() => DarknessSeverity.SemiDarkness;
+
+    /// <summary>
+    /// Defaults to <see cref="CoverPenetrationRuling.StoppedByCover"/> -- the cover did its job.
+    /// This matches the base Cover rule's own outcome for a shot that lands on the obstacle (Ch 7,
+    /// p.169: "the attack has hit the obstacle or cover rather than the target"), and adds no
+    /// assumption about the obstacle's armor or the weapon's damage that the spot-rule layer does
+    /// not model.
+    /// </summary>
+    public CoverPenetrationRuling DecideCoverPenetration() => CoverPenetrationRuling.StoppedByCover;
+
+    /// <summary>
+    /// Defaults to <see cref="CoverExtentRuling.PartiallyProtected"/> -- the premise of the Ch 7
+    /// Cover rule itself ("If a target is partially covered...").
+    /// </summary>
+    public CoverExtentRuling DecideCoverExtent() => CoverExtentRuling.PartiallyProtected;
+
+    /// <summary>
+    /// Defaults to <see cref="HelplessReprieveRuling.NoReprieve"/> -- the mechanical baseline. The
+    /// book frames the reprieve as something the gamemaster "may allow," so the default is to grant
+    /// nothing beyond the printed rule (the attack proceeds).
+    /// </summary>
+    public HelplessReprieveRuling DecideBackstabHelplessReprieve() => HelplessReprieveRuling.NoReprieve;
+
+    /// <summary>
+    /// Defaults to no bystander struck (a <see langword="null"/> index). Resolving which ally is
+    /// hit requires the bystanders' Luck rolls, which this default cannot perform; asserting "no
+    /// stray hit" adds no unmodeled fact.
+    /// </summary>
+    public StrayTargetRuling DecideFiringIntoCombatStrayTarget(int bystanderCount) => new(null);
+}

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -23,6 +23,7 @@
     <EmbeddedResource Include="combat-round-ruleset.json" />
     <EmbeddedResource Include="attack-defense-matrix-ruleset.json" />
     <EmbeddedResource Include="damage-ruleset.json" />
+    <EmbeddedResource Include="spot-rule-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirSpotRuleRuleset.cs
+++ b/src/Brp.Data/NoirSpotRuleRuleset.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Brp.Rules.Combat;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's situational combat spot-rule percentage values from embedded JSON. Sourced:
+/// Ch 7: Spot Rules -- "Firing Into Combat" (p.173) and "Darkness" (p.169, whose modifiers come
+/// from the Ch 5 Situational Modifiers "Environment" row, p.133) -- see each field on
+/// <see cref="SpotRuleRuleset"/> for its exact citation. Recorded in
+/// <c>docs/decisions/0018-spot-rules.md</c>.
+/// </summary>
+public static class NoirSpotRuleRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable spot-rule ruleset from the shipped data.</summary>
+    public static SpotRuleRuleset Load()
+    {
+        var assembly = typeof(NoirSpotRuleRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.spot-rule-ruleset.json")
+            ?? throw new InvalidOperationException("The spot-rule ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<SpotRuleRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The spot-rule ruleset data is empty.");
+
+        return new SpotRuleRuleset(
+            firingIntoCombatModifier: data.FiringIntoCombatModifier,
+            darknessSemiDarknessModifier: data.DarknessSemiDarknessModifier,
+            darknessPitchBlackModifier: data.DarknessPitchBlackModifier,
+            darknessDetectionHalvingNumerator: data.DarknessDetectionHalvingNumerator,
+            darknessDetectionHalvingDenominator: data.DarknessDetectionHalvingDenominator);
+    }
+
+    private sealed class SpotRuleRulesetData
+    {
+        public required int FiringIntoCombatModifier { get; init; }
+
+        public required int DarknessSemiDarknessModifier { get; init; }
+
+        public required int DarknessPitchBlackModifier { get; init; }
+
+        public required int DarknessDetectionHalvingNumerator { get; init; }
+
+        public required int DarknessDetectionHalvingDenominator { get; init; }
+    }
+}

--- a/src/Brp.Data/spot-rule-ruleset.json
+++ b/src/Brp.Data/spot-rule-ruleset.json
@@ -1,0 +1,17 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 7: Spot Rules",
+    "notes": "Percentage values for the in-scope situational combat spot rules. Grade-only rules (Ambushes, Backstabs, Cover, firing while engaged) contribute Easy/Difficult grades whose multipliers are data on ModifierPolicy, so they carry no number here. See docs/decisions/0018-spot-rules.md."
+  },
+  "firingIntoCombatModifier": -20,
+  "firingIntoCombatSource": "Ch 7, Firing Into Combat (p.173): 'Firing a missile weapon into combat is modified by -20%.'",
+
+  "darknessSemiDarknessModifier": -20,
+  "darknessPitchBlackModifier": -50,
+  "darknessSource": "Ch 7, Darkness (p.169) directs to the Ch 5 Situational Modifiers 'Environment' row (p.133): darkness/semi-darkness -20%, pitch black -50%.",
+
+  "darknessDetectionHalvingNumerator": 1,
+  "darknessDetectionHalvingDenominator": 2,
+  "darknessDetectionHalvingSource": "Ch 7, Darkness (p.169): 'To detect an opponent in complete darkness, you must make a successful Difficult Sense or Listen roll. If successful, reduce the darkness modifier by half.'"
+}

--- a/src/Brp.Rules/Combat/AmbushKind.cs
+++ b/src/Brp.Rules/Combat/AmbushKind.cs
@@ -1,0 +1,40 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The four ambush cases of Ch 7: Spot Rules, "Ambushes" (p.162). An ambush requires a successful
+/// Stealth roll opposed by the target's Listen, Sense, or Spot; the resulting case determines both
+/// the attacker's attack modifier and the target's defense. See <see cref="SpotRuleResolver.Ambush"/>.
+/// </summary>
+public enum AmbushKind
+{
+    /// <summary>
+    /// Attackers using missile weapons and <em>not</em> seen (p.162): "the attackers get a free
+    /// round of Easy attacks. The target(s) cannot dodge or parry this initial round of attacks."
+    /// Attack Easy; defense forbidden.
+    /// </summary>
+    MissileUnseen,
+
+    /// <summary>
+    /// Attackers using missile weapons and seen (p.162): "the attackers get a free round of Easy
+    /// attacks, but the targets can dodge or parry this initial round." Attack Easy; defense
+    /// normal.
+    /// </summary>
+    MissileSeen,
+
+    /// <summary>
+    /// Attackers using hand-to-hand weapons who failed their Stealth rolls, and the target fails
+    /// the Easy Listen/Sense/Spot roll to notice them (p.162): "attacks against them are Easy and
+    /// any parries or dodges they make are Difficult." Attack Easy; defense Difficult.
+    /// </summary>
+    HandToHandTargetUnaware,
+
+    /// <summary>
+    /// Attackers using hand-to-hand weapons whom the target notices with a successful
+    /// Listen/Sense/Spot roll (p.162): "the attackers' skill ratings are unmodified and the targets
+    /// can parry or Dodge normally but cannot retaliate or move until the next combat round."
+    /// Attack unmodified; defense normal. The "cannot retaliate or move" clause is a turn-economy
+    /// effect on the target's next action, not a modifier on any single roll, and is not modeled as
+    /// a <see cref="Brp.Core.Modifiers.Modifier"/> here (see <see cref="SpotRuleResolver.Ambush"/>).
+    /// </summary>
+    HandToHandTargetAware,
+}

--- a/src/Brp.Rules/Combat/BackstabKind.cs
+++ b/src/Brp.Rules/Combat/BackstabKind.cs
@@ -1,0 +1,26 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The two cases of Ch 7: Spot Rules, "Backstabs and Helpless Opponents" (p.164). Both make the
+/// attack Easy; they differ in whether, and how, the target may defend. See
+/// <see cref="SpotRuleResolver.Backstab"/>.
+/// </summary>
+public enum BackstabKind
+{
+    /// <summary>
+    /// An attack on the unprotected back of a target in hand-to-hand combat (p.164): "that one
+    /// attack is Easy. If the target succeeds in a Difficult Listen or Sense roll, they can make a
+    /// Difficult Dodge or parry attempt, but only if they have any remaining opportunities for
+    /// defense. No additional damage is done by such an attack." Attack Easy; defense Difficult
+    /// only if the target detected the attacker (and has a defense left), otherwise none.
+    /// </summary>
+    UnprotectedBack,
+
+    /// <summary>
+    /// An attack on a helpless target -- "unconscious, asleep, or restrained entirely" (p.164):
+    /// "the attack is Easy and they cannot make a dodge or parry attempt against the attack."
+    /// Attack Easy; defense forbidden. Subject to the gamemaster's optional POW×1 reprieve
+    /// (<see cref="Brp.Core.Contests.SpotRuleDecisionId.BackstabHelplessReprieve"/>).
+    /// </summary>
+    Helpless,
+}

--- a/src/Brp.Rules/Combat/SpotRuleResolver.cs
+++ b/src/Brp.Rules/Combat/SpotRuleResolver.cs
@@ -1,0 +1,271 @@
+using Brp.Core.Contests;
+using Brp.Core.Modifiers;
+using Brp.Core.Primitives;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Produces the <see cref="Modifier"/> contributions of the five in-scope situational combat spot
+/// rules of Ch 7: Spot Rules -- Ambushes (p.162), Backstabs and Helpless Opponents (p.164), Cover
+/// (p.169), Darkness (p.169), and Firing Into Combat (p.173). Each rule is a <em>modifier
+/// producer</em> feeding ADR 0007's <see cref="ModifierPipeline"/>, not a new resolution path: a
+/// rule that makes an action Easy or Difficult emits a <see cref="DifficultyModifier"/> so it takes
+/// part in ADR 0007's non-stacking collapse (a spot-rule Difficult and a range-band Difficult halve
+/// once, not twice; a point-blank Easy and a firing-while-engaged Difficult cancel); a rule that
+/// applies a flat percentage emits a situational <see cref="AdditiveModifier"/> so its stated weight
+/// survives the difficulty stage (Ch 5, "Modifying Action Rolls", p.132); and a rule that forbids an
+/// action emits a <see cref="GateModifier"/>. The book's percentage values live in
+/// <see cref="SpotRuleRuleset"/> (AGENTS.md invariant 7); the grade semantics live on
+/// <see cref="ModifierPolicy"/>.
+/// <para>
+/// Mirrors <see cref="RangeBandResolver"/> in shape -- a static resolver whose per-case methods
+/// return the contributions, plus an <see cref="Evaluate"/> that concatenates them with a roll's
+/// other modifiers and runs the pipeline. Unlike range bands, no spot rule needs an exclusive
+/// override, so the contributions are plain composable modifiers. The gamemaster-discretion points
+/// each rule leaves open (Ch 7's "at the gamemaster's discretion" clauses) are named ports on
+/// <see cref="ISpotRuleAdjudicator"/>; see <c>docs/decisions/0018-spot-rules.md</c>.
+/// </para>
+/// </summary>
+public static class SpotRuleResolver
+{
+    /// <summary>
+    /// The modifier(s) an ambush (Ch 7, "Ambushes", p.162) contributes to <paramref name="role"/>'s
+    /// roll for the given <paramref name="kind"/>. The attacker's attack is Easy in every case
+    /// except <see cref="AmbushKind.HandToHandTargetAware"/> (unmodified); the target's defense is
+    /// forbidden outright (<see cref="AmbushKind.MissileUnseen"/>), Difficult
+    /// (<see cref="AmbushKind.HandToHandTargetUnaware"/>), or unmodified (the other two).
+    /// <para>
+    /// Only the initial ambush round carries these modifiers: "In most cases, the target's armor
+    /// defends normally" and, after the surprise round, normal combat with no surprise modifiers
+    /// resumes (p.162). The <see cref="AmbushKind.HandToHandTargetAware"/> target's inability to
+    /// "retaliate or move until the next combat round" is a turn-economy effect on its next action,
+    /// not a modifier on this roll, and is not emitted here.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<Modifier> Ambush(AmbushKind kind, SpotRuleRole role, string source = "ambush")
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var label = $"{source} (Ch 7, Ambushes)";
+        return role switch
+        {
+            SpotRuleRole.Attacker => kind switch
+            {
+                AmbushKind.MissileUnseen or AmbushKind.MissileSeen or AmbushKind.HandToHandTargetUnaware =>
+                    [DifficultyModifier.Easy(label)],
+                AmbushKind.HandToHandTargetAware => [],
+                _ => throw UnknownKind(kind),
+            },
+            SpotRuleRole.Defender => kind switch
+            {
+                AmbushKind.MissileUnseen => [new GateModifier($"{label}: cannot dodge or parry", GateKind.Impossible)],
+                AmbushKind.HandToHandTargetUnaware => [DifficultyModifier.Difficult(label)],
+                AmbushKind.MissileSeen or AmbushKind.HandToHandTargetAware => [],
+                _ => throw UnknownKind(kind),
+            },
+            _ => throw UnknownRole(role),
+        };
+    }
+
+    /// <summary>
+    /// The modifier(s) a backstab or helpless-opponent attack (Ch 7, "Backstabs and Helpless
+    /// Opponents", p.164) contributes to <paramref name="role"/>'s roll. Both kinds make the
+    /// attacker's attack Easy and do <em>no additional damage</em> (the Easy grade is the whole
+    /// benefit). The defender's options differ:
+    /// <list type="bullet">
+    /// <item><see cref="BackstabKind.UnprotectedBack"/>: a Difficult Dodge/parry only if the target
+    /// detected the attacker (a successful Difficult Listen/Sense) and has a defense left --
+    /// <paramref name="defenderDetectedAttacker"/> models that detection; otherwise the target gets
+    /// no defense this attack.</item>
+    /// <item><see cref="BackstabKind.Helpless"/>: the target "cannot make a dodge or parry attempt"
+    /// regardless -- <paramref name="defenderDetectedAttacker"/> does not apply. The optional POW×1
+    /// reprieve is the <see cref="SpotRuleDecisionId.BackstabHelplessReprieve"/> port's concern, not
+    /// a modifier, and gates the whole attack rather than adjusting this roll.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="kind">Which backstab case applies.</param>
+    /// <param name="role">Whose roll to produce the modifier for.</param>
+    /// <param name="defenderDetectedAttacker">
+    /// For <see cref="BackstabKind.UnprotectedBack"/> only: whether the target made the Difficult
+    /// Listen/Sense roll to notice the attacker (and so may attempt a Difficult defense). Ignored
+    /// for <see cref="BackstabKind.Helpless"/>.
+    /// </param>
+    /// <param name="source">A label prefix identifying the attack, used in the rendered chain.</param>
+    public static IReadOnlyList<Modifier> Backstab(
+        BackstabKind kind, SpotRuleRole role, bool defenderDetectedAttacker = false, string source = "backstab")
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var label = $"{source} (Ch 7, Backstabs and Helpless Opponents)";
+        return role switch
+        {
+            SpotRuleRole.Attacker => [DifficultyModifier.Easy(label)],
+            SpotRuleRole.Defender => kind switch
+            {
+                BackstabKind.UnprotectedBack when defenderDetectedAttacker => [DifficultyModifier.Difficult(label)],
+                BackstabKind.UnprotectedBack => [new GateModifier($"{label}: undetected, no defense", GateKind.Impossible)],
+                BackstabKind.Helpless => [new GateModifier($"{label}: helpless, cannot dodge or parry", GateKind.Impossible)],
+                _ => throw UnknownKind(kind),
+            },
+            _ => throw UnknownRole(role),
+        };
+    }
+
+    /// <summary>
+    /// The modifier a partial-cover situation (Ch 7, "Cover", p.169) contributes: "any attacks on
+    /// that target are Difficult." Only the attacker's attack roll is modified; cover is not a
+    /// defensive action the defender rolls for, so <see cref="SpotRuleRole.Defender"/> contributes
+    /// nothing here.
+    /// <para>
+    /// The rest of the Cover rule is post-roll and out of this producer's scope: a roll "over the
+    /// adjusted amount to hit (but less than the normal skill rating)" hits the obstacle rather than
+    /// the target, and whether the shot's damage then penetrates the cover
+    /// (<see cref="SpotRuleDecisionId.CoverPenetration"/>) or which regions the obstacle screens
+    /// with hit locations (<see cref="SpotRuleDecisionId.CoverExtent"/>) are gamemaster rulings, not
+    /// modifiers. The "attack hits the cover" band is derivable from the resolved
+    /// <see cref="ModifierChain"/> -- the interval between the Difficult effective chance and the
+    /// unmodified base chance -- by a caller that needs it.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<Modifier> Cover(SpotRuleRole role, string source = "cover")
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var label = $"{source} (Ch 7, Cover)";
+        return role switch
+        {
+            SpotRuleRole.Attacker => [DifficultyModifier.Difficult(label)],
+            SpotRuleRole.Defender => [],
+            _ => throw UnknownRole(role),
+        };
+    }
+
+    /// <summary>
+    /// The situational modifier fighting in darkness (Ch 7, "Darkness", p.169) contributes. The rule
+    /// directs the reader to the Ch 5 Situational Modifiers "Environment" row (p.133):
+    /// <see cref="DarknessSeverity.SemiDarkness"/> is -20% and <see cref="DarknessSeverity.PitchBlack"/>
+    /// is -50% (both data on <paramref name="ruleset"/>). When <paramref name="opponentDetected"/>
+    /// is true -- the character made the Difficult Sense or Listen roll to detect the opponent -- the
+    /// penalty is reduced by half (p.169), scaled by the ruleset's halving fraction and rounded
+    /// toward zero so the reduction favors the roller. Emitted as a <em>situational</em>
+    /// <see cref="AdditiveModifier"/> so the stated penalty is applied after any difficulty grade and
+    /// is not itself doubled or halved (Ch 5, p.132; ADR 0007). Role-agnostic: darkness modifies
+    /// whichever roll is made in the dark.
+    /// </summary>
+    /// <param name="severity">The darkness tier -- typically from
+    /// <see cref="ISpotRuleAdjudicator.DecideDarknessSeverity"/>.</param>
+    /// <param name="opponentDetected">Whether the Difficult Sense/Listen detection roll succeeded.</param>
+    /// <param name="ruleset">The data-defined darkness penalties and halving fraction.</param>
+    /// <param name="source">A label prefix used in the rendered chain.</param>
+    public static IReadOnlyList<Modifier> Darkness(
+        DarknessSeverity severity, bool opponentDetected, SpotRuleRuleset ruleset, string source = "darkness")
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var delta = severity switch
+        {
+            DarknessSeverity.SemiDarkness => ruleset.DarknessSemiDarknessModifier,
+            DarknessSeverity.PitchBlack => ruleset.DarknessPitchBlackModifier,
+            _ => throw new ArgumentOutOfRangeException(nameof(severity), severity, "Unknown darkness severity."),
+        };
+
+        var label = $"{source}: {(severity == DarknessSeverity.PitchBlack ? "pitch black" : "semi-darkness")} " +
+            "(Ch 7, Darkness; Ch 5, Situational Modifiers)";
+
+        if (opponentDetected)
+        {
+            // Ch 7 (p.169): "If successful, reduce the darkness modifier by half." Scale the penalty
+            // magnitude by the ruleset's fraction, truncating toward zero so the reduced penalty
+            // rounds in the roller's favor (the codebase convention for rounding a penalty), then
+            // restore the sign.
+            var magnitude = Math.Abs(delta) * ruleset.DarknessDetectionHalvingNumerator
+                / ruleset.DarknessDetectionHalvingDenominator;
+            delta = Math.Sign(delta) * magnitude;
+            label = $"{source}: {(severity == DarknessSeverity.PitchBlack ? "pitch black" : "semi-darkness")}, " +
+                "opponent detected, penalty halved (Ch 7, Darkness)";
+        }
+
+        return [new AdditiveModifier(label, delta, AdditiveKind.Situational)];
+    }
+
+    /// <summary>
+    /// The modifier(s) firing a missile weapon in or around a melee (Ch 7, "Firing Into Combat",
+    /// p.173) contributes. The book distinguishes two independent conditions, reconciling the two
+    /// earlier partial citations (ADR 0007 recorded this as Difficult; <c>AdditiveModifier</c>'s
+    /// remarks recorded it as -20%) -- both were half the rule:
+    /// <list type="bullet">
+    /// <item><paramref name="firingIntoMelee"/> -- the shot passes <em>into</em> a hand-to-hand
+    /// combat others are engaged in: "Firing a missile weapon into combat is modified by -20%" -- a
+    /// situational <see cref="AdditiveModifier"/> from <paramref name="ruleset"/>.</item>
+    /// <item><paramref name="firingWhileEngaged"/> -- the shooter is themselves engaged in melee:
+    /// "firing a missile weapon while engaged in combat is Difficult" -- a
+    /// <see cref="DifficultyModifier"/>.</item>
+    /// </list>
+    /// The book's point-blank cancellation -- "if the attacker and the target are both within close
+    /// combat range, the attack is Easy (for Point-blank Range), so the Difficult and Easy modifiers
+    /// cancel one another" -- is <em>not</em> re-emitted here: the point-blank Easy is
+    /// <see cref="RangeBandResolver"/>'s contribution (<see cref="RangeBand.PointBlank"/>), and when a
+    /// caller composes it alongside this rule's while-engaged Difficult, ADR 0007's non-stacking
+    /// collapse cancels the pair automatically. Producing the Easy here as well would double-count it.
+    /// The stray-ally risk on a roll between the skill rating and the -20% chance is the
+    /// <see cref="SpotRuleDecisionId.FiringIntoCombatStrayTarget"/> port's concern (and such a shot
+    /// earns no experience check), not a modifier.
+    /// </summary>
+    /// <param name="firingIntoMelee">Whether the shot passes into a melee others are engaged in.</param>
+    /// <param name="firingWhileEngaged">Whether the shooter is themselves engaged in melee.</param>
+    /// <param name="ruleset">The data-defined -20% firing-into-combat penalty.</param>
+    /// <param name="source">A label prefix used in the rendered chain.</param>
+    public static IReadOnlyList<Modifier> FiringIntoCombat(
+        bool firingIntoMelee, bool firingWhileEngaged, SpotRuleRuleset ruleset, string source = "firing into combat")
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var modifiers = new List<Modifier>();
+        if (firingIntoMelee)
+        {
+            modifiers.Add(new AdditiveModifier(
+                $"{source}: into a melee (Ch 7, Firing Into Combat)",
+                ruleset.FiringIntoCombatModifier,
+                AdditiveKind.Situational));
+        }
+
+        if (firingWhileEngaged)
+        {
+            modifiers.Add(DifficultyModifier.Difficult($"{source}: while engaged (Ch 7, Firing Into Combat)"));
+        }
+
+        return modifiers;
+    }
+
+    /// <summary>
+    /// Composes a roll's spot-rule contributions with its other pending modifiers through
+    /// <see cref="ModifierPipeline"/>, so ADR 0007's stage order (situational additives applied
+    /// after the difficulty grade) and difficulty non-stacking (Easy/Difficult collapse and cancel)
+    /// govern the result. A thin convenience over <see cref="ModifierPipeline.Evaluate"/> that makes
+    /// the "spot rules are ordinary pipeline modifiers" contract explicit; callers may equally
+    /// concatenate the lists and call the pipeline directly.
+    /// </summary>
+    /// <param name="baseChance">The character's current rating the modifiers apply to.</param>
+    /// <param name="spotRuleContributions">The modifiers produced by this resolver's rule methods.</param>
+    /// <param name="otherModifiers">The roll's other modifiers (range band, and so on).</param>
+    /// <param name="policy">The stage order and difficulty multipliers, or null for the default.</param>
+    public static ModifierChain Evaluate(
+        Percent baseChance,
+        IEnumerable<Modifier> spotRuleContributions,
+        IEnumerable<Modifier> otherModifiers,
+        ModifierPolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(spotRuleContributions);
+        ArgumentNullException.ThrowIfNull(otherModifiers);
+
+        return ModifierPipeline.Evaluate(baseChance, spotRuleContributions.Concat(otherModifiers), policy);
+    }
+
+    private static ArgumentOutOfRangeException UnknownKind<TKind>(TKind kind) =>
+        new(nameof(kind), kind, $"Unknown {typeof(TKind).Name}.");
+
+    private static ArgumentOutOfRangeException UnknownRole(SpotRuleRole role) =>
+        new(nameof(role), role, "Unknown spot-rule role.");
+}

--- a/src/Brp.Rules/Combat/SpotRuleRole.cs
+++ b/src/Brp.Rules/Combat/SpotRuleRole.cs
@@ -1,0 +1,16 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Which side of an interaction a spot-rule modifier is being produced for. Several Ch 7 spot
+/// rules modify the attacker's attack roll and the defender's defense roll differently in the same
+/// situation (an ambush makes the attack Easy while forbidding or hampering the defense), so the
+/// producer needs to know whose roll it is asked to modify. See <see cref="SpotRuleResolver"/>.
+/// </summary>
+public enum SpotRuleRole
+{
+    /// <summary>The character making the attack whose roll the modifier applies to.</summary>
+    Attacker,
+
+    /// <summary>The character defending (dodging or parrying) whose roll the modifier applies to.</summary>
+    Defender,
+}

--- a/src/Brp.Rules/Combat/SpotRuleRuleset.cs
+++ b/src/Brp.Rules/Combat/SpotRuleRuleset.cs
@@ -1,0 +1,88 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The data-defined percentage values the situational combat spot rules read (AGENTS.md
+/// invariant 7: rules values are data, not constants). Every value is sourced on its own member
+/// below. Loaded from <c>spot-rule-ruleset.json</c> by <c>Brp.Data.NoirSpotRuleRuleset.Load()</c>.
+/// <para>
+/// Carries only the values the book prints as <em>numbers</em>. The spot rules that work purely by
+/// difficulty grade -- Ambushes and Backstabs (Easy attacks, Difficult defenses), Cover (Difficult
+/// attacks), and firing while engaged (Difficult) -- contribute
+/// <see cref="Brp.Core.Modifiers.DifficultyModifier"/>s, whose Easy/Difficult multipliers already
+/// live as data on <see cref="Brp.Core.Modifiers.ModifierPolicy"/>; they need no per-rule number
+/// here. See <see cref="SpotRuleResolver"/> and <c>docs/decisions/0018-spot-rules.md</c>.
+/// </para>
+/// </summary>
+public sealed class SpotRuleRuleset
+{
+    /// <summary>Creates a spot-rule ruleset from data-defined values.</summary>
+    public SpotRuleRuleset(
+        int firingIntoCombatModifier,
+        int darknessSemiDarknessModifier,
+        int darknessPitchBlackModifier,
+        int darknessDetectionHalvingNumerator,
+        int darknessDetectionHalvingDenominator)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(
+            firingIntoCombatModifier, 0, nameof(firingIntoCombatModifier));
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(
+            darknessSemiDarknessModifier, 0, nameof(darknessSemiDarknessModifier));
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(
+            darknessPitchBlackModifier, 0, nameof(darknessPitchBlackModifier));
+
+        // Pitch black must be the more severe (more negative) penalty than semi-darkness; the
+        // book prints them as distinct Environment tiers (Ch 5, p.133) and darkness-severity keys
+        // on the difference.
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(
+            darknessPitchBlackModifier, darknessSemiDarknessModifier, nameof(darknessPitchBlackModifier));
+
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            darknessDetectionHalvingNumerator, nameof(darknessDetectionHalvingNumerator));
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            darknessDetectionHalvingDenominator, nameof(darknessDetectionHalvingDenominator));
+
+        FiringIntoCombatModifier = firingIntoCombatModifier;
+        DarknessSemiDarknessModifier = darknessSemiDarknessModifier;
+        DarknessPitchBlackModifier = darknessPitchBlackModifier;
+        DarknessDetectionHalvingNumerator = darknessDetectionHalvingNumerator;
+        DarknessDetectionHalvingDenominator = darknessDetectionHalvingDenominator;
+    }
+
+    /// <summary>
+    /// Ch 7: Spot Rules, "Firing Into Combat" (p.173): "Firing a missile weapon into combat is
+    /// modified by -20%." The flat situational penalty for a shot passing into a melee others are
+    /// engaged in -- distinct from firing <em>while engaged</em> oneself, which is a Difficult
+    /// grade rather than this additive penalty (see <see cref="SpotRuleResolver.FiringIntoCombat"/>).
+    /// Stored as the signed penalty (-20), applied as a situational
+    /// <see cref="Brp.Core.Modifiers.AdditiveModifier"/> so its stated weight is not itself halved
+    /// by any difficulty grade in play (Ch 5, "Modifying Action Rolls", p.132; ADR 0007).
+    /// </summary>
+    public int FiringIntoCombatModifier { get; }
+
+    /// <summary>
+    /// Ch 7, "Darkness" (p.169) directs the reader to the Ch 5 Situational Modifiers table for the
+    /// modifier; the Environment tier "Unpleasant or unsanitary conditions, unsteady footing,
+    /// darkness, bad weather, etc." is -20% (Ch 5, p.133). Applied for
+    /// <see cref="Brp.Core.Contests.DarknessSeverity.SemiDarkness"/>.
+    /// </summary>
+    public int DarknessSemiDarknessModifier { get; }
+
+    /// <summary>
+    /// Ch 5 Situational Modifiers, Environment tier "Distracting environment, highly unstable
+    /// ground, pitch black, stormy, etc." at -50% (p.133), reached from Ch 7, "Darkness" (p.169).
+    /// Applied for <see cref="Brp.Core.Contests.DarknessSeverity.PitchBlack"/>.
+    /// </summary>
+    public int DarknessPitchBlackModifier { get; }
+
+    /// <summary>
+    /// Ch 7, "Darkness" (p.169): "To detect an opponent in complete darkness, you must make a
+    /// successful Difficult Sense or Listen roll. If successful, reduce the darkness modifier by
+    /// half." The fraction the darkness penalty is scaled by once the opponent is detected;
+    /// numerator of 1 over <see cref="DarknessDetectionHalvingDenominator"/> of 2 gives "by half."
+    /// Kept as data so a campaign could tune the fraction without touching code.
+    /// </summary>
+    public int DarknessDetectionHalvingNumerator { get; }
+
+    /// <summary>See <see cref="DarknessDetectionHalvingNumerator"/>.</summary>
+    public int DarknessDetectionHalvingDenominator { get; }
+}

--- a/tests/Brp.Core.Tests/Contests/SpotRuleAdjudicatorTests.cs
+++ b/tests/Brp.Core.Tests/Contests/SpotRuleAdjudicatorTests.cs
@@ -1,0 +1,77 @@
+using Brp.Core.Contests;
+
+namespace Brp.Core.Tests.Contests;
+
+/// <summary>
+/// Covers the named gamemaster-discretion ports for the Ch 7 situational combat spot rules: the
+/// canonical decision ids, the documented neutral defaults of <see cref="DefaultSpotRuleAdjudicator"/>,
+/// and that a deterministic stub can drive every port for replayable tests. See
+/// <c>docs/decisions/0018-spot-rules.md</c>.
+/// </summary>
+public class SpotRuleAdjudicatorTests
+{
+    [Theory]
+    [InlineData(SpotRuleDecisionId.CoverPenetration, "cover-penetration")]
+    [InlineData(SpotRuleDecisionId.CoverExtent, "cover-extent")]
+    [InlineData(SpotRuleDecisionId.DarknessSeverity, "darkness-severity")]
+    [InlineData(SpotRuleDecisionId.BackstabHelplessReprieve, "backstab-helpless-reprieve")]
+    [InlineData(SpotRuleDecisionId.FiringIntoCombatStrayTarget, "firing-into-combat-stray-target")]
+    public void Every_decision_id_has_its_canonical_kebab_case_string(SpotRuleDecisionId id, string expected)
+    {
+        Assert.Equal(expected, SpotRuleDecisionIds.CanonicalId(id));
+    }
+
+    [Fact]
+    public void The_five_named_discretion_points_are_exactly_those_issue_50_calls_out()
+    {
+        Assert.Equal(5, Enum.GetValues<SpotRuleDecisionId>().Length);
+    }
+
+    [Fact]
+    public void The_default_adjudicator_returns_the_documented_minimal_assumption_answers()
+    {
+        var adjudicator = new DefaultSpotRuleAdjudicator();
+
+        Assert.Equal(DarknessSeverity.SemiDarkness, adjudicator.DecideDarknessSeverity());
+        Assert.Equal(CoverPenetrationRuling.StoppedByCover, adjudicator.DecideCoverPenetration());
+        Assert.Equal(CoverExtentRuling.PartiallyProtected, adjudicator.DecideCoverExtent());
+        Assert.Equal(HelplessReprieveRuling.NoReprieve, adjudicator.DecideBackstabHelplessReprieve());
+        Assert.Null(adjudicator.DecideFiringIntoCombatStrayTarget(bystanderCount: 3).StruckBystanderIndex);
+    }
+
+    [Fact]
+    public void A_deterministic_stub_drives_every_port_with_scripted_answers()
+    {
+        ISpotRuleAdjudicator adjudicator = new ScriptedSpotRuleAdjudicator(
+            darkness: DarknessSeverity.PitchBlack,
+            coverPenetration: CoverPenetrationRuling.PenetratesToTarget,
+            coverExtent: CoverExtentRuling.FullyProtected,
+            reprieve: HelplessReprieveRuling.ReprievedThisRound,
+            strayTargetIndex: 1);
+
+        Assert.Equal(DarknessSeverity.PitchBlack, adjudicator.DecideDarknessSeverity());
+        Assert.Equal(CoverPenetrationRuling.PenetratesToTarget, adjudicator.DecideCoverPenetration());
+        Assert.Equal(CoverExtentRuling.FullyProtected, adjudicator.DecideCoverExtent());
+        Assert.Equal(HelplessReprieveRuling.ReprievedThisRound, adjudicator.DecideBackstabHelplessReprieve());
+        Assert.Equal(1, adjudicator.DecideFiringIntoCombatStrayTarget(bystanderCount: 3).StruckBystanderIndex);
+    }
+
+    /// <summary>A deterministic test double returning pre-scripted rulings for each port.</summary>
+    private sealed class ScriptedSpotRuleAdjudicator(
+        DarknessSeverity darkness,
+        CoverPenetrationRuling coverPenetration,
+        CoverExtentRuling coverExtent,
+        HelplessReprieveRuling reprieve,
+        int? strayTargetIndex) : ISpotRuleAdjudicator
+    {
+        public DarknessSeverity DecideDarknessSeverity() => darkness;
+
+        public CoverPenetrationRuling DecideCoverPenetration() => coverPenetration;
+
+        public CoverExtentRuling DecideCoverExtent() => coverExtent;
+
+        public HelplessReprieveRuling DecideBackstabHelplessReprieve() => reprieve;
+
+        public StrayTargetRuling DecideFiringIntoCombatStrayTarget(int bystanderCount) => new(strayTargetIndex);
+    }
+}

--- a/tests/Brp.Data.Tests/NoirSpotRuleRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirSpotRuleRulesetTests.cs
@@ -1,0 +1,50 @@
+using Brp.Rules.Combat;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped spot-rule data loads and reproduces every printed percentage value of the
+/// in-scope Ch 7 situational combat spot rules -- one case per printed figure rather than sampled,
+/// per AGENTS.md's "table-backed rule" convention. Sources: Ch 7, "Firing Into Combat" (p.173) and
+/// "Darkness" (p.169, drawing on the Ch 5 Situational Modifiers "Environment" row, p.133). See
+/// <c>docs/decisions/0018-spot-rules.md</c>.
+/// </summary>
+public class NoirSpotRuleRulesetTests
+{
+    private static readonly SpotRuleRuleset Ruleset = NoirSpotRuleRuleset.Load();
+
+    public static IEnumerable<object[]> PrintedValues()
+    {
+        // (label, actual, expected) -- every number the book prints for the in-scope spot rules.
+        yield return new object[] { "firing into combat -20% (Ch 7, p.173)", Ruleset.FiringIntoCombatModifier, -20 };
+        yield return new object[] { "darkness / semi-darkness -20% (Ch 5, p.133)", Ruleset.DarknessSemiDarknessModifier, -20 };
+        yield return new object[] { "pitch black -50% (Ch 5, p.133)", Ruleset.DarknessPitchBlackModifier, -50 };
+        yield return new object[] { "darkness detection halving numerator (Ch 7, p.169)", Ruleset.DarknessDetectionHalvingNumerator, 1 };
+        yield return new object[] { "darkness detection halving denominator (Ch 7, p.169)", Ruleset.DarknessDetectionHalvingDenominator, 2 };
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintedValues))]
+    public void Every_printed_spot_rule_value_matches_the_book(string label, int actual, int expected)
+    {
+        Assert.Equal(expected, actual);
+        Assert.False(string.IsNullOrWhiteSpace(label));
+    }
+
+    [Fact]
+    public void The_shipped_ruleset_carries_exactly_the_five_printed_values()
+    {
+        Assert.Equal(5, PrintedValues().Count());
+    }
+
+    [Fact]
+    public void The_shipped_data_loads_without_throwing()
+    {
+        // A validating constructor (SpotRuleRuleset) means a bad transcription -- a positive
+        // penalty, or pitch black milder than semi-darkness -- fails to load rather than shipping.
+        var ruleset = NoirSpotRuleRuleset.Load();
+
+        Assert.NotNull(ruleset);
+        Assert.True(ruleset.DarknessPitchBlackModifier < ruleset.DarknessSemiDarknessModifier);
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/SpotRuleResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/SpotRuleResolverTests.cs
@@ -1,0 +1,234 @@
+using Brp.Core.Contests;
+using Brp.Core.Modifiers;
+using Brp.Core.Primitives;
+using Brp.Core.Resolution;
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Covers the five in-scope situational combat spot rules against Ch 7: Spot Rules -- Ambushes
+/// (p.162), Backstabs and Helpless Opponents (p.164), Cover (p.169), Darkness (p.169), and Firing
+/// Into Combat (p.173) -- as ordinary modifier producers feeding ADR 0007's pipeline. See
+/// <c>docs/decisions/0018-spot-rules.md</c>.
+/// </summary>
+public class SpotRuleResolverTests
+{
+    // Constructed inline from the book's literal values so a change to the shipped data cannot
+    // silently rewrite what these logic tests assert (the data itself is pinned by
+    // NoirSpotRuleRulesetTests).
+    private static readonly SpotRuleRuleset Ruleset = new(
+        firingIntoCombatModifier: -20,
+        darknessSemiDarknessModifier: -20,
+        darknessPitchBlackModifier: -50,
+        darknessDetectionHalvingNumerator: 1,
+        darknessDetectionHalvingDenominator: 2);
+
+    private static readonly Modifier[] NoOtherModifiers = [];
+
+    // ---- Ambushes (Ch 7, p.162) -------------------------------------------------------------
+
+    [Theory]
+    // (kind, role, expectsEasy, expectsDifficult, expectsImpossibleGate, expectsEmpty)
+    [InlineData(AmbushKind.MissileUnseen, SpotRuleRole.Attacker, true, false, false, false)]
+    [InlineData(AmbushKind.MissileSeen, SpotRuleRole.Attacker, true, false, false, false)]
+    [InlineData(AmbushKind.HandToHandTargetUnaware, SpotRuleRole.Attacker, true, false, false, false)]
+    [InlineData(AmbushKind.HandToHandTargetAware, SpotRuleRole.Attacker, false, false, false, true)]
+    [InlineData(AmbushKind.MissileUnseen, SpotRuleRole.Defender, false, false, true, false)]
+    [InlineData(AmbushKind.MissileSeen, SpotRuleRole.Defender, false, false, false, true)]
+    [InlineData(AmbushKind.HandToHandTargetUnaware, SpotRuleRole.Defender, false, true, false, false)]
+    [InlineData(AmbushKind.HandToHandTargetAware, SpotRuleRole.Defender, false, false, false, true)]
+    public void Ambush_produces_the_book_modifier_per_case_and_role(
+        AmbushKind kind, SpotRuleRole role, bool expectsEasy, bool expectsDifficult, bool expectsImpossibleGate, bool expectsEmpty)
+    {
+        var modifiers = SpotRuleResolver.Ambush(kind, role);
+
+        AssertGrade(modifiers, expectsEasy, expectsDifficult, expectsImpossibleGate, expectsEmpty);
+    }
+
+    [Fact]
+    public void Ambush_missile_unseen_makes_the_attack_easy_and_forbids_the_defense()
+    {
+        // Ch 7, "Ambushes" (p.162): "the attackers get a free round of Easy attacks. The target(s)
+        // cannot dodge or parry this initial round of attacks."
+        var attack = SpotRuleResolver.Ambush(AmbushKind.MissileUnseen, SpotRuleRole.Attacker);
+        var defense = SpotRuleResolver.Ambush(AmbushKind.MissileUnseen, SpotRuleRole.Defender);
+
+        Assert.Equal(DifficultyDirection.Easier, Assert.Single(attack.OfType<DifficultyModifier>()).Direction);
+
+        var defenseChain = SpotRuleResolver.Evaluate(Percent.Of(60), defense, NoOtherModifiers);
+        Assert.True(defenseChain.IsGated);
+        Assert.Equal(GateKind.Impossible, defenseChain.Gate);
+    }
+
+    // ---- Backstabs and Helpless Opponents (Ch 7, p.164) -------------------------------------
+
+    [Theory]
+    [InlineData(BackstabKind.UnprotectedBack, true)]
+    [InlineData(BackstabKind.Helpless, true)]
+    public void Backstab_attack_is_always_easy(BackstabKind kind, bool expectsEasy)
+    {
+        // Ch 7, "Backstabs and Helpless Opponents" (p.164): the unprotected-back attack and the
+        // helpless-target attack are both Easy. "No additional damage is done by such an attack" --
+        // the Easy grade is the whole benefit, not a damage bonus (damage is out of scope).
+        var modifiers = SpotRuleResolver.Backstab(kind, SpotRuleRole.Attacker);
+
+        Assert.Equal(expectsEasy, modifiers.OfType<DifficultyModifier>().Any(d => d.Direction == DifficultyDirection.Easier));
+    }
+
+    [Fact]
+    public void Backstab_unprotected_back_gives_a_difficult_defense_only_when_the_target_detects_the_attacker()
+    {
+        // Ch 7 (p.164): "If the target succeeds in a Difficult Listen or Sense roll, they can make a
+        // Difficult Dodge or parry attempt" -- otherwise the undetected target gets no defense.
+        var detected = SpotRuleResolver.Backstab(BackstabKind.UnprotectedBack, SpotRuleRole.Defender, defenderDetectedAttacker: true);
+        var undetected = SpotRuleResolver.Backstab(BackstabKind.UnprotectedBack, SpotRuleRole.Defender, defenderDetectedAttacker: false);
+
+        Assert.Equal(DifficultyDirection.Harder, Assert.Single(detected.OfType<DifficultyModifier>()).Direction);
+        Assert.Equal(GateKind.Impossible, Assert.Single(undetected.OfType<GateModifier>()).Kind);
+    }
+
+    [Fact]
+    public void Backstab_helpless_target_cannot_defend_regardless_of_detection()
+    {
+        // Ch 7 (p.164): a helpless target "cannot make a dodge or parry attempt against the attack."
+        var detected = SpotRuleResolver.Backstab(BackstabKind.Helpless, SpotRuleRole.Defender, defenderDetectedAttacker: true);
+        var undetected = SpotRuleResolver.Backstab(BackstabKind.Helpless, SpotRuleRole.Defender, defenderDetectedAttacker: false);
+
+        Assert.Equal(GateKind.Impossible, Assert.Single(detected.OfType<GateModifier>()).Kind);
+        Assert.Equal(GateKind.Impossible, Assert.Single(undetected.OfType<GateModifier>()).Kind);
+    }
+
+    // ---- Cover (Ch 7, p.169) ----------------------------------------------------------------
+
+    [Fact]
+    public void Cover_makes_the_attack_difficult_and_the_book_example_halves_a_72_percent_rating_to_36()
+    {
+        // Ch 7, "Cover" (p.169): "any attacks on that target are Difficult... Their normal skill
+        // rating is 72%, reduced by half to 36% because the task is Difficult." Cover is not a
+        // defensive roll, so the defender contributes nothing.
+        var attack = SpotRuleResolver.Cover(SpotRuleRole.Attacker);
+        var defense = SpotRuleResolver.Cover(SpotRuleRole.Defender);
+
+        Assert.Equal(DifficultyDirection.Harder, Assert.Single(attack.OfType<DifficultyModifier>()).Direction);
+        Assert.Empty(defense);
+
+        var chain = SpotRuleResolver.Evaluate(Percent.Of(72), attack, NoOtherModifiers);
+        Assert.Equal(Percent.Of(36), chain.EffectiveChance); // the book's worked example
+    }
+
+    // ---- Darkness (Ch 7, p.169; Ch 5 Situational Modifiers, p.133) --------------------------
+
+    [Theory]
+    // (severity, opponentDetected, expectedDelta)
+    [InlineData(DarknessSeverity.SemiDarkness, false, -20)] // Ch 5 Environment tier, p.133
+    [InlineData(DarknessSeverity.PitchBlack, false, -50)]   // Ch 5 Environment tier, p.133
+    [InlineData(DarknessSeverity.SemiDarkness, true, -10)]  // Ch 7 p.169: "reduce the darkness modifier by half"
+    [InlineData(DarknessSeverity.PitchBlack, true, -25)]
+    public void Darkness_produces_the_situational_penalty_and_halves_it_when_the_opponent_is_detected(
+        DarknessSeverity severity, bool opponentDetected, int expectedDelta)
+    {
+        var modifiers = SpotRuleResolver.Darkness(severity, opponentDetected, Ruleset);
+
+        var additive = Assert.Single(modifiers.OfType<AdditiveModifier>());
+        Assert.Equal(expectedDelta, additive.Delta);
+        Assert.Equal(AdditiveKind.Situational, additive.Kind); // applied after any difficulty grade (Ch 5, p.132)
+    }
+
+    [Fact]
+    public void Darkness_penalty_is_situational_so_it_is_not_halved_by_a_difficult_grade_in_play()
+    {
+        // ADR 0007 / Ch 5 (p.132): a situational modifier is applied AFTER the difficulty grade, so
+        // a -20% darkness penalty stays -20 even when the same roll is also Difficult (e.g. cover).
+        // 65 -> ceil(65/2)=33 (Difficult) -> 33-20=13, not 65-20=45 then halved to 23.
+        var darkness = SpotRuleResolver.Darkness(DarknessSeverity.SemiDarkness, opponentDetected: false, Ruleset);
+        var cover = SpotRuleResolver.Cover(SpotRuleRole.Attacker);
+
+        var chain = SpotRuleResolver.Evaluate(Percent.Of(65), darkness, cover);
+
+        Assert.Equal(Percent.Of(13), chain.EffectiveChance);
+    }
+
+    // ---- Firing Into Combat (Ch 7, p.173) ---------------------------------------------------
+
+    [Theory]
+    // (firingIntoMelee, firingWhileEngaged, expectsMinus20, expectsDifficult)
+    [InlineData(true, false, true, false)]  // into a melee: -20%
+    [InlineData(false, true, false, true)]  // while engaged: Difficult
+    [InlineData(true, true, true, true)]    // both conditions at once
+    [InlineData(false, false, false, false)]
+    public void Firing_into_combat_distinguishes_into_a_melee_from_firing_while_engaged(
+        bool firingIntoMelee, bool firingWhileEngaged, bool expectsMinus20, bool expectsDifficult)
+    {
+        var modifiers = SpotRuleResolver.FiringIntoCombat(firingIntoMelee, firingWhileEngaged, Ruleset);
+
+        Assert.Equal(expectsMinus20, modifiers.OfType<AdditiveModifier>().Any(a => a.Delta == -20));
+        Assert.Equal(
+            expectsDifficult,
+            modifiers.OfType<DifficultyModifier>().Any(d => d.Direction == DifficultyDirection.Harder));
+    }
+
+    [Fact]
+    public void Firing_while_engaged_difficult_is_cancelled_by_a_point_blank_easy_when_both_in_close_range()
+    {
+        // Ch 7, "Firing Into Combat" (p.173): "if the attacker and the target are both within close
+        // combat range, the attack is Easy (for Point-blank Range), so the Difficult and Easy
+        // modifiers cancel one another." This resolver PRODUCES the while-engaged Difficult; the
+        // point-blank Easy is RangeBandResolver's contribution (RangeBand.PointBlank). Composed
+        // together, ADR 0007's non-stacking collapse cancels the pair -- reconciling the same
+        // mechanic RangeBandResolverTests.Point_blank_and_a_difficult_condition_cancel_pairwise
+        // hand-rolls, without duplicating it.
+        var firing = SpotRuleResolver.FiringIntoCombat(firingIntoMelee: false, firingWhileEngaged: true, Ruleset);
+        var pointBlank = RangeBandResolver.Resolve(
+            RangeBand.PointBlank, Percent.Of(65), NoOtherModifiers, aimedWithTargetingEquipment: false,
+            new RangeBandRuleset(3, 2, 1, 5, 2, 1, 2));
+        var pointBlankModifiers = Assert.IsType<RangeBandOutcome.Composable>(pointBlank).Modifiers;
+
+        var chain = SpotRuleResolver.Evaluate(Percent.Of(65), firing, pointBlankModifiers);
+
+        Assert.Equal(Percent.Of(65), chain.EffectiveChance); // Difficult and Easy cancel
+    }
+
+    [Fact]
+    public void Firing_into_a_melee_minus_20_is_the_situational_penalty_the_pipeline_applies_last()
+    {
+        var firing = SpotRuleResolver.FiringIntoCombat(firingIntoMelee: true, firingWhileEngaged: false, Ruleset);
+
+        var chain = SpotRuleResolver.Evaluate(Percent.Of(65), firing, NoOtherModifiers);
+
+        Assert.Equal(Percent.Of(45), chain.EffectiveChance); // 65 - 20
+    }
+
+    // ---- Composition and deterministic resolution -------------------------------------------
+
+    [Fact]
+    public void A_spot_rule_modified_chain_resolves_a_fixed_roll_deterministically()
+    {
+        // Wire the whole path: a darkness situational penalty through the pipeline, then a single
+        // scripted percentile via FixedEntropySource (AGENTS.md invariant 5: seeded, replayable).
+        var darkness = SpotRuleResolver.Darkness(DarknessSeverity.SemiDarkness, opponentDetected: false, Ruleset);
+        var chain = SpotRuleResolver.Evaluate(Percent.Of(65), darkness, NoOtherModifiers);
+        Assert.Equal(Percent.Of(45), chain.EffectiveChance);
+
+        var entropy = new FixedEntropySource(10);
+        var outcome = chain.Resolve(printedBaseChance: Percent.Of(25), entropy);
+
+        Assert.NotNull(outcome);
+        Assert.Equal(SuccessLevel.Success, outcome!.Level); // 10 <= 45, a normal success
+        Assert.Equal(1, entropy.DrawCount);
+    }
+
+    private static void AssertGrade(
+        IReadOnlyList<Modifier> modifiers, bool expectsEasy, bool expectsDifficult, bool expectsImpossibleGate, bool expectsEmpty)
+    {
+        if (expectsEmpty)
+        {
+            Assert.Empty(modifiers);
+            return;
+        }
+
+        Assert.Equal(expectsEasy, modifiers.OfType<DifficultyModifier>().Any(d => d.Direction == DifficultyDirection.Easier));
+        Assert.Equal(expectsDifficult, modifiers.OfType<DifficultyModifier>().Any(d => d.Direction == DifficultyDirection.Harder));
+        Assert.Equal(expectsImpossibleGate, modifiers.OfType<GateModifier>().Any(g => g.Kind == GateKind.Impossible));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #50

## Exact behavioral claim

Common tactical combat situations now contribute **named situational modifiers** into the
existing ADR-0007 modifier pipeline through a pluggable spot-rule mechanism: `SpotRuleResolver`
emits `DifficultyModifier`/`AdditiveModifier`/`GateModifier` contributions for **ambush,
backstab/helpless, cover, darkness, and firing-into-combat**, and every Ch 7 "at the
gamemaster's discretion" point is a first-class `ISpotRuleAdjudicator` decision id rather than a
silent hardcode. This is Layer 4 piece F (deferred to here by ADR 0015 and 0016). It prevents the
gap where combat could express range/round/matrix but not the everyday facts that change a roll
(cover, darkness, ambush, firing into a melee).

## Scope

Adds the spot-rule mechanism and the five **situational** combat rules only. New: the adjudicator
port (`src/Brp.Core/Contests/ISpotRuleAdjudicator.cs`), the ruleset + resolver + enums
(`src/Brp.Rules/Combat/SpotRule*.cs`, `AmbushKind`, `BackstabKind`), the data (`spot-rule-ruleset.json`
+ `NoirSpotRuleRuleset` loader, registered in `Brp.Data.csproj`), ADR 0018, and tests. Spot rules
are pre-roll `Modifier` producers only — they do not touch the attack/defense matrix or the round
scaffold. "Firing into combat" is *produced* here for real, reconciling the two prior citations
(ADR 0007's Difficult, `AdditiveModifier`'s −20%); the existing hand-rolled
`RangeBandResolverTests` strings are left green.

## Rules conformance

Source: **Ch 7 (Spot Rules)** of `BasicRoleplaying-ORC-Content-Document.pdf`, drawing on the Ch 5
Situational Modifiers table for the darkness percentages. Verified adversarially by the
`rules-conformance` pass against the printed text (not the issue):

- **Ambush** — attack **Easy**; defense forbidden (missile unseen), Difficult (H2H vs unaware), or normal (target aware). *Ch 7 "Ambushes", p.162.*
- **Backstab / helpless** — attack **Easy**, **no bonus damage**; defense Difficult only if the target made a Difficult Listen/Sense, else forbidden; helpless = no defense. *Ch 7 "Backstabs and Helpless Opponents", p.164.*
- **Cover** — attacks **Difficult**; the printed 72% → 36% worked example is pinned in a test. *Ch 7 "Cover", p.169.*
- **Darkness** — situational **−20%** (semi-darkness) / **−50%** (pitch black) from the Ch 5 "Environment" tier (which literally lists "darkness" −20% and "pitch black" −50%, p.133); **halved** when the opponent is detected via a Difficult Sense/Listen. *Ch 7 "Darkness", p.169 → Ch 5 p.133.*
- **Firing into combat** — **−20%** firing *into* a melee; **Difficult** firing *while engaged*; Easy point-blank cancels the Difficult via ADR-0007 non-stacking (not re-emitted here). *Ch 7 "Firing Into Combat", p.173.*

All modifier values live in `spot-rule-ruleset.json` (invariant 7); the data test
(`NoirSpotRuleRulesetTests`) reproduces the printed figures with an exact-count `[Fact]`. Difficulty
grades reuse `ModifierPolicy` (Easy ×2, Difficult ÷2 round up) rather than re-encoding the grade math.

## Tests and evidence

- `dotnet build NoiRPG.slnx` → Build succeeded, **0 warnings** (warnings-as-errors), 0 errors.
- `dotnet test NoiRPG.slnx --no-build` → **2013 passed, 0 failed** (Brp.Core 1526, Brp.Rules 219, Brp.Data 217, Brp.Cli 51) — +41 over the 1972 baseline. Re-run independently by the orchestrator, not just the implementer.
- `dotnet format NoiRPG.slnx --verify-no-changes` → exit 0.
- New tests: per-printed-row data tests + per-rule resolver tests, each cited to a Ch 7 page, deterministic rolls via the existing `FixedEntropySource`.

## Decisions and tradeoffs

- Spot rules are **Modifier producers** into ADR 0007, mirroring `RangeBandResolver` — no new resolution path, so they collapse correctly (difficulty non-stacking, situational-after-difficulty ordering).
- Discretion points (`cover-penetration`, `cover-extent`, `darkness-severity`, `backstab-helpless-reprieve`, `firing-into-combat-stray-target`) are named `ISpotRuleAdjudicator` decision ids with default minimal-assumption rulings; return types live in `Brp.Core.Contests` to preserve layer direction.
- The darkness detection-halving is applied to semi-darkness as well as pitch black — a roller-favoring **house generalization**, now marked explicitly in ADR 0018 per the sourced/house discipline (raised by the conformance review).

## Known limitations

- Post-roll / turn-economy effects are **named but not wired into a running encounter**: ambush "cannot retaliate/move next round", the cover obstacle-hit band, cover-penetration damage, firing stray-target Luck rolls, and the helpless-reprieve POW×1. These are deliberate caller seams (same pattern as ADR 0015/0016), routed through the ports and documented in the ADR — not silent gaps.
- Injury/environmental spot rules (falling, poison, disease) are the **sibling issue** and are excluded here (they deal damage/drain, not roll modifiers). Fumble tables, fatigue, dying blows, and aging are out of scope per the acceptance criteria.

## Agent provenance

Implemented by a build agent acting as the repo's **`engine-dev`** (Claude, via Claude Code), from a
cited Ch 7 source extract and an architecture map. Verified by adversarial **`rules-conformance`**
(every modifier value + citation checked against the printed book — PASS) and **`scope-warden`**
(no out-of-scope/injury/damage content, data-driven, discretion via ports, layer invariants — PASS).
Orchestrated at the repository owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
