### PR TITLE
Fix stale State of the code in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,18 +86,23 @@ If you discover unrelated work, file a separate Issue. Do not enlarge the curren
 
 ## State of the code
 
-`Brp.Core` holds Layer 0, complete: seeded dice (`Dice/`, `Randomness/`), the five-grade
-resolution kernel (`Resolution/`), the modifier pipeline (`Modifiers/`), and resistance
-and opposed rolls (`Contests/`). Layer 1 (`Abilities/`) adds data-defined
-characteristics, characteristic rolls, and live derived values. `Brp.Data` supplies
-the ability ruleset JSON. The solution has 1,972 tests, including printed tables
-reproduced cell by cell.
+The BRP engine is built through Layer 4. `Brp.Core` (Layers 0–2) holds seeded dice
+(`Dice/`, `Randomness/`), the five-grade resolution kernel (`Resolution/`), the modifier
+pipeline (`Modifiers/`), resistance and opposed rolls (`Contests/`), data-defined
+characteristics with live-recomputing derived values (`Abilities/`), and the skill system
+(`Skills/`). `Brp.Rules` (Layers 3–4) adds characters — point-buy creation and tick-on-use
+experience — and combat: range bands, the combat round, the attack/defense matrix, gear,
+damage/wounds, and situational spot rules (`Combat/`). `Brp.Data` supplies the ruleset JSON.
+The solution has 2,013 tests, including printed tables reproduced cell by cell.
 
 `tools/Brp.Cli` is the `brp` command line over that kernel — one command, `roll`, which
 resolves a check and prints its whole derivation. It has its own `AGENTS.md`.
 
-Nothing above Layer 1 exists yet. See `engine-implementation-plan.md` §3 for the layer
-map — the *structure* there is sound even though its formulas are not.
+**What's left** — see [`ROADMAP.md`](ROADMAP.md) for the ordered plan. Layer 4 is nearly
+complete: injury/environmental spot rules (#96) and the fumble tables (#97) remain. Layer 5 —
+the noir game layer (cases, clue-routing, interrogation) — has not started (epic #98).
+`engine-implementation-plan.md` §3 has the layer map — the *structure* there is sound even
+though its formulas are not.
 
 ## Commands
 


### PR DESCRIPTION
## Linked Issue

Closes #106

## Exact behavioral claim

`AGENTS.md`'s "State of the code" now matches reality: it no longer claims "Nothing above
Layer 1 exists yet" (Layers 2–4 are built) or "1,972 tests" (now 2,013), and it points to
`ROADMAP.md`. An agent reading `AGENTS.md` first gets an accurate picture of what exists and
what's next instead of a description that contradicts the roadmap.

## Scope

Rewrites one paragraph of `AGENTS.md` (the "State of the code" section). No code, no other docs.

## Rules conformance

N/A — documentation only; no files under `src/Brp.*` are touched.

## Tests and evidence

- `dotnet test NoiRPG.slnx` on `main` → 2,013 total (Brp.Core 1526, Brp.Rules 219, Brp.Data 217, Brp.Cli 51) — the figure written into the section.
- Cross-checked the layer claims against merged issues: skills, characters (#40), combat round (#47), attack/defense (#49), damage (#52), spot rules (#50) all closed.

## Decisions and tradeoffs

Kept the section short (the file asks to) and deferred the ordered detail to `ROADMAP.md` rather
than duplicating it, so the two don't drift.

## Known limitations

The test count and layer status are a hand-maintained snapshot; they must be updated as work lands
(the same caveat as ROADMAP.md's "you are here").

## Agent provenance

Authored by Claude (Opus 4.8) via Claude Code, at the repository owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
