### PR TITLE
Add Ch 7 injury/effect spot rules: falling, poison, disease

### DIFF
--- a/docs/decisions/0019-injury-spot-rules.md
+++ b/docs/decisions/0019-injury-spot-rules.md
@@ -11,14 +11,14 @@ Together #50 and #96 complete the Ch 7 spot-rules surface for Layer 4.
 ## Context
 
 Ch 7: Spot Rules collects situational rules of two natures. #50 delivered nature (a): rules that
-modify an action roll. This record covers nature (b): rules that inflict harm — **Falling** (p.171),
-**Poison** and **Poison Antidotes** (pp.175-176), and **Disease** with the **Illness Severity Table**
-(pp.169-170). These do not touch the modifier pipeline; they remove hit points or lower a
+modify an action roll. This record covers nature (b): rules that inflict harm — **Falling** (pp.171-172),
+**Poison** and **Poison Antidotes** (p.176), and **Disease** with the **Illness Severity Table**
+(p.170). These do not touch the modifier pipeline; they remove hit points or lower a
 characteristic, and a lowered characteristic must recompute its derived values (hit points, major
 wound level, category modifiers) rather than being baked (AGENTS.md; ADR 0008's live-recompute
 `AbilitySet`).
 
-Ch 7 (pp.169-176) and the associated Ch 2 hit-point rules are the sole sources consulted. Each value
+Ch 7 (pp.170-176) and the associated Ch 2 hit-point rules are the sole sources consulted. Each value
 below was verified against the printed book text, not the issue or `engine-implementation-plan.md`
 (AGENTS.md invariant 2).
 
@@ -58,16 +58,16 @@ row-by-row in tests (`NoirInjuryRulesetTests`).
 | **Falling — force** | dice rolled doubled when thrown with considerable force | Ch 7, p.171 — **sourced** |
 | **Falling — small SIZ** | SIZ ≤ 5: reduce damage by 1D6 | Ch 7, p.171 — **sourced** |
 | **Falling — large SIZ** | SIZ > 20: +1D6, and another 1D6 per fraction of 20 above, cumulative with force | Ch 7, p.171 — **sourced** (band interpretation is a house reading, below) |
-| **Falling — armor** | half protection up to 3 m | Ch 7, p.171 — **sourced** (armor beyond 3 m is a house reading, below) |
-| **Poison — overcome** | overcomes CON → full POT as damage | Ch 7, "Poison", p.175 — **sourced** |
-| **Poison — resisted** | does not overcome CON → half POT, round up | Ch 7, p.175 — **sourced** |
-| **Poison — target** | damage to total HP or to a characteristic | Ch 7, p.175 — **sourced** |
-| **Poison — onset** | 3 combat rounds (fast) / 3 full turns (slow) default | Ch 7, p.175 — **sourced** |
-| **Poison — two doses** | two doses = two separate resistance rolls | Ch 7, p.175 — **sourced** |
+| **Falling — armor** | half protection up to 3 m | Ch 7, p.172 — **sourced** (armor beyond 3 m is a house reading, below) |
+| **Poison — overcome** | overcomes CON → full POT as damage | Ch 7, "Poison", p.176 — **sourced** |
+| **Poison — resisted** | does not overcome CON → half POT, round up | Ch 7, p.176 — **sourced** |
+| **Poison — target** | damage to total HP or to a characteristic | Ch 7, p.176 — **sourced** |
+| **Poison — onset** | 3 combat rounds (fast) / 3 full turns (slow) default | Ch 7, p.176 — **sourced** |
+| **Poison — two doses** | two doses = two separate resistance rolls | Ch 7, p.176 — **sourced** |
 | **Antidote** | POT taken ≤ 6 full turns before poisoning subtracts from poison POT before damage | Ch 7, "Poison Antidotes", p.176 — **sourced** |
-| **Disease — contract** | Stamina roll: success avoids, failure contracts | Ch 7, "Disease", p.169 — **sourced** (Stamina = CON's roll, below) |
-| **Disease — minor cost** | 1–2 HP (1D2) + 1D6 fatigue over a few days | Ch 7, p.169 — **sourced** |
-| **Disease — recovery ladder** | day 2 CON×2, day 3 CON×3, +1 multiplier/day; fumble −×1; strenuous −×1 per condition | Ch 7, p.169 — **sourced** |
+| **Disease — contract** | Stamina roll: success avoids, failure contracts | Ch 7, "Disease", p.170 — **sourced** (Stamina = CON's roll, below) |
+| **Disease — minor cost** | 1–2 HP (1D2) + 1D6 fatigue over a few days | Ch 7, p.170 — **sourced** |
+| **Disease — recovery ladder** | day 2 CON×2, day 3 CON×3, +1 multiplier/day; fumble −×1; strenuous −×1 per condition | Ch 7, p.170 — **sourced** |
 | **Illness Severity Table** | 0 None / 1 Mild (wk) / 2 Acute (day) / 3 Severe (hr) / 4+ Terminal (min) | Ch 7, "Illness Severity Table", p.170 — **sourced**, reproduced row-by-row |
 
 Details worth recording:
@@ -75,12 +75,17 @@ Details worth recording:
 - **Stamina is CON's characteristic roll — sourced.** The book says only "make a Stamina roll" here,
   but the ability ruleset (Ch 2) names CON's roll "Stamina," so the contraction roll is the standard
   CON roll (CON×5). This is a citation, not a house choice.
-- **Characteristic points lost = number of failed CON rolls — house procedural reading (marked).**
-  The book (p.170) says "the first characteristic point is lost within 24 hours... each successive
-  loss is added to the total whenever the CON roll is made to recover," and cross-indexes the failure
-  count on the Illness Severity Table to give a *rate* (per week/day/hour/minute). The resolver drains
-  one point per failed recovery roll and reports the table's degree as the rate; it does not simulate
-  wall-clock time. Recorded here rather than left silent.
+- **Illness Severity is a rate, applied over time by a clock-aware caller — sourced model.** The
+  Illness Severity Table (p.170) cross-indexes the failed-CON-roll count to a *degree*, and each
+  degree is a **rate** of characteristic loss over wall-clock time — Mild 1 pt/week, Acute 1 pt/day,
+  Severe 1 pt/hour, Terminal 1 pt/minute — with "the first characteristic point lost within 24 hours"
+  and "each successive loss added... whenever the CON roll is made to recover." Baking a flat
+  failed-roll count of points once would invent a quantity the book does not print. So
+  `DiseaseResolver.ResolveSeverity` reports only the degree and its loss period (`IllnessLossPeriod`),
+  and `DiseaseResolver.ApplyCharacteristicLoss` drains the points a clock-aware caller has accrued
+  (rate × elapsed periods) through `AbilitySet.Set`, so derived values recompute. This is the same
+  "resolver reports the rate, caller applies it over time" seam as poison onset (below) and the #50
+  turn-economy effects — this piece does not hold the campaign clock the wall-clock loss needs.
 
 ### House readings of ambiguous or silent prose (marked)
 
@@ -107,8 +112,8 @@ an `InjuryDecisionId` enum, canonical kebab-case ids (`InjuryDecisionIds.Canonic
 
 | Decision id | What the book leaves open | Timing | Default | Source |
 |---|---|---|---|---|
-| `falling-surface` | How the surface / intervening obstacles adjust falling damage | post-roll | no adjustment (0) | **sourced** — Ch 7 p.171 |
-| `poison-onset` | Which onset category (fast/slow), and any bespoke delay | pre-effect | fast-acting, printed default | **sourced** — Ch 7 p.175 |
+| `falling-surface` | How the surface / intervening obstacles adjust falling damage | post-roll | no adjustment (0) | **sourced** — Ch 7 p.172 |
+| `poison-onset` | Which onset category (fast/slow), and any bespoke delay | pre-effect | fast-acting, printed default | **sourced** — Ch 7 p.176 |
 | `antidote-cross-type` | How much of a mismatched antidote's POT still applies | pre-effect | none (0) | **sourced** — Ch 7 p.176 |
 | `disease-affected-characteristic` | Which characteristic a disease drains | pre-drain | CON | **sourced** — Ch 7 p.170 |
 
@@ -119,9 +124,11 @@ every port with a deterministic stub.
 ## Out of scope (per `orc-scope-filter.md` and the issue)
 
 Not implemented here: the situational-modifier spot rules (ADR 0018); radiation, fire/heat, prone,
-and stake/trap damage; **hit-location** falling damage (Ch 7 p.171: "a fall does damage to 1D4 hit
-locations" — the entire hit-location subsystem is deferred, so the split is **named as discretion**
-and not built); the fumble tables (#97); a **fatigue-point** subsystem (the minor-disease 1D6 fatigue
+and stake/trap damage; **hit-location** falling damage (Ch 7 p.172: "a fall does damage to 1D4 hit
+locations" — the entire hit-location subsystem is **deferred and out of scope**, so this split is
+neither built nor given an adjudicator id; the resolver applies falling damage to total hit points
+only, as the book also does when hit locations are not used); the fumble tables (#97); a
+**fatigue-point** subsystem (the minor-disease 1D6 fatigue
 is rolled and reported but not applied — no fatigue system exists yet); "some diseases may combine the
 effects" (p.170) beyond selecting one affected characteristic; and any fantastical content.
 
@@ -135,7 +142,9 @@ effects" (p.170) beyond selecting one affected characteristic; and any fantastic
   `DefaultInjuryAdjudicator`, and the ruling types.
 - `DamageResolver` gains a public plain-int `ApplyDamage` overload — the non-weapon damage entry
   point falling and poison share, reused rather than reimplemented.
-- The onset delays, the poison hit-location variant, the fatigue subsystem, disease combined-effects,
-  and the falling hit-location split all need caller/round/time state these resolvers do not hold. As
-  in ADR 0018, the resolvers compute and apply the harm and name the open calls; whichever piece
-  orchestrates a running encounter or campaign clock wires the ports and the timing.
+- The poison onset delays, the **disease severity characteristic loss over wall-clock time** (a rate
+  this piece reports and a clock-aware caller applies), the poison hit-location variant, the fatigue
+  subsystem, disease combined-effects, and the deferred falling hit-location damage all need
+  caller/round/time state these resolvers do not hold. As in ADR 0018, the resolvers compute the harm
+  and name the open calls; whichever piece orchestrates a running encounter or campaign clock wires
+  the ports and the timing.

--- a/docs/decisions/0019-injury-spot-rules.md
+++ b/docs/decisions/0019-injury-spot-rules.md
@@ -1,0 +1,141 @@
+# 0019. Injury/effect spot rules: falling, poison, and disease, flowing through the damage and characteristic-drain paths
+
+## Status
+
+Accepted — 2026-08-31. Resolves #96 (Layer 4, the injury/effect half of the Ch 7 spot rules). The
+sibling of ADR 0018 (#50, the situational-*modifier* half): where 0018's rules produce
+`Modifier`s for the roll pipeline, these rules produce **damage or characteristic drain** and flow
+through the damage/HP path (ADR 0017) and the Layer 1 derived-characteristic recompute (ADR 0008).
+Together #50 and #96 complete the Ch 7 spot-rules surface for Layer 4.
+
+## Context
+
+Ch 7: Spot Rules collects situational rules of two natures. #50 delivered nature (a): rules that
+modify an action roll. This record covers nature (b): rules that inflict harm — **Falling** (p.171),
+**Poison** and **Poison Antidotes** (pp.175-176), and **Disease** with the **Illness Severity Table**
+(pp.169-170). These do not touch the modifier pipeline; they remove hit points or lower a
+characteristic, and a lowered characteristic must recompute its derived values (hit points, major
+wound level, category modifiers) rather than being baked (AGENTS.md; ADR 0008's live-recompute
+`AbilitySet`).
+
+Ch 7 (pp.169-176) and the associated Ch 2 hit-point rules are the sole sources consulted. Each value
+below was verified against the printed book text, not the issue or `engine-implementation-plan.md`
+(AGENTS.md invariant 2).
+
+## Decision
+
+### The mechanism — reuse the existing damage and drain seams — sourced
+
+Three static resolvers in `Brp.Rules.Combat` (`FallingResolver`, `PoisonResolver`, `DiseaseResolver`)
+compute harm from ruleset data plus injected entropy and apply it through the mapped, already-tested
+calls:
+
+- **Hit-point loss** (falling, poison-to-HP, minor disease) goes through a **new non-weapon overload
+  of `DamageResolver.ApplyDamage`** — `ApplyDamage(AbilitySet, WoundTrack, int hitPointDamage,
+  DamageRuleset, string)` — which reaches the same private `Apply` the weapon overload uses, so
+  hit-point tracking (Ch 2, p.13: HP may go negative) and condition classification
+  (`Unaffected`/`Unconscious`/`FatallyWounded`, from `DamageRuleset`) are identical. No fake
+  `DamageRoll` is fabricated for non-weapon damage.
+- **Characteristic drain** (poison-to-characteristic, disease) goes through `AbilitySet.Set` (via a
+  shared `InjuryDrain` helper that floors the new value at the characteristic's ruleset minimum), so
+  `MaximumHitPoints`, `MajorWoundLevel`, and `DamageModifier` recompute live (ADR 0008).
+- **POT vs CON** reuses `ResistanceResolver.Resolve(active: POT, passive: CON, entropy)` — binary
+  `Succeeded` (poison overcomes CON), `ResistancePolicy.Standard`.
+- The **CON×N recovery ladder** reuses `AbilityRuleset.CharacteristicRoll(CON, n)` →
+  `AbilityResolver.Resolve`.
+
+All book numbers live in `Brp.Data/injury-ruleset.json` (loaded by `NoirInjuryRuleset` into the
+immutable `InjuryRuleset` = `FallingRuleset` + `PoisonRuleset` + `DiseaseRuleset`), per AGENTS.md
+invariant 7. The Illness Severity Table is a banded lookup (`IllnessSeverityTable` /
+`IllnessSeverityBand`) mirroring `DamageModifierTable` / `DamageModifierBand`, and is reproduced
+row-by-row in tests (`NoirInjuryRulesetTests`).
+
+### The implemented rules
+
+| Rule | Book value | Citation |
+|---|---|---|
+| **Falling — base** | 1D6 per 3 m fallen | Ch 7, "Falling", p.171 — **sourced** |
+| **Falling — force** | dice rolled doubled when thrown with considerable force | Ch 7, p.171 — **sourced** |
+| **Falling — small SIZ** | SIZ ≤ 5: reduce damage by 1D6 | Ch 7, p.171 — **sourced** |
+| **Falling — large SIZ** | SIZ > 20: +1D6, and another 1D6 per fraction of 20 above, cumulative with force | Ch 7, p.171 — **sourced** (band interpretation is a house reading, below) |
+| **Falling — armor** | half protection up to 3 m | Ch 7, p.171 — **sourced** (armor beyond 3 m is a house reading, below) |
+| **Poison — overcome** | overcomes CON → full POT as damage | Ch 7, "Poison", p.175 — **sourced** |
+| **Poison — resisted** | does not overcome CON → half POT, round up | Ch 7, p.175 — **sourced** |
+| **Poison — target** | damage to total HP or to a characteristic | Ch 7, p.175 — **sourced** |
+| **Poison — onset** | 3 combat rounds (fast) / 3 full turns (slow) default | Ch 7, p.175 — **sourced** |
+| **Poison — two doses** | two doses = two separate resistance rolls | Ch 7, p.175 — **sourced** |
+| **Antidote** | POT taken ≤ 6 full turns before poisoning subtracts from poison POT before damage | Ch 7, "Poison Antidotes", p.176 — **sourced** |
+| **Disease — contract** | Stamina roll: success avoids, failure contracts | Ch 7, "Disease", p.169 — **sourced** (Stamina = CON's roll, below) |
+| **Disease — minor cost** | 1–2 HP (1D2) + 1D6 fatigue over a few days | Ch 7, p.169 — **sourced** |
+| **Disease — recovery ladder** | day 2 CON×2, day 3 CON×3, +1 multiplier/day; fumble −×1; strenuous −×1 per condition | Ch 7, p.169 — **sourced** |
+| **Illness Severity Table** | 0 None / 1 Mild (wk) / 2 Acute (day) / 3 Severe (hr) / 4+ Terminal (min) | Ch 7, "Illness Severity Table", p.170 — **sourced**, reproduced row-by-row |
+
+Details worth recording:
+
+- **Stamina is CON's characteristic roll — sourced.** The book says only "make a Stamina roll" here,
+  but the ability ruleset (Ch 2) names CON's roll "Stamina," so the contraction roll is the standard
+  CON roll (CON×5). This is a citation, not a house choice.
+- **Characteristic points lost = number of failed CON rolls — house procedural reading (marked).**
+  The book (p.170) says "the first characteristic point is lost within 24 hours... each successive
+  loss is added to the total whenever the CON roll is made to recover," and cross-indexes the failure
+  count on the Illness Severity Table to give a *rate* (per week/day/hour/minute). The resolver drains
+  one point per failed recovery roll and reports the table's degree as the rate; it does not simulate
+  wall-clock time. Recorded here rather than left silent.
+
+### House readings of ambiguous or silent prose (marked)
+
+- **Falling large-SIZ bands.** "adding an extra 1D6 damage if the character's SIZ is over 20 and
+  another 1D6 for every fraction of 20 after that" is read as **one extra die per started 20-point
+  band above 20** (`ceil((SIZ − 20) / 20)`: SIZ 21-40 = one die, 41-60 = two, …), treating the
+  "over 20" die and the "fraction of 20" dice as one series rather than double-counting them. The
+  alternative literal reading (a flat +1D6 *plus* one per fraction) would give every over-20 faller a
+  minimum of +2D6; the chosen reading is the more conservative.
+- **Falling armor beyond 3 m.** The book grants "half protection... up to three meters" and is silent
+  on longer falls. The resolver applies half the armor value within 3 m and **no** armor beyond it.
+  Half-armor rounds toward zero (`RoundingMode.Down`).
+- **Falling small-SIZ / large-SIZ as dice-pool modifiers.** Force doubles the base **dice count**;
+  the large-SIZ dice are added and the small-SIZ 1D6 is subtracted as separately rolled dice, with
+  the total floored at zero — matching the book's "reduce by 1D6" / "adding an extra 1D6" language.
+
+### The gamemaster-discretion points become named adjudication ports
+
+Following the `ISpotRuleAdjudicator` precedent (ADR 0018), Ch 7's "at the gamemaster's discretion"
+clauses in these rules become first-class ports: `IInjuryAdjudicator` (in `Brp.Core.Contests`) with
+an `InjuryDecisionId` enum, canonical kebab-case ids (`InjuryDecisionIds.CanonicalId`), and a
+`DefaultInjuryAdjudicator` whose defaults are the minimal-assumption reading. Return types are
+`Brp.Core` values (no `Brp.Rules` dependency; AGENTS.md invariant 6).
+
+| Decision id | What the book leaves open | Timing | Default | Source |
+|---|---|---|---|---|
+| `falling-surface` | How the surface / intervening obstacles adjust falling damage | post-roll | no adjustment (0) | **sourced** — Ch 7 p.171 |
+| `poison-onset` | Which onset category (fast/slow), and any bespoke delay | pre-effect | fast-acting, printed default | **sourced** — Ch 7 p.175 |
+| `antidote-cross-type` | How much of a mismatched antidote's POT still applies | pre-effect | none (0) | **sourced** — Ch 7 p.176 |
+| `disease-affected-characteristic` | Which characteristic a disease drains | pre-drain | CON | **sourced** — Ch 7 p.170 |
+
+The decision *ports* are sourced to the passages that leave the call open; the *default answers* are
+a **house choice** of the most neutral reading (documented on `DefaultInjuryAdjudicator`). Tests drive
+every port with a deterministic stub.
+
+## Out of scope (per `orc-scope-filter.md` and the issue)
+
+Not implemented here: the situational-modifier spot rules (ADR 0018); radiation, fire/heat, prone,
+and stake/trap damage; **hit-location** falling damage (Ch 7 p.171: "a fall does damage to 1D4 hit
+locations" — the entire hit-location subsystem is deferred, so the split is **named as discretion**
+and not built); the fumble tables (#97); a **fatigue-point** subsystem (the minor-disease 1D6 fatigue
+is rolled and reported but not applied — no fatigue system exists yet); "some diseases may combine the
+effects" (p.170) beyond selecting one affected characteristic; and any fantastical content.
+
+## Consequences
+
+- `Brp.Rules.Combat` gains `InjuryRuleset` (+ `FallingRuleset`/`PoisonRuleset`/`DiseaseRuleset`),
+  `FallingResolver`, `PoisonResolver`, `DiseaseResolver`, the `IllnessSeverityTable`/
+  `IllnessSeverityBand` lookup, and the `IllnessDegree`/`IllnessLossPeriod`/`PoisonOnsetUnit` enums
+  and outcome records. `Brp.Data` gains `injury-ruleset.json` and `NoirInjuryRuleset`.
+  `Brp.Core.Contests` gains `IInjuryAdjudicator`, `InjuryDecisionId`/`InjuryDecisionIds`,
+  `DefaultInjuryAdjudicator`, and the ruling types.
+- `DamageResolver` gains a public plain-int `ApplyDamage` overload — the non-weapon damage entry
+  point falling and poison share, reused rather than reimplemented.
+- The onset delays, the poison hit-location variant, the fatigue subsystem, disease combined-effects,
+  and the falling hit-location split all need caller/round/time state these resolvers do not hold. As
+  in ADR 0018, the resolvers compute and apply the harm and name the open calls; whichever piece
+  orchestrates a running encounter or campaign clock wires the ports and the timing.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -41,3 +41,4 @@ supersedes it — the original is not edited or deleted.
 | [0016](0016-attack-defense-matrix.md) | Attack/defense matrix: data-driven cells, the undefended case, and the deferred -30% | Accepted |
 | [0017](0017-damage.md) | Damage: normal/special/critical arithmetic, hit-point conditions, and knockout attacks | Accepted |
 | [0018](0018-spot-rules.md) | Situational combat spot rules: five modifier producers and named adjudication ports | Accepted |
+| [0019](0019-injury-spot-rules.md) | Injury/effect spot rules: falling, poison, and disease through the damage and characteristic-drain paths | Accepted |

--- a/src/Brp.Core/Contests/IInjuryAdjudicator.cs
+++ b/src/Brp.Core/Contests/IInjuryAdjudicator.cs
@@ -15,7 +15,7 @@ namespace Brp.Core.Contests;
 public enum InjuryDecisionId
 {
     /// <summary>
-    /// Canonical id <c>falling-surface</c>. Ch 7, "Falling" (p.171): "The gamemaster may adjust the
+    /// Canonical id <c>falling-surface</c>. Ch 7, "Falling" (p.172): "The gamemaster may adjust the
     /// damage based on the surface impacted, or any intervening minor obstacles like branches."
     /// How much a soft (or unusually hard) landing surface, or obstacles broken through on the way
     /// down, adjust the rolled falling damage is a gamemaster call. A post-roll ruling: it adjusts
@@ -24,7 +24,7 @@ public enum InjuryDecisionId
     FallingSurface,
 
     /// <summary>
-    /// Canonical id <c>poison-onset</c>. Ch 7, "Poison" (p.175): "Poison damage does not usually
+    /// Canonical id <c>poison-onset</c>. Ch 7, "Poison" (p.176): "Poison damage does not usually
     /// occur on the same combat round in which the character is poisoned... Unless otherwise
     /// specified by the gamemaster, the delay is three combat rounds for fast-acting poisons, or
     /// three full turns for slower poisons." Which onset category a given poison falls in -- and
@@ -74,21 +74,21 @@ public static class InjuryDecisionIds
 
 /// <summary>
 /// Which onset category a poison falls in, for the <see cref="InjuryDecisionId.PoisonOnset"/>
-/// ruling (Ch 7, p.175). The two categories select different default delays and different time
+/// ruling (Ch 7, p.176). The two categories select different default delays and different time
 /// units (combat rounds vs. full turns).
 /// </summary>
 public enum PoisonOnsetSpeed
 {
-    /// <summary>A fast-acting poison: the printed default delay is three combat rounds (p.175).</summary>
+    /// <summary>A fast-acting poison: the printed default delay is three combat rounds (p.176).</summary>
     FastActing,
 
-    /// <summary>A slower poison: the printed default delay is three full turns (p.175).</summary>
+    /// <summary>A slower poison: the printed default delay is three full turns (p.176).</summary>
     SlowActing,
 }
 
 /// <summary>
 /// The gamemaster's ruling on a poison's onset, for the <see cref="InjuryDecisionId.PoisonOnset"/>
-/// port (Ch 7, p.175).
+/// port (Ch 7, p.176).
 /// </summary>
 /// <param name="Speed">Which onset category the poison falls in.</param>
 /// <param name="GamemasterSpecifiedDelay">
@@ -100,7 +100,7 @@ public readonly record struct PoisonOnsetRuling(PoisonOnsetSpeed Speed, int? Gam
 
 /// <summary>
 /// The gamemaster's adjustment to rolled falling damage, for the
-/// <see cref="InjuryDecisionId.FallingSurface"/> port (Ch 7, p.171).
+/// <see cref="InjuryDecisionId.FallingSurface"/> port (Ch 7, p.172).
 /// </summary>
 /// <param name="DamageAdjustment">
 /// A signed adjustment applied to the rolled (and armor-mitigated) falling damage: negative for a

--- a/src/Brp.Core/Contests/IInjuryAdjudicator.cs
+++ b/src/Brp.Core/Contests/IInjuryAdjudicator.cs
@@ -1,0 +1,184 @@
+using Brp.Core.Abilities;
+
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// The named gamemaster-adjudication points the Ch 7 injury/effect spot rules (Falling, Poison,
+/// Disease) leave open. Like <see cref="SpotRuleDecisionId"/> for the situational-modifier spot
+/// rules (#50, ADR 0018), each member is a decision the source book explicitly hands to the
+/// gamemaster ("at the gamemaster's discretion", "unless otherwise specified by the gamemaster",
+/// "the type of disease dictates") rather than resolving mechanically. Naming them as first-class
+/// ids keeps the injury resolvers from silently hardcoding these calls. The canonical kebab-case
+/// id for each is given in its summary and returned by <see cref="InjuryDecisionIds.CanonicalId"/>.
+/// See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public enum InjuryDecisionId
+{
+    /// <summary>
+    /// Canonical id <c>falling-surface</c>. Ch 7, "Falling" (p.171): "The gamemaster may adjust the
+    /// damage based on the surface impacted, or any intervening minor obstacles like branches."
+    /// How much a soft (or unusually hard) landing surface, or obstacles broken through on the way
+    /// down, adjust the rolled falling damage is a gamemaster call. A post-roll ruling: it adjusts
+    /// the damage the Falling rule has already rolled.
+    /// </summary>
+    FallingSurface,
+
+    /// <summary>
+    /// Canonical id <c>poison-onset</c>. Ch 7, "Poison" (p.175): "Poison damage does not usually
+    /// occur on the same combat round in which the character is poisoned... Unless otherwise
+    /// specified by the gamemaster, the delay is three combat rounds for fast-acting poisons, or
+    /// three full turns for slower poisons." Which onset category a given poison falls in -- and
+    /// whether the gamemaster overrides the printed default with a bespoke delay -- is a gamemaster
+    /// call. A pre-effect ruling: it decides when the already-resolved poison damage lands.
+    /// </summary>
+    PoisonOnset,
+
+    /// <summary>
+    /// Canonical id <c>antidote-cross-type</c>. Ch 7, "Poison Antidotes" (p.176): "An antidote for
+    /// one type of poison may give a lessened benefit even when used with a different poison type,
+    /// at the gamemaster's discretion." How much of a mismatched antidote's POT still subtracts from
+    /// the poison POT is a gamemaster call. A pre-effect ruling: it feeds the effective antidote POT
+    /// into the poison's damage figure.
+    /// </summary>
+    AntidoteCrossType,
+
+    /// <summary>
+    /// Canonical id <c>disease-affected-characteristic</c>. Ch 7, "Disease" (p.170): "The type of
+    /// disease dictates what characteristic points are being lost... A major disease such as plague
+    /// might attack any characteristic, but most diseases attack CON or hit points." Which
+    /// characteristic a given disease drains -- and, "at the gamemaster's discretion, some diseases
+    /// may combine the effects" -- is a gamemaster/setting call. A pre-drain ruling: it selects the
+    /// characteristic the Illness Severity Table's loss is applied to via
+    /// <see cref="AbilitySet.Set"/> so derived values recompute.
+    /// </summary>
+    DiseaseAffectedCharacteristic,
+}
+
+/// <summary>Canonical kebab-case ids for the <see cref="InjuryDecisionId"/> ports.</summary>
+public static class InjuryDecisionIds
+{
+    /// <summary>
+    /// The canonical kebab-case id for <paramref name="decisionId"/> -- the stable string a GM
+    /// tool, authored policy, or log keys on (e.g. <c>falling-surface</c>), matching the ids named
+    /// in Issue #96 and ADR 0019.
+    /// </summary>
+    public static string CanonicalId(InjuryDecisionId decisionId) => decisionId switch
+    {
+        InjuryDecisionId.FallingSurface => "falling-surface",
+        InjuryDecisionId.PoisonOnset => "poison-onset",
+        InjuryDecisionId.AntidoteCrossType => "antidote-cross-type",
+        InjuryDecisionId.DiseaseAffectedCharacteristic => "disease-affected-characteristic",
+        _ => throw new ArgumentOutOfRangeException(nameof(decisionId), decisionId, "Unknown injury decision id."),
+    };
+}
+
+/// <summary>
+/// Which onset category a poison falls in, for the <see cref="InjuryDecisionId.PoisonOnset"/>
+/// ruling (Ch 7, p.175). The two categories select different default delays and different time
+/// units (combat rounds vs. full turns).
+/// </summary>
+public enum PoisonOnsetSpeed
+{
+    /// <summary>A fast-acting poison: the printed default delay is three combat rounds (p.175).</summary>
+    FastActing,
+
+    /// <summary>A slower poison: the printed default delay is three full turns (p.175).</summary>
+    SlowActing,
+}
+
+/// <summary>
+/// The gamemaster's ruling on a poison's onset, for the <see cref="InjuryDecisionId.PoisonOnset"/>
+/// port (Ch 7, p.175).
+/// </summary>
+/// <param name="Speed">Which onset category the poison falls in.</param>
+/// <param name="GamemasterSpecifiedDelay">
+/// A bespoke delay the gamemaster specifies in place of the printed default ("unless otherwise
+/// specified by the gamemaster"), in the units implied by <paramref name="Speed"/>, or
+/// <see langword="null"/> to use the printed default for that speed.
+/// </param>
+public readonly record struct PoisonOnsetRuling(PoisonOnsetSpeed Speed, int? GamemasterSpecifiedDelay);
+
+/// <summary>
+/// The gamemaster's adjustment to rolled falling damage, for the
+/// <see cref="InjuryDecisionId.FallingSurface"/> port (Ch 7, p.171).
+/// </summary>
+/// <param name="DamageAdjustment">
+/// A signed adjustment applied to the rolled (and armor-mitigated) falling damage: negative for a
+/// soft surface or obstacles broken through, positive for an unusually unforgiving landing. The
+/// final damage is floored at zero regardless. Defaults to zero -- no adjustment.
+/// </param>
+public readonly record struct FallingSurfaceRuling(int DamageAdjustment);
+
+/// <summary>
+/// A gamemaster-discretion port for the Ch 7 injury/effect spot rules (Falling, Poison, Disease),
+/// modeled -- like <see cref="ISpotRuleAdjudicator"/> for the situational-modifier spot rules --
+/// as a first-class interface rather than a set of silent hardcoded choices. Each method answers
+/// one <see cref="InjuryDecisionId"/> the book leaves open. A GM tool can prompt a human; an
+/// unattended simulation can supply an authored policy; tests supply a deterministic stub. The
+/// return types are ordinary <c>Brp.Core</c> values so this port stays within <c>Brp.Core</c> and
+/// does not invert the layer dependency (AGENTS.md invariant 6). See
+/// <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public interface IInjuryAdjudicator
+{
+    /// <summary>
+    /// Decides how the landing surface or intervening obstacles adjust rolled falling damage
+    /// (<see cref="InjuryDecisionId.FallingSurface"/>). Post-roll.
+    /// </summary>
+    FallingSurfaceRuling DecideFallingSurface();
+
+    /// <summary>
+    /// Decides a poison's onset category and any bespoke delay
+    /// (<see cref="InjuryDecisionId.PoisonOnset"/>). Pre-effect.
+    /// </summary>
+    PoisonOnsetRuling DecidePoisonOnset();
+
+    /// <summary>
+    /// Decides how much of a cross-type antidote's POT still applies against a poison
+    /// (<see cref="InjuryDecisionId.AntidoteCrossType"/>). Pre-effect.
+    /// </summary>
+    /// <param name="crossTypeAntidotePotency">
+    /// The mismatched antidote's full POT. The returned value is the "lessened benefit" POT that
+    /// subtracts from the poison POT, in <c>[0, crossTypeAntidotePotency]</c>.
+    /// </param>
+    int DecideAntidoteCrossTypePotency(int crossTypeAntidotePotency);
+
+    /// <summary>
+    /// Decides which characteristic a disease drains
+    /// (<see cref="InjuryDecisionId.DiseaseAffectedCharacteristic"/>). Pre-drain.
+    /// </summary>
+    CharacteristicId DecideDiseaseAffectedCharacteristic();
+}
+
+/// <summary>
+/// The documented default policy for every <see cref="InjuryDecisionId"/>: the most
+/// minimal-assumption answer to "the book does not say," mirroring
+/// <see cref="DefaultSpotRuleAdjudicator"/>. A table with a house rule or a human gamemaster should
+/// supply its own <see cref="IInjuryAdjudicator"/> instead.
+/// </summary>
+public sealed class DefaultInjuryAdjudicator : IInjuryAdjudicator
+{
+    /// <summary>
+    /// Defaults to no adjustment (<c>0</c>) -- the printed falling damage stands, adding no fact
+    /// about the surface the book did not state.
+    /// </summary>
+    public FallingSurfaceRuling DecideFallingSurface() => new(DamageAdjustment: 0);
+
+    /// <summary>
+    /// Defaults to <see cref="PoisonOnsetSpeed.FastActing"/> with no bespoke delay -- the
+    /// combat-round default the book lists first, the reading most relevant to a fight.
+    /// </summary>
+    public PoisonOnsetRuling DecidePoisonOnset() => new(PoisonOnsetSpeed.FastActing, GamemasterSpecifiedDelay: null);
+
+    /// <summary>
+    /// Defaults to no benefit (<c>0</c>) from a cross-type antidote -- the book says the gamemaster
+    /// <em>may</em> allow a lessened benefit, so the neutral default grants none.
+    /// </summary>
+    public int DecideAntidoteCrossTypePotency(int crossTypeAntidotePotency) => 0;
+
+    /// <summary>
+    /// Defaults to <c>CON</c> -- the book states "most diseases attack CON or hit points," so CON
+    /// is the least-assuming default characteristic to drain.
+    /// </summary>
+    public CharacteristicId DecideDiseaseAffectedCharacteristic() => new("CON");
+}

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -24,6 +24,7 @@
     <EmbeddedResource Include="attack-defense-matrix-ruleset.json" />
     <EmbeddedResource Include="damage-ruleset.json" />
     <EmbeddedResource Include="spot-rule-ruleset.json" />
+    <EmbeddedResource Include="injury-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirInjuryRuleset.cs
+++ b/src/Brp.Data/NoirInjuryRuleset.cs
@@ -6,8 +6,8 @@ namespace Brp.Data;
 
 /// <summary>
 /// Loads NoiRPG's injury/effect spot-rule values from embedded JSON. Sourced: Ch 7: Spot Rules --
-/// "Falling" (p.171), "Poison"/"Poison Antidotes" (pp.175-176), and "Disease"/"Illness Severity
-/// Table" (pp.169-170) -- see each field on <see cref="FallingRuleset"/>, <see cref="PoisonRuleset"/>,
+/// "Falling" (pp.171-172), "Poison"/"Poison Antidotes" (p.176), and "Disease"/"Illness Severity
+/// Table" (p.170) -- see each field on <see cref="FallingRuleset"/>, <see cref="PoisonRuleset"/>,
 /// and <see cref="DiseaseRuleset"/> for its exact citation. Recorded in
 /// <c>docs/decisions/0019-injury-spot-rules.md</c>.
 /// </summary>

--- a/src/Brp.Data/NoirInjuryRuleset.cs
+++ b/src/Brp.Data/NoirInjuryRuleset.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using Brp.Core.Dice;
+using Brp.Rules.Combat;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's injury/effect spot-rule values from embedded JSON. Sourced: Ch 7: Spot Rules --
+/// "Falling" (p.171), "Poison"/"Poison Antidotes" (pp.175-176), and "Disease"/"Illness Severity
+/// Table" (pp.169-170) -- see each field on <see cref="FallingRuleset"/>, <see cref="PoisonRuleset"/>,
+/// and <see cref="DiseaseRuleset"/> for its exact citation. Recorded in
+/// <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public static class NoirInjuryRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable injury ruleset from the shipped data.</summary>
+    public static InjuryRuleset Load()
+    {
+        var assembly = typeof(NoirInjuryRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.injury-ruleset.json")
+            ?? throw new InvalidOperationException("The injury ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<InjuryRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The injury ruleset data is empty.");
+
+        return new InjuryRuleset(BuildFalling(data.Falling), BuildPoison(data.Poison), BuildDisease(data.Disease));
+    }
+
+    private static FallingRuleset BuildFalling(FallingData data) => new(
+        baseDamagePerIncrement: DiceExpression.Parse(data.BaseDamagePerIncrementFormula),
+        metersPerDamageIncrement: data.MetersPerDamageIncrement,
+        forceMultiplier: data.ForceMultiplier,
+        smallSizeThreshold: data.SmallSizeThreshold,
+        smallSizeReduction: DiceExpression.Parse(data.SmallSizeReductionFormula),
+        largeSizeThreshold: data.LargeSizeThreshold,
+        largeSizeBand: data.LargeSizeBand,
+        largeSizeExtraDamage: DiceExpression.Parse(data.LargeSizeExtraDamageFormula),
+        armorHalfProtectionMaxMeters: data.ArmorHalfProtectionMaxMeters,
+        armorProtectionNumerator: data.ArmorProtectionNumerator,
+        armorProtectionDenominator: data.ArmorProtectionDenominator);
+
+    private static PoisonRuleset BuildPoison(PoisonData data) => new(
+        notOvercomeNumerator: data.NotOvercomeNumerator,
+        notOvercomeDenominator: data.NotOvercomeDenominator,
+        onsetFastActingRounds: data.OnsetFastActingRounds,
+        onsetSlowActingTurns: data.OnsetSlowActingTurns,
+        antidoteWindowTurns: data.AntidoteWindowTurns);
+
+    private static DiseaseRuleset BuildDisease(DiseaseData data)
+    {
+        var bands = data.IllnessSeverityTable.Select(row => new IllnessSeverityBand(
+            row.MinimumFailures,
+            row.MaximumFailures,
+            Enum.Parse<IllnessDegree>(row.Degree),
+            Enum.Parse<IllnessLossPeriod>(row.LossPeriod)));
+
+        return new DiseaseRuleset(
+            minorDiseaseHitPointLoss: DiceExpression.Parse(data.MinorDiseaseHitPointLossFormula),
+            minorDiseaseFatigueLoss: DiceExpression.Parse(data.MinorDiseaseFatigueLossFormula),
+            recoveryLadderStartingMultiplier: data.RecoveryLadderStartingMultiplier,
+            recoveryLadderMultiplierIncrementPerDay: data.RecoveryLadderMultiplierIncrementPerDay,
+            recoveryLadderFumbleMultiplierPenalty: data.RecoveryLadderFumbleMultiplierPenalty,
+            recoveryLadderStrenuousConditionPenalty: data.RecoveryLadderStrenuousConditionPenalty,
+            illnessSeverityTable: new IllnessSeverityTable(bands));
+    }
+
+    private sealed class InjuryRulesetData
+    {
+        public required FallingData Falling { get; init; }
+
+        public required PoisonData Poison { get; init; }
+
+        public required DiseaseData Disease { get; init; }
+    }
+
+    private sealed class FallingData
+    {
+        public required string BaseDamagePerIncrementFormula { get; init; }
+
+        public required int MetersPerDamageIncrement { get; init; }
+
+        public required int ForceMultiplier { get; init; }
+
+        public required int SmallSizeThreshold { get; init; }
+
+        public required string SmallSizeReductionFormula { get; init; }
+
+        public required int LargeSizeThreshold { get; init; }
+
+        public required int LargeSizeBand { get; init; }
+
+        public required string LargeSizeExtraDamageFormula { get; init; }
+
+        public required int ArmorHalfProtectionMaxMeters { get; init; }
+
+        public required int ArmorProtectionNumerator { get; init; }
+
+        public required int ArmorProtectionDenominator { get; init; }
+    }
+
+    private sealed class PoisonData
+    {
+        public required int NotOvercomeNumerator { get; init; }
+
+        public required int NotOvercomeDenominator { get; init; }
+
+        public required int OnsetFastActingRounds { get; init; }
+
+        public required int OnsetSlowActingTurns { get; init; }
+
+        public required int AntidoteWindowTurns { get; init; }
+    }
+
+    private sealed class DiseaseData
+    {
+        public required string MinorDiseaseHitPointLossFormula { get; init; }
+
+        public required string MinorDiseaseFatigueLossFormula { get; init; }
+
+        public required int RecoveryLadderStartingMultiplier { get; init; }
+
+        public required int RecoveryLadderMultiplierIncrementPerDay { get; init; }
+
+        public required int RecoveryLadderFumbleMultiplierPenalty { get; init; }
+
+        public required int RecoveryLadderStrenuousConditionPenalty { get; init; }
+
+        public required IReadOnlyList<IllnessSeverityRowData> IllnessSeverityTable { get; init; }
+    }
+
+    private sealed class IllnessSeverityRowData
+    {
+        public required int MinimumFailures { get; init; }
+
+        public int? MaximumFailures { get; init; }
+
+        public required string Degree { get; init; }
+
+        public required string LossPeriod { get; init; }
+    }
+}

--- a/src/Brp.Data/injury-ruleset.json
+++ b/src/Brp.Data/injury-ruleset.json
@@ -2,7 +2,7 @@
   "source": {
     "book": "BasicRoleplaying-ORC-Content-Document.pdf",
     "chapter": "Chapter 7: Spot Rules",
-    "notes": "Injury/effect spot rules that deal damage or characteristic drain: Falling (p.171), Poison and Poison Antidotes (pp.175-176), Disease and the Illness Severity Table (pp.169-170). Sibling of spot-rule-ruleset.json (#50). See docs/decisions/0019-injury-spot-rules.md."
+    "notes": "Injury/effect spot rules that deal damage or characteristic drain: Falling (pp.171-172), Poison and Poison Antidotes (p.176), Disease and the Illness Severity Table (p.170). Sibling of spot-rule-ruleset.json (#50). See docs/decisions/0019-injury-spot-rules.md."
   },
   "falling": {
     "baseDamagePerIncrementFormula": "1D6",
@@ -16,7 +16,7 @@
     "armorHalfProtectionMaxMeters": 3,
     "armorProtectionNumerator": 1,
     "armorProtectionDenominator": 2,
-    "source": "Ch 7, Falling (p.171): '1D6 base damage for every three meters fallen'; 'If thrown with considerable force, the dice rolled may be doubled'; 'if SIZ is 5 or less, reduce the damage from falling by 1D6'; 'adding an extra 1D6 damage if the character's SIZ is over 20 and another 1D6 for every fraction of 20 after that'; 'Armor provides half protection against falling damage up to three meters.'"
+    "source": "Ch 7, Falling: base/force/SIZ on p.171 ('1D6 base damage for every three meters fallen'; 'If thrown with considerable force, the dice rolled may be doubled'; 'if SIZ is 5 or less, reduce the damage from falling by 1D6'; 'adding an extra 1D6 damage if the character's SIZ is over 20 and another 1D6 for every fraction of 20 after that'); armor on p.172 ('Armor provides half protection against falling damage up to three meters.')."
   },
   "poison": {
     "notOvercomeNumerator": 1,
@@ -24,7 +24,7 @@
     "onsetFastActingRounds": 3,
     "onsetSlowActingTurns": 3,
     "antidoteWindowTurns": 6,
-    "source": "Ch 7, Poison (p.175): full POT if it overcomes CON, else 'half the poison's POT in damage (round up)'; 'the delay is three combat rounds for fast-acting poisons, or three full turns for slower poisons'. Poison Antidotes (p.176): 'no more than six full turns before being poisoned, the antidote's POT is subtracted from the poison's POT before damage is figured.'"
+    "source": "Ch 7, Poison (p.176): full POT if it overcomes CON, else 'half the poison's POT in damage (round up)'; 'the delay is three combat rounds for fast-acting poisons, or three full turns for slower poisons'. Poison Antidotes (p.176): 'no more than six full turns before being poisoned, the antidote's POT is subtracted from the poison's POT before damage is figured.'"
   },
   "disease": {
     "minorDiseaseHitPointLossFormula": "1D2",
@@ -33,7 +33,7 @@
     "recoveryLadderMultiplierIncrementPerDay": 1,
     "recoveryLadderFumbleMultiplierPenalty": 1,
     "recoveryLadderStrenuousConditionPenalty": 1,
-    "recoverySource": "Ch 7, Disease (p.169): minor disease costs '1 or 2 hit points and 1D6 fatigue points'; 'On the morning of the second day... roll CON×2'; 'the third day, roll CON×3, continuing by increasing the multiplier... until the disease is finally overcome. A fumble reduces the multiplier by ×1.'; 'Strenuous conditions... reduce this characteristic roll by ×1 per outstanding condition.'",
+    "recoverySource": "Ch 7, Disease (p.170): minor disease costs '1 or 2 hit points and 1D6 fatigue points'; 'On the morning of the second day... roll CON×2'; 'the third day, roll CON×3, continuing by increasing the multiplier... until the disease is finally overcome. A fumble reduces the multiplier by ×1.'; 'Strenuous conditions... reduce this characteristic roll by ×1 per outstanding condition.'",
     "illnessSeverityTable": [
       { "minimumFailures": 0, "maximumFailures": 0, "degree": "None", "lossPeriod": "None" },
       { "minimumFailures": 1, "maximumFailures": 1, "degree": "Mild", "lossPeriod": "Week" },

--- a/src/Brp.Data/injury-ruleset.json
+++ b/src/Brp.Data/injury-ruleset.json
@@ -1,0 +1,46 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 7: Spot Rules",
+    "notes": "Injury/effect spot rules that deal damage or characteristic drain: Falling (p.171), Poison and Poison Antidotes (pp.175-176), Disease and the Illness Severity Table (pp.169-170). Sibling of spot-rule-ruleset.json (#50). See docs/decisions/0019-injury-spot-rules.md."
+  },
+  "falling": {
+    "baseDamagePerIncrementFormula": "1D6",
+    "metersPerDamageIncrement": 3,
+    "forceMultiplier": 2,
+    "smallSizeThreshold": 5,
+    "smallSizeReductionFormula": "1D6",
+    "largeSizeThreshold": 20,
+    "largeSizeBand": 20,
+    "largeSizeExtraDamageFormula": "1D6",
+    "armorHalfProtectionMaxMeters": 3,
+    "armorProtectionNumerator": 1,
+    "armorProtectionDenominator": 2,
+    "source": "Ch 7, Falling (p.171): '1D6 base damage for every three meters fallen'; 'If thrown with considerable force, the dice rolled may be doubled'; 'if SIZ is 5 or less, reduce the damage from falling by 1D6'; 'adding an extra 1D6 damage if the character's SIZ is over 20 and another 1D6 for every fraction of 20 after that'; 'Armor provides half protection against falling damage up to three meters.'"
+  },
+  "poison": {
+    "notOvercomeNumerator": 1,
+    "notOvercomeDenominator": 2,
+    "onsetFastActingRounds": 3,
+    "onsetSlowActingTurns": 3,
+    "antidoteWindowTurns": 6,
+    "source": "Ch 7, Poison (p.175): full POT if it overcomes CON, else 'half the poison's POT in damage (round up)'; 'the delay is three combat rounds for fast-acting poisons, or three full turns for slower poisons'. Poison Antidotes (p.176): 'no more than six full turns before being poisoned, the antidote's POT is subtracted from the poison's POT before damage is figured.'"
+  },
+  "disease": {
+    "minorDiseaseHitPointLossFormula": "1D2",
+    "minorDiseaseFatigueLossFormula": "1D6",
+    "recoveryLadderStartingMultiplier": 2,
+    "recoveryLadderMultiplierIncrementPerDay": 1,
+    "recoveryLadderFumbleMultiplierPenalty": 1,
+    "recoveryLadderStrenuousConditionPenalty": 1,
+    "recoverySource": "Ch 7, Disease (p.169): minor disease costs '1 or 2 hit points and 1D6 fatigue points'; 'On the morning of the second day... roll CON×2'; 'the third day, roll CON×3, continuing by increasing the multiplier... until the disease is finally overcome. A fumble reduces the multiplier by ×1.'; 'Strenuous conditions... reduce this characteristic roll by ×1 per outstanding condition.'",
+    "illnessSeverityTable": [
+      { "minimumFailures": 0, "maximumFailures": 0, "degree": "None", "lossPeriod": "None" },
+      { "minimumFailures": 1, "maximumFailures": 1, "degree": "Mild", "lossPeriod": "Week" },
+      { "minimumFailures": 2, "maximumFailures": 2, "degree": "Acute", "lossPeriod": "Day" },
+      { "minimumFailures": 3, "maximumFailures": 3, "degree": "Severe", "lossPeriod": "Hour" },
+      { "minimumFailures": 4, "maximumFailures": null, "degree": "Terminal", "lossPeriod": "Minute" }
+    ],
+    "illnessSeverityTableSource": "Ch 7, Illness Severity Table (p.170): 0 None; 1 Mild (lose 1 characteristic point per week); 2 Acute (per day); 3 Severe (per hour); 4+ Terminal (per minute)."
+  }
+}

--- a/src/Brp.Rules/Combat/DamageApplicationResult.cs
+++ b/src/Brp.Rules/Combat/DamageApplicationResult.cs
@@ -4,7 +4,7 @@ namespace Brp.Rules.Combat;
 
 /// <summary>
 /// The result of applying a rolled damage amount to a target's hit points --
-/// <see cref="DamageResolver.ApplyDamage"/>'s output.
+/// the output of <see cref="DamageResolver"/>'s <c>ApplyDamage</c> overloads.
 /// </summary>
 /// <param name="DamageDealt">The hit points actually removed (0 for a Miss).</param>
 /// <param name="ResultingHitPoints">The target's hit points after the change; may be negative.</param>

--- a/src/Brp.Rules/Combat/DamageResolver.cs
+++ b/src/Brp.Rules/Combat/DamageResolver.cs
@@ -219,6 +219,40 @@ public static class DamageResolver
     }
 
     /// <summary>
+    /// Applies a flat, already-computed hit-point loss to <paramref name="target"/>, recording it
+    /// as a <see cref="Wound"/> and returning the resulting condition -- the non-weapon damage
+    /// entry point the injury spot rules (#96) use for falling and poison, where the loss comes
+    /// from a distance/SIZ or POT calculation rather than a weapon
+    /// <see cref="DamageRoll"/>. Mirrors the private <see cref="Apply"/> that the weapon-damage
+    /// overload of <see cref="ApplyDamage(AbilitySet, WoundTrack, DamageRoll, DamageRuleset, string)"/>
+    /// reaches, so hit-point tracking (Ch 2, p.13: HP may go negative) and condition classification
+    /// (Ch 2, p.13; Ch 6, p.156) are identical -- there is no fabricated weapon <see cref="DamageRoll"/>.
+    /// </summary>
+    /// <param name="target">The character taking the damage.</param>
+    /// <param name="wounds">The wound track the blow is recorded in.</param>
+    /// <param name="hitPointDamage">
+    /// The hit points to remove, already fully computed by the caller (falling armor/SIZ/force,
+    /// poison POT full-or-half). Must be non-negative; the resolver does not re-clamp or re-mitigate.
+    /// </param>
+    /// <param name="ruleset">Supplies the unconscious/dead thresholds for condition classification.</param>
+    /// <param name="woundDescription">A free-text note describing the injury, for piece E to heal.</param>
+    public static DamageApplicationResult ApplyDamage(
+        AbilitySet target,
+        WoundTrack wounds,
+        int hitPointDamage,
+        DamageRuleset ruleset,
+        string woundDescription)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(wounds);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentOutOfRangeException.ThrowIfNegative(hitPointDamage);
+        ArgumentException.ThrowIfNullOrWhiteSpace(woundDescription);
+
+        return Apply(target, wounds, hitPointDamage, ruleset, new Wound(woundDescription));
+    }
+
+    /// <summary>
     /// Resolves a declared knockout attack (Ch 7: Spot Rules, "Knockout Attacks", p.174). The
     /// caller is responsible for the parts of that spot rule outside this piece's scope: that
     /// the attack was declared at the start of the round, rolled as a Difficult attack against a
@@ -287,7 +321,8 @@ public static class DamageResolver
 
     /// <summary>
     /// Applies a knockout attack's resolved damage to <paramref name="target"/>'s hit points,
-    /// mirroring <see cref="ApplyDamage"/> for the knockout-specific outcome shape. Records no
+    /// mirroring <see cref="ApplyDamage(AbilitySet, WoundTrack, DamageRoll, DamageRuleset, string)"/>
+    /// for the knockout-specific outcome shape. Records no
     /// wound if the attack missed.
     /// </summary>
     public static DamageApplicationResult ApplyKnockoutAttack(

--- a/src/Brp.Rules/Combat/DiseaseResolver.cs
+++ b/src/Brp.Rules/Combat/DiseaseResolver.cs
@@ -5,18 +5,22 @@ using Brp.Core.Resolution;
 namespace Brp.Rules.Combat;
 
 /// <summary>
-/// Resolves and applies Ch 7: Spot Rules, "Disease" (pp.169-170): a Stamina roll to contract, the
+/// Resolves and applies Ch 7: Spot Rules, "Disease" (p.170): a Stamina roll to contract, the
 /// CON×N recovery ladder, and the "Illness Severity Table" characteristic drain. Characteristic
 /// loss is applied through <see cref="AbilitySet.Set"/> (via <see cref="InjuryDrain"/>) so derived
 /// values recompute (Ch 2, p.13). One of the injury/effect spot rules (#96). See
 /// <c>docs/decisions/0019-injury-spot-rules.md</c>.
 /// <para>
-/// <strong>House readings (marked in ADR 0019):</strong> the "Stamina roll" to contract a disease
+/// <strong>House reading (marked in ADR 0019):</strong> the "Stamina roll" to contract a disease
 /// is modeled as the standard CON roll (CON×5, the book's standard characteristic-roll multiplier),
-/// the book not restating Stamina's rating in this section. The characteristic points lost is taken
-/// as the number of failed recovery rolls -- "each successive loss is added to the total whenever
-/// the CON roll is made to recover" (p.170) -- with the Illness Severity Table degree reporting the
-/// rate at which further loss would accrue.
+/// the book not restating Stamina's rating in this section.
+/// </para>
+/// <para>
+/// The Illness Severity Table gives a <em>rate</em> of characteristic loss (one point per
+/// week/day/hour/minute by degree), not a one-time quantity, so <see cref="ResolveSeverity"/> reports
+/// the degree and period and <see cref="ApplyCharacteristicLoss"/> applies the points a clock-aware
+/// caller has accrued over time -- the "resolver reports the rate, caller applies it over time" seam
+/// this piece shares with poison onset.
 /// </para>
 /// </summary>
 public static class DiseaseResolver
@@ -24,7 +28,7 @@ public static class DiseaseResolver
     private static readonly CharacteristicId Constitution = new("CON");
 
     /// <summary>
-    /// Rolls to contract a minor disease, per Ch 7, "Disease" (p.169): "make a Stamina roll to see
+    /// Rolls to contract a minor disease, per Ch 7, "Disease" (p.170): "make a Stamina roll to see
     /// if the disease is contracted. Success means that it is avoided, while failure means that your
     /// character catches the disease." Modeled as the standard CON roll (see the type remarks).
     /// </summary>
@@ -41,7 +45,7 @@ public static class DiseaseResolver
     }
 
     /// <summary>
-    /// Rolls the CON×N recovery ladder, per Ch 7, "Disease" (p.169): day two is CON×2, rising by
+    /// Rolls the CON×N recovery ladder, per Ch 7, "Disease" (p.170): day two is CON×2, rising by
     /// <see cref="DiseaseRuleset.RecoveryLadderMultiplierIncrementPerDay"/> each successive day, a
     /// fumble reducing the multiplier by
     /// <see cref="DiseaseRuleset.RecoveryLadderFumbleMultiplierPenalty"/> and each outstanding
@@ -108,26 +112,42 @@ public static class DiseaseResolver
 
     /// <summary>
     /// Looks up the Illness Severity Table degree for <paramref name="failures"/> failed CON rolls
-    /// and drains that many points from <paramref name="characteristic"/> (via
-    /// <see cref="InjuryDrain"/>, so derived values recompute), per Ch 7, "Disease"/"Illness
-    /// Severity Table" (p.170). The affected characteristic is the gamemaster's call
-    /// (<see cref="Core.Contests.InjuryDecisionId.DiseaseAffectedCharacteristic"/>), supplied by the
-    /// caller.
+    /// and reports the resulting <em>rate</em> of characteristic loss -- one point per the degree's
+    /// period (Mild per week, Acute per day, Severe per hour, Terminal per minute), per Ch 7,
+    /// "Disease"/"Illness Severity Table" (p.170). This method applies no drain: the loss accrues
+    /// over wall-clock time, so the actual point loss is applied by a clock-aware caller via
+    /// <see cref="ApplyCharacteristicLoss"/> -- the same "resolver reports the rate, caller applies
+    /// it over time" seam as poison onset (<see cref="PoisonResolver.ResolveOnset"/>). Baking a flat
+    /// <paramref name="failures"/>-point quantity would invent a number the book does not print (the
+    /// table gives a rate, not a one-time amount).
     /// </summary>
-    public static DiseaseSeverityOutcome ApplySeverityDrain(
-        AbilitySet abilities, CharacteristicId characteristic, int failures, DiseaseRuleset ruleset)
+    public static DiseaseSeverity ResolveSeverity(int failures, DiseaseRuleset ruleset)
     {
-        ArgumentNullException.ThrowIfNull(abilities);
         ArgumentNullException.ThrowIfNull(ruleset);
         ArgumentOutOfRangeException.ThrowIfNegative(failures);
 
         var band = ruleset.IllnessSeverityTable.ForFailures(failures);
-        var newValue = InjuryDrain.Apply(abilities, characteristic, failures);
-        return new DiseaseSeverityOutcome(band.Degree, band.LossPeriod, PointsLost: failures, newValue);
+        return new DiseaseSeverity(band.Degree, band.LossPeriod);
     }
 
     /// <summary>
-    /// Rolls a minor disease's incidental cost, per Ch 7, "Disease" (p.169): "1 or 2 hit points and
+    /// Drains disease characteristic loss accrued over time, per Ch 7, "Disease" (p.170): "The first
+    /// characteristic point is lost within 24 hours of initially contracting the disease... Each
+    /// successive loss is added to the total whenever the CON roll is made to recover." The
+    /// <paramref name="points"/> a clock-aware caller has accrued -- from the
+    /// <see cref="ResolveSeverity"/> rate over elapsed periods, drained from the disease's affected
+    /// characteristic (<see cref="Core.Contests.InjuryDecisionId.DiseaseAffectedCharacteristic"/>) --
+    /// are applied through <see cref="AbilitySet.Set"/> (via <see cref="InjuryDrain"/>), so derived
+    /// values recompute. Returns the resulting characteristic value.
+    /// </summary>
+    public static int ApplyCharacteristicLoss(AbilitySet abilities, CharacteristicId characteristic, int points)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        return InjuryDrain.Apply(abilities, characteristic, points);
+    }
+
+    /// <summary>
+    /// Rolls a minor disease's incidental cost, per Ch 7, "Disease" (p.170): "1 or 2 hit points and
     /// 1D6 fatigue points over a few days." The hit-point loss can be applied through
     /// <see cref="DamageResolver.ApplyDamage(AbilitySet, Characters.WoundTrack, int, DamageRuleset, string)"/>;
     /// the fatigue-point loss is reported for callers but not applied here (no fatigue-point
@@ -144,32 +164,34 @@ public static class DiseaseResolver
     }
 }
 
-/// <summary>The result of a Stamina contraction roll (Ch 7, p.169).</summary>
+/// <summary>The result of a Stamina contraction roll (Ch 7, p.170).</summary>
 /// <param name="StaminaRoll">The resolved Stamina (CON) roll.</param>
 /// <param name="Contracted">Whether the disease was contracted (the roll failed).</param>
 public sealed record DiseaseContraction(RollOutcome StaminaRoll, bool Contracted);
 
-/// <summary>One day's recovery roll on the CON×N ladder (Ch 7, p.169).</summary>
+/// <summary>One day's recovery roll on the CON×N ladder (Ch 7, p.170).</summary>
 /// <param name="Day">The zero-based day index (day 0 is the book's "second day", CON×2).</param>
 /// <param name="EffectiveMultiplier">The CON multiplier actually rolled, after penalties and clamping.</param>
 /// <param name="Roll">The resolved CON roll.</param>
 public sealed record DailyRecoveryRoll(int Day, int EffectiveMultiplier, RollOutcome Roll);
 
-/// <summary>The result of running the CON×N recovery ladder (Ch 7, p.169).</summary>
+/// <summary>The result of running the CON×N recovery ladder (Ch 7, p.170).</summary>
 /// <param name="Failures">The number of failed recovery rolls (the Illness Severity Table index).</param>
 /// <param name="Recovered">Whether the character recovered within the day budget.</param>
 /// <param name="Days">Each day's roll, in order.</param>
 public sealed record RecoveryLadderOutcome(int Failures, bool Recovered, IReadOnlyList<DailyRecoveryRoll> Days);
 
-/// <summary>The result of applying Illness Severity Table drain (Ch 7, p.170).</summary>
+/// <summary>
+/// The severity of a disease looked up from the Illness Severity Table (Ch 7, p.170): a degree and
+/// the period over which one characteristic point is lost. Deliberately carries no baked point
+/// quantity -- the loss is a rate over wall-clock time, applied by a clock-aware caller via
+/// <see cref="DiseaseResolver.ApplyCharacteristicLoss"/>.
+/// </summary>
 /// <param name="Degree">The degree of illness for the failure count.</param>
-/// <param name="LossPeriod">The period over which further points would be lost.</param>
-/// <param name="PointsLost">The characteristic points drained.</param>
-/// <param name="ResultingValue">The characteristic's value after the drain.</param>
-public sealed record DiseaseSeverityOutcome(
-    IllnessDegree Degree, IllnessLossPeriod LossPeriod, int PointsLost, int ResultingValue);
+/// <param name="LossPeriod">The period over which one characteristic point is lost (None = no loss).</param>
+public readonly record struct DiseaseSeverity(IllnessDegree Degree, IllnessLossPeriod LossPeriod);
 
-/// <summary>The incidental cost of a minor disease (Ch 7, p.169).</summary>
+/// <summary>The incidental cost of a minor disease (Ch 7, p.170).</summary>
 /// <param name="HitPointLoss">Hit points lost over the illness.</param>
 /// <param name="FatigueLoss">Fatigue points lost (reported only; no fatigue subsystem yet).</param>
 public readonly record struct MinorDiseaseEffect(int HitPointLoss, int FatigueLoss);

--- a/src/Brp.Rules/Combat/DiseaseResolver.cs
+++ b/src/Brp.Rules/Combat/DiseaseResolver.cs
@@ -1,0 +1,175 @@
+using Brp.Core.Abilities;
+using Brp.Core.Randomness;
+using Brp.Core.Resolution;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Resolves and applies Ch 7: Spot Rules, "Disease" (pp.169-170): a Stamina roll to contract, the
+/// CON×N recovery ladder, and the "Illness Severity Table" characteristic drain. Characteristic
+/// loss is applied through <see cref="AbilitySet.Set"/> (via <see cref="InjuryDrain"/>) so derived
+/// values recompute (Ch 2, p.13). One of the injury/effect spot rules (#96). See
+/// <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// <para>
+/// <strong>House readings (marked in ADR 0019):</strong> the "Stamina roll" to contract a disease
+/// is modeled as the standard CON roll (CON×5, the book's standard characteristic-roll multiplier),
+/// the book not restating Stamina's rating in this section. The characteristic points lost is taken
+/// as the number of failed recovery rolls -- "each successive loss is added to the total whenever
+/// the CON roll is made to recover" (p.170) -- with the Illness Severity Table degree reporting the
+/// rate at which further loss would accrue.
+/// </para>
+/// </summary>
+public static class DiseaseResolver
+{
+    private static readonly CharacteristicId Constitution = new("CON");
+
+    /// <summary>
+    /// Rolls to contract a minor disease, per Ch 7, "Disease" (p.169): "make a Stamina roll to see
+    /// if the disease is contracted. Success means that it is avoided, while failure means that your
+    /// character catches the disease." Modeled as the standard CON roll (see the type remarks).
+    /// </summary>
+    public static DiseaseContraction RollContraction(AbilitySet abilities, IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var staminaRoll = abilities.Ruleset.StandardCharacteristicRoll(Constitution);
+        var outcome = AbilityResolver.Resolve(abilities, staminaRoll, [], entropy)
+            ?? throw new InvalidOperationException("The Stamina contraction roll was unexpectedly gated.");
+
+        return new DiseaseContraction(outcome, Contracted: !outcome.Succeeded);
+    }
+
+    /// <summary>
+    /// Rolls the CON×N recovery ladder, per Ch 7, "Disease" (p.169): day two is CON×2, rising by
+    /// <see cref="DiseaseRuleset.RecoveryLadderMultiplierIncrementPerDay"/> each successive day, a
+    /// fumble reducing the multiplier by
+    /// <see cref="DiseaseRuleset.RecoveryLadderFumbleMultiplierPenalty"/> and each outstanding
+    /// strenuous condition reducing it by
+    /// <see cref="DiseaseRuleset.RecoveryLadderStrenuousConditionPenalty"/>. The multiplier is
+    /// clamped to the ability ruleset's supported range. Stops on the first successful roll (the
+    /// character recovers) or after <paramref name="maxDays"/> days.
+    /// </summary>
+    /// <param name="abilities">The recovering character (CON is read live for each roll).</param>
+    /// <param name="strenuousConditionCount">Outstanding strenuous conditions (0 = rest and care).</param>
+    /// <param name="ruleset">The disease values.</param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    /// <param name="maxDays">The maximum number of recovery days to roll before giving up.</param>
+    public static RecoveryLadderOutcome ResolveRecoveryLadder(
+        AbilitySet abilities,
+        int strenuousConditionCount,
+        DiseaseRuleset ruleset,
+        IEntropySource entropy,
+        int maxDays)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+        ArgumentOutOfRangeException.ThrowIfNegative(strenuousConditionCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDays);
+
+        var minMultiplier = abilities.Ruleset.MinimumCharacteristicRollMultiplier;
+        var maxMultiplier = abilities.Ruleset.MaximumCharacteristicRollMultiplier;
+
+        var days = new List<DailyRecoveryRoll>();
+        var failures = 0;
+        var fumblePenalty = 0;
+        var recovered = false;
+
+        for (var day = 0; day < maxDays; day++)
+        {
+            var dayMultiplier = ruleset.RecoveryLadderStartingMultiplier
+                + (day * ruleset.RecoveryLadderMultiplierIncrementPerDay);
+            var reduced = dayMultiplier
+                - (strenuousConditionCount * ruleset.RecoveryLadderStrenuousConditionPenalty)
+                - fumblePenalty;
+            var effectiveMultiplier = Math.Clamp(reduced, minMultiplier, maxMultiplier);
+
+            var roll = abilities.Ruleset.CharacteristicRoll(Constitution, effectiveMultiplier);
+            var outcome = AbilityResolver.Resolve(abilities, roll, [], entropy)
+                ?? throw new InvalidOperationException("A CON recovery roll was unexpectedly gated.");
+            days.Add(new DailyRecoveryRoll(day, effectiveMultiplier, outcome));
+
+            if (outcome.Succeeded)
+            {
+                recovered = true;
+                break;
+            }
+
+            failures++;
+            if (outcome.Level == SuccessLevel.Fumble)
+            {
+                fumblePenalty += ruleset.RecoveryLadderFumbleMultiplierPenalty;
+            }
+        }
+
+        return new RecoveryLadderOutcome(failures, recovered, days);
+    }
+
+    /// <summary>
+    /// Looks up the Illness Severity Table degree for <paramref name="failures"/> failed CON rolls
+    /// and drains that many points from <paramref name="characteristic"/> (via
+    /// <see cref="InjuryDrain"/>, so derived values recompute), per Ch 7, "Disease"/"Illness
+    /// Severity Table" (p.170). The affected characteristic is the gamemaster's call
+    /// (<see cref="Core.Contests.InjuryDecisionId.DiseaseAffectedCharacteristic"/>), supplied by the
+    /// caller.
+    /// </summary>
+    public static DiseaseSeverityOutcome ApplySeverityDrain(
+        AbilitySet abilities, CharacteristicId characteristic, int failures, DiseaseRuleset ruleset)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentOutOfRangeException.ThrowIfNegative(failures);
+
+        var band = ruleset.IllnessSeverityTable.ForFailures(failures);
+        var newValue = InjuryDrain.Apply(abilities, characteristic, failures);
+        return new DiseaseSeverityOutcome(band.Degree, band.LossPeriod, PointsLost: failures, newValue);
+    }
+
+    /// <summary>
+    /// Rolls a minor disease's incidental cost, per Ch 7, "Disease" (p.169): "1 or 2 hit points and
+    /// 1D6 fatigue points over a few days." The hit-point loss can be applied through
+    /// <see cref="DamageResolver.ApplyDamage(AbilitySet, Characters.WoundTrack, int, DamageRuleset, string)"/>;
+    /// the fatigue-point loss is reported for callers but not applied here (no fatigue-point
+    /// subsystem exists yet -- out of scope for #96).
+    /// </summary>
+    public static MinorDiseaseEffect RollMinorDiseaseEffect(DiseaseRuleset ruleset, IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var hitPointLoss = ruleset.MinorDiseaseHitPointLoss.Roll(entropy).Total;
+        var fatigueLoss = ruleset.MinorDiseaseFatigueLoss.Roll(entropy).Total;
+        return new MinorDiseaseEffect(hitPointLoss, fatigueLoss);
+    }
+}
+
+/// <summary>The result of a Stamina contraction roll (Ch 7, p.169).</summary>
+/// <param name="StaminaRoll">The resolved Stamina (CON) roll.</param>
+/// <param name="Contracted">Whether the disease was contracted (the roll failed).</param>
+public sealed record DiseaseContraction(RollOutcome StaminaRoll, bool Contracted);
+
+/// <summary>One day's recovery roll on the CON×N ladder (Ch 7, p.169).</summary>
+/// <param name="Day">The zero-based day index (day 0 is the book's "second day", CON×2).</param>
+/// <param name="EffectiveMultiplier">The CON multiplier actually rolled, after penalties and clamping.</param>
+/// <param name="Roll">The resolved CON roll.</param>
+public sealed record DailyRecoveryRoll(int Day, int EffectiveMultiplier, RollOutcome Roll);
+
+/// <summary>The result of running the CON×N recovery ladder (Ch 7, p.169).</summary>
+/// <param name="Failures">The number of failed recovery rolls (the Illness Severity Table index).</param>
+/// <param name="Recovered">Whether the character recovered within the day budget.</param>
+/// <param name="Days">Each day's roll, in order.</param>
+public sealed record RecoveryLadderOutcome(int Failures, bool Recovered, IReadOnlyList<DailyRecoveryRoll> Days);
+
+/// <summary>The result of applying Illness Severity Table drain (Ch 7, p.170).</summary>
+/// <param name="Degree">The degree of illness for the failure count.</param>
+/// <param name="LossPeriod">The period over which further points would be lost.</param>
+/// <param name="PointsLost">The characteristic points drained.</param>
+/// <param name="ResultingValue">The characteristic's value after the drain.</param>
+public sealed record DiseaseSeverityOutcome(
+    IllnessDegree Degree, IllnessLossPeriod LossPeriod, int PointsLost, int ResultingValue);
+
+/// <summary>The incidental cost of a minor disease (Ch 7, p.169).</summary>
+/// <param name="HitPointLoss">Hit points lost over the illness.</param>
+/// <param name="FatigueLoss">Fatigue points lost (reported only; no fatigue subsystem yet).</param>
+public readonly record struct MinorDiseaseEffect(int HitPointLoss, int FatigueLoss);

--- a/src/Brp.Rules/Combat/DiseaseRuleset.cs
+++ b/src/Brp.Rules/Combat/DiseaseRuleset.cs
@@ -1,0 +1,80 @@
+using Brp.Core.Dice;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The data-defined values of Ch 7: Spot Rules, "Disease" (pp.169-170) (AGENTS.md invariant 7:
+/// rules values are data, not constants), including the "Illness Severity Table" as a banded
+/// lookup. Loaded from <c>injury-ruleset.json</c> by <c>Brp.Data.NoirInjuryRuleset.Load()</c>.
+/// See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public sealed class DiseaseRuleset
+{
+    /// <summary>Creates a disease ruleset from data-defined values.</summary>
+    public DiseaseRuleset(
+        DiceExpression minorDiseaseHitPointLoss,
+        DiceExpression minorDiseaseFatigueLoss,
+        int recoveryLadderStartingMultiplier,
+        int recoveryLadderMultiplierIncrementPerDay,
+        int recoveryLadderFumbleMultiplierPenalty,
+        int recoveryLadderStrenuousConditionPenalty,
+        IllnessSeverityTable illnessSeverityTable)
+    {
+        ArgumentNullException.ThrowIfNull(minorDiseaseHitPointLoss);
+        ArgumentNullException.ThrowIfNull(minorDiseaseFatigueLoss);
+        ArgumentNullException.ThrowIfNull(illnessSeverityTable);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(recoveryLadderStartingMultiplier);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(recoveryLadderMultiplierIncrementPerDay);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(recoveryLadderFumbleMultiplierPenalty);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(recoveryLadderStrenuousConditionPenalty);
+
+        MinorDiseaseHitPointLoss = minorDiseaseHitPointLoss;
+        MinorDiseaseFatigueLoss = minorDiseaseFatigueLoss;
+        RecoveryLadderStartingMultiplier = recoveryLadderStartingMultiplier;
+        RecoveryLadderMultiplierIncrementPerDay = recoveryLadderMultiplierIncrementPerDay;
+        RecoveryLadderFumbleMultiplierPenalty = recoveryLadderFumbleMultiplierPenalty;
+        RecoveryLadderStrenuousConditionPenalty = recoveryLadderStrenuousConditionPenalty;
+        IllnessSeverityTable = illnessSeverityTable;
+    }
+
+    /// <summary>
+    /// Ch 7, "Disease" (p.169): a minor disease should "merely cost 1 or 2 hit points... over a few
+    /// days." The hit-point loss a minor disease inflicts.
+    /// </summary>
+    public DiceExpression MinorDiseaseHitPointLoss { get; }
+
+    /// <summary>
+    /// Ch 7, "Disease" (p.169): "...and 1D6 fatigue points over a few days." The fatigue-point loss
+    /// a minor disease inflicts. (No fatigue-point subsystem is built yet -- see the resolver.)
+    /// </summary>
+    public DiceExpression MinorDiseaseFatigueLoss { get; }
+
+    /// <summary>
+    /// Ch 7, "Disease" (p.169): "On the morning of the second day... roll CON×2." The multiplier the
+    /// recovery ladder begins at (the second day).
+    /// </summary>
+    public int RecoveryLadderStartingMultiplier { get; }
+
+    /// <summary>
+    /// Ch 7, "Disease" (p.169): "On the morning of the third day, roll CON×3, continuing by
+    /// increasing the multiplier... until the disease is finally overcome." The amount the recovery
+    /// multiplier rises each successive day.
+    /// </summary>
+    public int RecoveryLadderMultiplierIncrementPerDay { get; }
+
+    /// <summary>
+    /// Ch 7, "Disease" (p.169): "A fumble reduces the multiplier by ×1." The amount a fumbled
+    /// recovery roll subtracts from subsequent recovery multipliers.
+    /// </summary>
+    public int RecoveryLadderFumbleMultiplierPenalty { get; }
+
+    /// <summary>
+    /// Ch 7, "Disease" (p.169): "Strenuous conditions (adventuring, combat, hard travel, etc.)
+    /// reduce this characteristic roll by ×1 per outstanding condition." The multiplier reduction
+    /// per outstanding strenuous condition.
+    /// </summary>
+    public int RecoveryLadderStrenuousConditionPenalty { get; }
+
+    /// <summary>Ch 7, "Illness Severity Table" (p.170), as a banded lookup by failed-roll count.</summary>
+    public IllnessSeverityTable IllnessSeverityTable { get; }
+}

--- a/src/Brp.Rules/Combat/DiseaseRuleset.cs
+++ b/src/Brp.Rules/Combat/DiseaseRuleset.cs
@@ -3,7 +3,7 @@ using Brp.Core.Dice;
 namespace Brp.Rules.Combat;
 
 /// <summary>
-/// The data-defined values of Ch 7: Spot Rules, "Disease" (pp.169-170) (AGENTS.md invariant 7:
+/// The data-defined values of Ch 7: Spot Rules, "Disease" (p.170) (AGENTS.md invariant 7:
 /// rules values are data, not constants), including the "Illness Severity Table" as a banded
 /// lookup. Loaded from <c>injury-ruleset.json</c> by <c>Brp.Data.NoirInjuryRuleset.Load()</c>.
 /// See <c>docs/decisions/0019-injury-spot-rules.md</c>.
@@ -38,38 +38,38 @@ public sealed class DiseaseRuleset
     }
 
     /// <summary>
-    /// Ch 7, "Disease" (p.169): a minor disease should "merely cost 1 or 2 hit points... over a few
+    /// Ch 7, "Disease" (p.170): a minor disease should "merely cost 1 or 2 hit points... over a few
     /// days." The hit-point loss a minor disease inflicts.
     /// </summary>
     public DiceExpression MinorDiseaseHitPointLoss { get; }
 
     /// <summary>
-    /// Ch 7, "Disease" (p.169): "...and 1D6 fatigue points over a few days." The fatigue-point loss
+    /// Ch 7, "Disease" (p.170): "...and 1D6 fatigue points over a few days." The fatigue-point loss
     /// a minor disease inflicts. (No fatigue-point subsystem is built yet -- see the resolver.)
     /// </summary>
     public DiceExpression MinorDiseaseFatigueLoss { get; }
 
     /// <summary>
-    /// Ch 7, "Disease" (p.169): "On the morning of the second day... roll CON×2." The multiplier the
+    /// Ch 7, "Disease" (p.170): "On the morning of the second day... roll CON×2." The multiplier the
     /// recovery ladder begins at (the second day).
     /// </summary>
     public int RecoveryLadderStartingMultiplier { get; }
 
     /// <summary>
-    /// Ch 7, "Disease" (p.169): "On the morning of the third day, roll CON×3, continuing by
+    /// Ch 7, "Disease" (p.170): "On the morning of the third day, roll CON×3, continuing by
     /// increasing the multiplier... until the disease is finally overcome." The amount the recovery
     /// multiplier rises each successive day.
     /// </summary>
     public int RecoveryLadderMultiplierIncrementPerDay { get; }
 
     /// <summary>
-    /// Ch 7, "Disease" (p.169): "A fumble reduces the multiplier by ×1." The amount a fumbled
+    /// Ch 7, "Disease" (p.170): "A fumble reduces the multiplier by ×1." The amount a fumbled
     /// recovery roll subtracts from subsequent recovery multipliers.
     /// </summary>
     public int RecoveryLadderFumbleMultiplierPenalty { get; }
 
     /// <summary>
-    /// Ch 7, "Disease" (p.169): "Strenuous conditions (adventuring, combat, hard travel, etc.)
+    /// Ch 7, "Disease" (p.170): "Strenuous conditions (adventuring, combat, hard travel, etc.)
     /// reduce this characteristic roll by ×1 per outstanding condition." The multiplier reduction
     /// per outstanding strenuous condition.
     /// </summary>

--- a/src/Brp.Rules/Combat/FallingResolver.cs
+++ b/src/Brp.Rules/Combat/FallingResolver.cs
@@ -1,0 +1,123 @@
+using Brp.Core.Contests;
+using Brp.Core.Dice;
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Computes and applies Ch 7: Spot Rules, "Falling" (p.171) damage: a base dice pool by distance,
+/// doubled if thrown with force, adjusted for a small or large faller's SIZ, then mitigated by
+/// (half) armor and any gamemaster surface ruling, and finally applied to hit points through the
+/// non-weapon overload of <see cref="DamageResolver.ApplyDamage(Core.Abilities.AbilitySet, Characters.WoundTrack, int, DamageRuleset, string)"/>.
+/// One of the injury/effect spot rules (#96), the sibling of the situational-modifier spot rules
+/// <see cref="SpotRuleResolver"/> (#50). See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// <para>
+/// <strong>House reading of ambiguous prose (marked in ADR 0019):</strong> the book's large-size
+/// clause -- "adding an extra 1D6 damage if the character's SIZ is over 20 and another 1D6 for
+/// every fraction of 20 after that" -- is read as one extra die per started band of
+/// <see cref="FallingRuleset.LargeSizeBand"/> above <see cref="FallingRuleset.LargeSizeThreshold"/>
+/// (SIZ 21-40 = one die, 41-60 = two, ...), so the "over 20" die and the "fraction of 20" dice are
+/// the same series rather than double-counted. Armor's "half protection... up to three meters" is
+/// applied as half the armor value within that distance and <em>no</em> armor beyond it, the latter
+/// being a house reading of the book's silence on armor for longer falls.
+/// </para>
+/// </summary>
+public static class FallingResolver
+{
+    /// <summary>
+    /// Rolls the pre-mitigation falling damage for a fall of <paramref name="metersFallen"/> by a
+    /// character of the given <paramref name="size"/>. Consumes one entropy draw per die in the
+    /// base pool, then the large-size dice, then the small-size reduction die -- in that order.
+    /// </summary>
+    /// <param name="metersFallen">The distance fallen, in meters. Non-negative.</param>
+    /// <param name="size">The falling character's SIZ.</param>
+    /// <param name="thrownWithForce">Whether the character was thrown with considerable force.</param>
+    /// <param name="ruleset">The falling values.</param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    public static FallingDamageRoll RollFallingDamage(
+        int metersFallen, int size, bool thrownWithForce, FallingRuleset ruleset, IEntropySource entropy)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(metersFallen);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var baseDiceCount = metersFallen / ruleset.MetersPerDamageIncrement;
+        if (thrownWithForce)
+        {
+            baseDiceCount *= ruleset.ForceMultiplier;
+        }
+
+        var damage = RollPool(ruleset.BaseDamagePerIncrement, baseDiceCount, entropy);
+
+        var largeSizeBands = 0;
+        if (size > ruleset.LargeSizeThreshold)
+        {
+            // House reading: one band per started LargeSizeBand above the threshold.
+            largeSizeBands = CeilingDivide(size - ruleset.LargeSizeThreshold, ruleset.LargeSizeBand);
+            damage += RollPool(ruleset.LargeSizeExtraDamage, largeSizeBands, entropy);
+        }
+
+        var smallSizeApplied = size <= ruleset.SmallSizeThreshold;
+        if (smallSizeApplied)
+        {
+            damage -= ruleset.SmallSizeReduction.Roll(entropy).Total;
+        }
+
+        return new FallingDamageRoll(
+            Math.Max(0, damage), baseDiceCount, largeSizeBands, smallSizeApplied, thrownWithForce);
+    }
+
+    /// <summary>
+    /// Mitigates a <see cref="FallingDamageRoll"/> by armor and a gamemaster surface ruling, giving
+    /// the hit-point loss to apply. Armor applies at half value only within
+    /// <see cref="FallingRuleset.ArmorHalfProtectionMaxMeters"/> (and not at all beyond it -- see
+    /// the type remarks); the surface adjustment (<see cref="InjuryDecisionId.FallingSurface"/>) is
+    /// then added, and the result floored at zero.
+    /// </summary>
+    public static int MitigateFallingDamage(
+        FallingDamageRoll roll, int armorValue, int metersFallen, FallingSurfaceRuling surface, FallingRuleset ruleset)
+    {
+        ArgumentNullException.ThrowIfNull(roll);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentOutOfRangeException.ThrowIfNegative(armorValue);
+        ArgumentOutOfRangeException.ThrowIfNegative(metersFallen);
+
+        var effectiveArmor = metersFallen <= ruleset.ArmorHalfProtectionMaxMeters
+            ? Rounding.Divide(
+                armorValue * ruleset.ArmorProtectionNumerator, ruleset.ArmorProtectionDenominator, RoundingMode.Down)
+            : 0;
+
+        var afterArmor = Math.Max(0, roll.DamageBeforeMitigation - effectiveArmor);
+        return Math.Max(0, afterArmor + surface.DamageAdjustment);
+    }
+
+    private static int RollPool(DiceExpression die, int count, IEntropySource entropy)
+    {
+        var total = 0;
+        for (var i = 0; i < count; i++)
+        {
+            total += die.Roll(entropy).Total;
+        }
+
+        return total;
+    }
+
+    private static int CeilingDivide(int numerator, int denominator) => (numerator + denominator - 1) / denominator;
+}
+
+/// <summary>
+/// The pre-mitigation result of a <see cref="FallingResolver.RollFallingDamage"/>, carrying the
+/// rolled damage and the breakdown that produced it (for provenance and tests).
+/// </summary>
+/// <param name="DamageBeforeMitigation">The rolled falling damage before armor and surface, floored at zero.</param>
+/// <param name="BaseDiceCount">The number of base distance dice rolled (already force-doubled if applicable).</param>
+/// <param name="LargeSizeBands">The number of large-size extra dice added (0 for a non-large faller).</param>
+/// <param name="SmallSizeReductionApplied">Whether the small-size reduction was subtracted.</param>
+/// <param name="ThrownWithForce">Whether the base dice count was doubled for being thrown with force.</param>
+public sealed record FallingDamageRoll(
+    int DamageBeforeMitigation,
+    int BaseDiceCount,
+    int LargeSizeBands,
+    bool SmallSizeReductionApplied,
+    bool ThrownWithForce);

--- a/src/Brp.Rules/Combat/FallingRuleset.cs
+++ b/src/Brp.Rules/Combat/FallingRuleset.cs
@@ -3,7 +3,7 @@ using Brp.Core.Dice;
 namespace Brp.Rules.Combat;
 
 /// <summary>
-/// The data-defined values of Ch 7: Spot Rules, "Falling" (p.171) (AGENTS.md invariant 7: rules
+/// The data-defined values of Ch 7: Spot Rules, "Falling" (pp.171-172) (AGENTS.md invariant 7: rules
 /// values are data, not constants). Loaded from <c>injury-ruleset.json</c> by
 /// <c>Brp.Data.NoirInjuryRuleset.Load()</c>. See <c>docs/decisions/0019-injury-spot-rules.md</c>.
 /// </summary>
@@ -99,13 +99,13 @@ public sealed class FallingRuleset
     public DiceExpression LargeSizeExtraDamage { get; }
 
     /// <summary>
-    /// Ch 7, "Falling" (p.171): "Armor provides half protection against falling damage up to three
+    /// Ch 7, "Falling" (p.172): "Armor provides half protection against falling damage up to three
     /// meters." The maximum fall distance for which armor applies at all.
     /// </summary>
     public int ArmorHalfProtectionMaxMeters { get; }
 
     /// <summary>
-    /// Ch 7, "Falling" (p.171): "half protection." Numerator of the fraction of the armor value that
+    /// Ch 7, "Falling" (p.172): "half protection." Numerator of the fraction of the armor value that
     /// applies within <see cref="ArmorHalfProtectionMaxMeters"/> (1 of 2 = half).
     /// </summary>
     public int ArmorProtectionNumerator { get; }

--- a/src/Brp.Rules/Combat/FallingRuleset.cs
+++ b/src/Brp.Rules/Combat/FallingRuleset.cs
@@ -1,0 +1,115 @@
+using Brp.Core.Dice;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The data-defined values of Ch 7: Spot Rules, "Falling" (p.171) (AGENTS.md invariant 7: rules
+/// values are data, not constants). Loaded from <c>injury-ruleset.json</c> by
+/// <c>Brp.Data.NoirInjuryRuleset.Load()</c>. See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public sealed class FallingRuleset
+{
+    /// <summary>Creates a falling ruleset from data-defined values.</summary>
+    public FallingRuleset(
+        DiceExpression baseDamagePerIncrement,
+        int metersPerDamageIncrement,
+        int forceMultiplier,
+        int smallSizeThreshold,
+        DiceExpression smallSizeReduction,
+        int largeSizeThreshold,
+        int largeSizeBand,
+        DiceExpression largeSizeExtraDamage,
+        int armorHalfProtectionMaxMeters,
+        int armorProtectionNumerator,
+        int armorProtectionDenominator)
+    {
+        ArgumentNullException.ThrowIfNull(baseDamagePerIncrement);
+        ArgumentNullException.ThrowIfNull(smallSizeReduction);
+        ArgumentNullException.ThrowIfNull(largeSizeExtraDamage);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(metersPerDamageIncrement);
+        ArgumentOutOfRangeException.ThrowIfLessThan(forceMultiplier, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(smallSizeThreshold);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(largeSizeBand);
+        ArgumentOutOfRangeException.ThrowIfLessThan(largeSizeThreshold, smallSizeThreshold);
+        ArgumentOutOfRangeException.ThrowIfNegative(armorHalfProtectionMaxMeters);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(armorProtectionNumerator);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(armorProtectionDenominator);
+
+        BaseDamagePerIncrement = baseDamagePerIncrement;
+        MetersPerDamageIncrement = metersPerDamageIncrement;
+        ForceMultiplier = forceMultiplier;
+        SmallSizeThreshold = smallSizeThreshold;
+        SmallSizeReduction = smallSizeReduction;
+        LargeSizeThreshold = largeSizeThreshold;
+        LargeSizeBand = largeSizeBand;
+        LargeSizeExtraDamage = largeSizeExtraDamage;
+        ArmorHalfProtectionMaxMeters = armorHalfProtectionMaxMeters;
+        ArmorProtectionNumerator = armorProtectionNumerator;
+        ArmorProtectionDenominator = armorProtectionDenominator;
+    }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "A falling character takes 1D6 base damage for every three meters
+    /// fallen." The dice pool contributed per <see cref="MetersPerDamageIncrement"/> of the fall.
+    /// </summary>
+    public DiceExpression BaseDamagePerIncrement { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "...for every three meters fallen." The distance one
+    /// <see cref="BaseDamagePerIncrement"/> covers.
+    /// </summary>
+    public int MetersPerDamageIncrement { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "If thrown with considerable force, the dice rolled may be
+    /// doubled." The factor the base distance dice count is multiplied by when thrown with force.
+    /// </summary>
+    public int ForceMultiplier { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "if SIZ is 5 or less, reduce the damage from falling by 1D6." A
+    /// character whose SIZ is at or below this threshold takes <see cref="SmallSizeReduction"/> less.
+    /// </summary>
+    public int SmallSizeThreshold { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "reduce the damage from falling by 1D6." The amount subtracted from
+    /// a small character's rolled falling damage.
+    /// </summary>
+    public DiceExpression SmallSizeReduction { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "adding an extra 1D6 damage if the character's SIZ is over 20." A
+    /// character whose SIZ exceeds this threshold takes <see cref="LargeSizeExtraDamage"/> per band.
+    /// </summary>
+    public int LargeSizeThreshold { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "another 1D6 for every fraction of 20 after that." The width of one
+    /// large-size band above <see cref="LargeSizeThreshold"/>; the number of bands started
+    /// determines how many <see cref="LargeSizeExtraDamage"/> the fall adds.
+    /// </summary>
+    public int LargeSizeBand { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "adding an extra 1D6 damage... and another 1D6 for every fraction of
+    /// 20 after that. This is cumulative with the modifier for force." The dice added per large-size
+    /// band.
+    /// </summary>
+    public DiceExpression LargeSizeExtraDamage { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "Armor provides half protection against falling damage up to three
+    /// meters." The maximum fall distance for which armor applies at all.
+    /// </summary>
+    public int ArmorHalfProtectionMaxMeters { get; }
+
+    /// <summary>
+    /// Ch 7, "Falling" (p.171): "half protection." Numerator of the fraction of the armor value that
+    /// applies within <see cref="ArmorHalfProtectionMaxMeters"/> (1 of 2 = half).
+    /// </summary>
+    public int ArmorProtectionNumerator { get; }
+
+    /// <summary>See <see cref="ArmorProtectionNumerator"/>.</summary>
+    public int ArmorProtectionDenominator { get; }
+}

--- a/src/Brp.Rules/Combat/IllnessDegree.cs
+++ b/src/Brp.Rules/Combat/IllnessDegree.cs
@@ -1,0 +1,47 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The degree of illness a diseased character suffers, one row of Ch 7: Spot Rules, "Illness
+/// Severity Table" (p.170), cross-indexed by the number of failed CON recovery rolls.
+/// </summary>
+public enum IllnessDegree
+{
+    /// <summary>0 failures: "None" -- no characteristic loss (p.170).</summary>
+    None,
+
+    /// <summary>1 failure: "Mild: lose 1 characteristic point per week" (p.170).</summary>
+    Mild,
+
+    /// <summary>2 failures: "Acute: lose 1 characteristic point per day" (p.170).</summary>
+    Acute,
+
+    /// <summary>3 failures: "Severe: lose 1 characteristic point per hour" (p.170).</summary>
+    Severe,
+
+    /// <summary>4+ failures: "Terminal: lose 1 characteristic point per minute" (p.170).</summary>
+    Terminal,
+}
+
+/// <summary>
+/// The period over which a diseased character loses one characteristic point, the "per week / per
+/// day / per hour / per minute" clause of each Ch 7 "Illness Severity Table" row (p.170). Carried
+/// alongside <see cref="IllnessDegree"/> so the printed table is reproduced in full rather than
+/// collapsed to the degree name alone.
+/// </summary>
+public enum IllnessLossPeriod
+{
+    /// <summary>No ongoing loss (the "None" degree).</summary>
+    None,
+
+    /// <summary>One characteristic point per week (the "Mild" degree).</summary>
+    Week,
+
+    /// <summary>One characteristic point per day (the "Acute" degree).</summary>
+    Day,
+
+    /// <summary>One characteristic point per hour (the "Severe" degree).</summary>
+    Hour,
+
+    /// <summary>One characteristic point per minute (the "Terminal" degree).</summary>
+    Minute,
+}

--- a/src/Brp.Rules/Combat/IllnessSeverityBand.cs
+++ b/src/Brp.Rules/Combat/IllnessSeverityBand.cs
@@ -1,0 +1,24 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// One row of Ch 7: Spot Rules, "Illness Severity Table" (p.170), banded by the number of failed
+/// CON recovery rolls. Mirrors <see cref="Core.Abilities.DamageModifierBand"/>: a lower bound, an
+/// optional upper bound (open-ended for the "4+" Terminal row), and the printed effect.
+/// </summary>
+/// <param name="MinimumFailures">The lowest failure count this row covers.</param>
+/// <param name="MaximumFailures">
+/// The highest failure count this row covers, or <see langword="null"/> for the open-ended "4+"
+/// Terminal row.
+/// </param>
+/// <param name="Degree">The printed degree of illness for this row.</param>
+/// <param name="LossPeriod">The printed loss period for this row.</param>
+public sealed record IllnessSeverityBand(
+    int MinimumFailures,
+    int? MaximumFailures,
+    IllnessDegree Degree,
+    IllnessLossPeriod LossPeriod)
+{
+    /// <summary>Whether this row covers the given number of failed CON recovery rolls.</summary>
+    public bool Contains(int failures) =>
+        failures >= MinimumFailures && (MaximumFailures is null || failures <= MaximumFailures.Value);
+}

--- a/src/Brp.Rules/Combat/IllnessSeverityTable.cs
+++ b/src/Brp.Rules/Combat/IllnessSeverityTable.cs
@@ -1,0 +1,35 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Data-backed lookup for Ch 7: Spot Rules, "Illness Severity Table" (p.170). The table's rows
+/// (0 None, 1 Mild, 2 Acute, 3 Severe, 4+ Terminal) are represented as ruleset bands, cross-indexed
+/// by the number of times a character has failed their CON recovery roll. Mirrors
+/// <see cref="Core.Abilities.DamageModifierTable"/>.
+/// </summary>
+public sealed class IllnessSeverityTable
+{
+    private readonly List<IllnessSeverityBand> _bands;
+
+    /// <summary>Creates a table from ordered ruleset rows.</summary>
+    public IllnessSeverityTable(IEnumerable<IllnessSeverityBand> bands)
+    {
+        ArgumentNullException.ThrowIfNull(bands);
+        _bands = bands.ToList();
+        if (_bands.Count == 0)
+        {
+            throw new ArgumentException("Illness severity table must contain at least one band.", nameof(bands));
+        }
+    }
+
+    /// <summary>Every printed row, in load order.</summary>
+    public IReadOnlyList<IllnessSeverityBand> Bands => _bands;
+
+    /// <summary>Returns the row that covers the given number of failed CON recovery rolls.</summary>
+    public IllnessSeverityBand ForFailures(int failures)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(failures);
+        return _bands.SingleOrDefault(band => band.Contains(failures))
+            ?? throw new ArgumentOutOfRangeException(
+                nameof(failures), failures, "No illness severity band covers this failure count.");
+    }
+}

--- a/src/Brp.Rules/Combat/InjuryDrain.cs
+++ b/src/Brp.Rules/Combat/InjuryDrain.cs
@@ -1,0 +1,33 @@
+using Brp.Core.Abilities;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Shared helper for the injury spot rules (#96) that drain a characteristic. Applies the loss
+/// through <see cref="AbilitySet.Set"/> -- never by baking hit points -- so the Layer 1 derived
+/// characteristics (hit points, major-wound level, skill category modifiers) recompute live, per
+/// Ch 2: Characters, "Derived Characteristics" (p.13). The new value is floored at the
+/// characteristic's ruleset minimum, since <see cref="AbilitySet.Set"/> rejects a value below it
+/// (Ch 7, "Disease" (p.170): reaching 0 "usually means death or permanent debilitation," a state
+/// the caller resolves rather than a negative characteristic).
+/// </summary>
+internal static class InjuryDrain
+{
+    /// <summary>
+    /// Lowers <paramref name="characteristic"/> by <paramref name="points"/>, floored at its ruleset
+    /// minimum, and returns the resulting value.
+    /// </summary>
+    public static int Apply(AbilitySet abilities, CharacteristicId characteristic, int points)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        ArgumentOutOfRangeException.ThrowIfNegative(points);
+
+        var minimum = abilities.Ruleset.Characteristics.TryGetValue(characteristic, out var definition)
+            ? definition.Minimum
+            : throw new KeyNotFoundException($"Unknown characteristic '{characteristic}'.");
+
+        var newValue = Math.Max(minimum, abilities.ValueOf(characteristic) - points);
+        abilities.Set(characteristic, newValue);
+        return newValue;
+    }
+}

--- a/src/Brp.Rules/Combat/InjuryRuleset.cs
+++ b/src/Brp.Rules/Combat/InjuryRuleset.cs
@@ -1,8 +1,8 @@
 namespace Brp.Rules.Combat;
 
 /// <summary>
-/// The aggregate ruleset for the Ch 7: Spot Rules injury/effect rules (#96) -- Falling (p.171),
-/// Poison (pp.175-176), and Disease (pp.169-170) -- grouped so a single
+/// The aggregate ruleset for the Ch 7: Spot Rules injury/effect rules (#96) -- Falling (pp.171-172),
+/// Poison (p.176), and Disease (p.170) -- grouped so a single
 /// <c>Brp.Data.NoirInjuryRuleset.Load()</c> supplies them all while each rule's resolver takes only
 /// the sub-ruleset it needs. The sibling of <see cref="SpotRuleRuleset"/> (the situational-modifier
 /// spot rules, #50). All values are data (AGENTS.md invariant 7); see
@@ -22,12 +22,12 @@ public sealed class InjuryRuleset
         Disease = disease;
     }
 
-    /// <summary>Ch 7, "Falling" (p.171) values.</summary>
+    /// <summary>Ch 7, "Falling" (pp.171-172) values.</summary>
     public FallingRuleset Falling { get; }
 
-    /// <summary>Ch 7, "Poison" / "Poison Antidotes" (pp.175-176) values.</summary>
+    /// <summary>Ch 7, "Poison" / "Poison Antidotes" (p.176) values.</summary>
     public PoisonRuleset Poison { get; }
 
-    /// <summary>Ch 7, "Disease" (pp.169-170) values, including the Illness Severity Table.</summary>
+    /// <summary>Ch 7, "Disease" (p.170) values, including the Illness Severity Table.</summary>
     public DiseaseRuleset Disease { get; }
 }

--- a/src/Brp.Rules/Combat/InjuryRuleset.cs
+++ b/src/Brp.Rules/Combat/InjuryRuleset.cs
@@ -1,0 +1,33 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The aggregate ruleset for the Ch 7: Spot Rules injury/effect rules (#96) -- Falling (p.171),
+/// Poison (pp.175-176), and Disease (pp.169-170) -- grouped so a single
+/// <c>Brp.Data.NoirInjuryRuleset.Load()</c> supplies them all while each rule's resolver takes only
+/// the sub-ruleset it needs. The sibling of <see cref="SpotRuleRuleset"/> (the situational-modifier
+/// spot rules, #50). All values are data (AGENTS.md invariant 7); see
+/// <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public sealed class InjuryRuleset
+{
+    /// <summary>Creates an injury ruleset from its three grouped sub-rulesets.</summary>
+    public InjuryRuleset(FallingRuleset falling, PoisonRuleset poison, DiseaseRuleset disease)
+    {
+        ArgumentNullException.ThrowIfNull(falling);
+        ArgumentNullException.ThrowIfNull(poison);
+        ArgumentNullException.ThrowIfNull(disease);
+
+        Falling = falling;
+        Poison = poison;
+        Disease = disease;
+    }
+
+    /// <summary>Ch 7, "Falling" (p.171) values.</summary>
+    public FallingRuleset Falling { get; }
+
+    /// <summary>Ch 7, "Poison" / "Poison Antidotes" (pp.175-176) values.</summary>
+    public PoisonRuleset Poison { get; }
+
+    /// <summary>Ch 7, "Disease" (pp.169-170) values, including the Illness Severity Table.</summary>
+    public DiseaseRuleset Disease { get; }
+}

--- a/src/Brp.Rules/Combat/PoisonResolver.cs
+++ b/src/Brp.Rules/Combat/PoisonResolver.cs
@@ -7,7 +7,7 @@ using Brp.Rules.Characters;
 namespace Brp.Rules.Combat;
 
 /// <summary>
-/// Resolves and applies Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (pp.175-176): a poison's
+/// Resolves and applies Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (p.176): a poison's
 /// POT is matched against a character's CON on the resistance table
 /// (<see cref="ResistanceResolver"/>); overcoming CON deals the full POT, otherwise half (round up).
 /// The damage lands on hit points (through the non-weapon overload of
@@ -19,7 +19,7 @@ namespace Brp.Rules.Combat;
 /// its POT from the poison POT before the resistance roll and damage are figured; a mismatched
 /// antidote's benefit is a gamemaster call (<see cref="InjuryDecisionId.AntidoteCrossType"/>). Two
 /// doses are two separate <see cref="ResolvePoison"/> calls, each drawing its own resistance roll --
-/// "two doses of a POT 10 poison are not the same as one dose of a POT 20 poison" (p.175).
+/// "two doses of a POT 10 poison are not the same as one dose of a POT 20 poison" (p.176).
 /// </para>
 /// </summary>
 public static class PoisonResolver
@@ -124,7 +124,7 @@ public static class PoisonResolver
     }
 
     /// <summary>
-    /// The onset delay before a resolved poison's damage takes effect, per Ch 7, "Poison" (p.175),
+    /// The onset delay before a resolved poison's damage takes effect, per Ch 7, "Poison" (p.176),
     /// as decided by the gamemaster (<see cref="InjuryDecisionId.PoisonOnset"/>): a bespoke delay if
     /// specified, otherwise the printed default for the poison's onset speed.
     /// </summary>
@@ -157,7 +157,7 @@ public sealed record PoisonOutcome(
     bool Overcame,
     int Damage);
 
-/// <summary>The time unit a <see cref="PoisonOnset"/> delay is measured in (Ch 7, p.175).</summary>
+/// <summary>The time unit a <see cref="PoisonOnset"/> delay is measured in (Ch 7, p.176).</summary>
 public enum PoisonOnsetUnit
 {
     /// <summary>Combat rounds -- the unit for a fast-acting poison's default delay.</summary>
@@ -167,7 +167,7 @@ public enum PoisonOnsetUnit
     FullTurns,
 }
 
-/// <summary>A resolved poison onset delay (Ch 7, p.175).</summary>
+/// <summary>A resolved poison onset delay (Ch 7, p.176).</summary>
 /// <param name="Delay">The number of <paramref name="Unit"/> before the poison's damage takes effect.</param>
 /// <param name="Unit">The time unit the delay is measured in.</param>
 public readonly record struct PoisonOnset(int Delay, PoisonOnsetUnit Unit);

--- a/src/Brp.Rules/Combat/PoisonResolver.cs
+++ b/src/Brp.Rules/Combat/PoisonResolver.cs
@@ -1,0 +1,173 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Resolves and applies Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (pp.175-176): a poison's
+/// POT is matched against a character's CON on the resistance table
+/// (<see cref="ResistanceResolver"/>); overcoming CON deals the full POT, otherwise half (round up).
+/// The damage lands on hit points (through the non-weapon overload of
+/// <see cref="DamageResolver.ApplyDamage(AbilitySet, WoundTrack, int, DamageRuleset, string)"/>) or
+/// drains a characteristic (through <see cref="AbilitySet.Set"/>, so derived values recompute). One
+/// of the injury/effect spot rules (#96). See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// <para>
+/// An antidote taken within the window (<see cref="PoisonRuleset.AntidoteWindowTurns"/>) subtracts
+/// its POT from the poison POT before the resistance roll and damage are figured; a mismatched
+/// antidote's benefit is a gamemaster call (<see cref="InjuryDecisionId.AntidoteCrossType"/>). Two
+/// doses are two separate <see cref="ResolvePoison"/> calls, each drawing its own resistance roll --
+/// "two doses of a POT 10 poison are not the same as one dose of a POT 20 poison" (p.175).
+/// </para>
+/// </summary>
+public static class PoisonResolver
+{
+    /// <summary>
+    /// The effective POT a taken antidote contributes against a poison, per Ch 7, "Poison
+    /// Antidotes" (p.176). Outside the window (<paramref name="turnsBeforePoisoning"/> greater than
+    /// <see cref="PoisonRuleset.AntidoteWindowTurns"/>) the antidote is spent and contributes
+    /// nothing; within it, a same-type antidote contributes its full POT and a cross-type antidote
+    /// contributes the gamemaster's lessened benefit
+    /// (<see cref="IInjuryAdjudicator.DecideAntidoteCrossTypePotency"/>).
+    /// </summary>
+    public static int EffectiveAntidotePotency(
+        int antidotePotency,
+        int turnsBeforePoisoning,
+        bool sameType,
+        PoisonRuleset ruleset,
+        IInjuryAdjudicator adjudicator)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(adjudicator);
+        ArgumentOutOfRangeException.ThrowIfNegative(antidotePotency);
+        ArgumentOutOfRangeException.ThrowIfNegative(turnsBeforePoisoning);
+
+        if (turnsBeforePoisoning > ruleset.AntidoteWindowTurns)
+        {
+            return 0;
+        }
+
+        if (sameType)
+        {
+            return antidotePotency;
+        }
+
+        var lessened = adjudicator.DecideAntidoteCrossTypePotency(antidotePotency);
+        return Math.Clamp(lessened, 0, antidotePotency);
+    }
+
+    /// <summary>
+    /// Resolves one dose of poison of the given <paramref name="poisonPotency"/> against
+    /// <paramref name="constitution"/>, after subtracting any <paramref name="effectiveAntidotePotency"/>
+    /// (from <see cref="EffectiveAntidotePotency"/>). Draws one resistance roll from
+    /// <paramref name="entropy"/> unless the antidote fully neutralizes the poison, in which case no
+    /// roll is drawn and no damage is dealt.
+    /// </summary>
+    public static PoisonOutcome ResolvePoison(
+        int poisonPotency,
+        int constitution,
+        int effectiveAntidotePotency,
+        PoisonRuleset ruleset,
+        IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+        ArgumentOutOfRangeException.ThrowIfNegative(poisonPotency);
+        ArgumentOutOfRangeException.ThrowIfNegative(effectiveAntidotePotency);
+
+        var effectivePotency = Math.Max(0, poisonPotency - effectiveAntidotePotency);
+        if (effectivePotency == 0)
+        {
+            // Fully neutralized (or a POT 0 poison): no resistance roll, no damage.
+            return new PoisonOutcome(effectivePotency, Resistance: null, Overcame: false, Damage: 0);
+        }
+
+        var resistance = ResistanceResolver.Resolve(active: effectivePotency, passive: constitution, entropy);
+        var damage = resistance.Succeeded
+            ? effectivePotency
+            : Rounding.Divide(
+                effectivePotency * ruleset.NotOvercomeNumerator, ruleset.NotOvercomeDenominator, RoundingMode.Up);
+
+        return new PoisonOutcome(effectivePotency, resistance, resistance.Succeeded, damage);
+    }
+
+    /// <summary>
+    /// Applies a poison's <see cref="PoisonOutcome.Damage"/> to <paramref name="target"/>'s hit
+    /// points via the non-weapon damage overload, recording a wound.
+    /// </summary>
+    public static DamageApplicationResult ApplyHitPointDamage(
+        AbilitySet target,
+        WoundTrack wounds,
+        PoisonOutcome outcome,
+        DamageRuleset damageRuleset,
+        string woundDescription)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        return DamageResolver.ApplyDamage(target, wounds, outcome.Damage, damageRuleset, woundDescription);
+    }
+
+    /// <summary>
+    /// Drains a poison's <see cref="PoisonOutcome.Damage"/> from <paramref name="characteristic"/>
+    /// via <see cref="AbilitySet.Set"/>, so derived values (hit points, category modifiers)
+    /// recompute. The new value is floored at the characteristic's ruleset minimum. Returns the
+    /// resulting characteristic value.
+    /// </summary>
+    public static int ApplyCharacteristicDrain(
+        AbilitySet abilities, CharacteristicId characteristic, PoisonOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        return InjuryDrain.Apply(abilities, characteristic, outcome.Damage);
+    }
+
+    /// <summary>
+    /// The onset delay before a resolved poison's damage takes effect, per Ch 7, "Poison" (p.175),
+    /// as decided by the gamemaster (<see cref="InjuryDecisionId.PoisonOnset"/>): a bespoke delay if
+    /// specified, otherwise the printed default for the poison's onset speed.
+    /// </summary>
+    public static PoisonOnset ResolveOnset(PoisonOnsetRuling ruling, PoisonRuleset ruleset)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+
+        return ruling.Speed switch
+        {
+            PoisonOnsetSpeed.FastActing => new PoisonOnset(
+                ruling.GamemasterSpecifiedDelay ?? ruleset.OnsetFastActingRounds, PoisonOnsetUnit.CombatRounds),
+            PoisonOnsetSpeed.SlowActing => new PoisonOnset(
+                ruling.GamemasterSpecifiedDelay ?? ruleset.OnsetSlowActingTurns, PoisonOnsetUnit.FullTurns),
+            _ => throw new ArgumentOutOfRangeException(nameof(ruling)),
+        };
+    }
+}
+
+/// <summary>The resolved result of one dose of poison (<see cref="PoisonResolver.ResolvePoison"/>).</summary>
+/// <param name="EffectivePotency">The poison POT after antidote subtraction (the value matched against CON).</param>
+/// <param name="Resistance">
+/// The resistance roll matching <see cref="EffectivePotency"/> against CON, or <see langword="null"/>
+/// when the antidote fully neutralized the poison and no roll was drawn.
+/// </param>
+/// <param name="Overcame">Whether the poison overcame CON (full POT) rather than being resisted (half POT).</param>
+/// <param name="Damage">The hit points or characteristic points the poison deals.</param>
+public sealed record PoisonOutcome(
+    int EffectivePotency,
+    ResistanceOutcome? Resistance,
+    bool Overcame,
+    int Damage);
+
+/// <summary>The time unit a <see cref="PoisonOnset"/> delay is measured in (Ch 7, p.175).</summary>
+public enum PoisonOnsetUnit
+{
+    /// <summary>Combat rounds -- the unit for a fast-acting poison's default delay.</summary>
+    CombatRounds,
+
+    /// <summary>Full turns -- the unit for a slower poison's default delay.</summary>
+    FullTurns,
+}
+
+/// <summary>A resolved poison onset delay (Ch 7, p.175).</summary>
+/// <param name="Delay">The number of <paramref name="Unit"/> before the poison's damage takes effect.</param>
+/// <param name="Unit">The time unit the delay is measured in.</param>
+public readonly record struct PoisonOnset(int Delay, PoisonOnsetUnit Unit);

--- a/src/Brp.Rules/Combat/PoisonRuleset.cs
+++ b/src/Brp.Rules/Combat/PoisonRuleset.cs
@@ -1,0 +1,61 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The data-defined values of Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (pp.175-176)
+/// (AGENTS.md invariant 7: rules values are data, not constants). Loaded from
+/// <c>injury-ruleset.json</c> by <c>Brp.Data.NoirInjuryRuleset.Load()</c>. See
+/// <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public sealed class PoisonRuleset
+{
+    /// <summary>Creates a poison ruleset from data-defined values.</summary>
+    public PoisonRuleset(
+        int notOvercomeNumerator,
+        int notOvercomeDenominator,
+        int onsetFastActingRounds,
+        int onsetSlowActingTurns,
+        int antidoteWindowTurns)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(notOvercomeNumerator);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(notOvercomeDenominator);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(onsetFastActingRounds);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(onsetSlowActingTurns);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(antidoteWindowTurns);
+
+        NotOvercomeNumerator = notOvercomeNumerator;
+        NotOvercomeDenominator = notOvercomeDenominator;
+        OnsetFastActingRounds = onsetFastActingRounds;
+        OnsetSlowActingTurns = onsetSlowActingTurns;
+        AntidoteWindowTurns = antidoteWindowTurns;
+    }
+
+    /// <summary>
+    /// Ch 7, "Poison" (p.175): "If the poison does not overcome the character's CON, it has a
+    /// lessened effect -- usually only doing half the poison's POT in damage (round up)." Numerator
+    /// of the fraction of POT dealt when the poison fails to overcome CON (1 of 2 = half).
+    /// </summary>
+    public int NotOvercomeNumerator { get; }
+
+    /// <summary>See <see cref="NotOvercomeNumerator"/>. Denominator of the not-overcome fraction.</summary>
+    public int NotOvercomeDenominator { get; }
+
+    /// <summary>
+    /// Ch 7, "Poison" (p.175): "Unless otherwise specified by the gamemaster, the delay is three
+    /// combat rounds for fast-acting poisons." The default onset delay, in combat rounds, for a
+    /// fast-acting poison.
+    /// </summary>
+    public int OnsetFastActingRounds { get; }
+
+    /// <summary>
+    /// Ch 7, "Poison" (p.175): "...or three full turns for slower poisons." The default onset delay,
+    /// in full turns, for a slower poison.
+    /// </summary>
+    public int OnsetSlowActingTurns { get; }
+
+    /// <summary>
+    /// Ch 7, "Poison Antidotes" (p.176): "If your character takes a poison's antidote no more than
+    /// six full turns before being poisoned, the antidote's POT is subtracted from the poison's POT
+    /// before damage is figured." The window, in full turns, within which an antidote still counts.
+    /// </summary>
+    public int AntidoteWindowTurns { get; }
+}

--- a/src/Brp.Rules/Combat/PoisonRuleset.cs
+++ b/src/Brp.Rules/Combat/PoisonRuleset.cs
@@ -1,7 +1,7 @@
 namespace Brp.Rules.Combat;
 
 /// <summary>
-/// The data-defined values of Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (pp.175-176)
+/// The data-defined values of Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (p.176)
 /// (AGENTS.md invariant 7: rules values are data, not constants). Loaded from
 /// <c>injury-ruleset.json</c> by <c>Brp.Data.NoirInjuryRuleset.Load()</c>. See
 /// <c>docs/decisions/0019-injury-spot-rules.md</c>.
@@ -30,7 +30,7 @@ public sealed class PoisonRuleset
     }
 
     /// <summary>
-    /// Ch 7, "Poison" (p.175): "If the poison does not overcome the character's CON, it has a
+    /// Ch 7, "Poison" (p.176): "If the poison does not overcome the character's CON, it has a
     /// lessened effect -- usually only doing half the poison's POT in damage (round up)." Numerator
     /// of the fraction of POT dealt when the poison fails to overcome CON (1 of 2 = half).
     /// </summary>
@@ -40,14 +40,14 @@ public sealed class PoisonRuleset
     public int NotOvercomeDenominator { get; }
 
     /// <summary>
-    /// Ch 7, "Poison" (p.175): "Unless otherwise specified by the gamemaster, the delay is three
+    /// Ch 7, "Poison" (p.176): "Unless otherwise specified by the gamemaster, the delay is three
     /// combat rounds for fast-acting poisons." The default onset delay, in combat rounds, for a
     /// fast-acting poison.
     /// </summary>
     public int OnsetFastActingRounds { get; }
 
     /// <summary>
-    /// Ch 7, "Poison" (p.175): "...or three full turns for slower poisons." The default onset delay,
+    /// Ch 7, "Poison" (p.176): "...or three full turns for slower poisons." The default onset delay,
     /// in full turns, for a slower poison.
     /// </summary>
     public int OnsetSlowActingTurns { get; }

--- a/tests/Brp.Core.Tests/Contests/InjuryAdjudicatorTests.cs
+++ b/tests/Brp.Core.Tests/Contests/InjuryAdjudicatorTests.cs
@@ -1,0 +1,72 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+
+namespace Brp.Core.Tests.Contests;
+
+/// <summary>
+/// Covers the named gamemaster-discretion ports for the Ch 7 injury/effect spot rules (Falling,
+/// Poison, Disease): the canonical decision ids, the documented neutral defaults of
+/// <see cref="DefaultInjuryAdjudicator"/>, and that a deterministic stub can drive every port for
+/// replayable tests. See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public class InjuryAdjudicatorTests
+{
+    [Theory]
+    [InlineData(InjuryDecisionId.FallingSurface, "falling-surface")]
+    [InlineData(InjuryDecisionId.PoisonOnset, "poison-onset")]
+    [InlineData(InjuryDecisionId.AntidoteCrossType, "antidote-cross-type")]
+    [InlineData(InjuryDecisionId.DiseaseAffectedCharacteristic, "disease-affected-characteristic")]
+    public void Every_decision_id_has_its_canonical_kebab_case_string(InjuryDecisionId id, string expected)
+    {
+        Assert.Equal(expected, InjuryDecisionIds.CanonicalId(id));
+    }
+
+    [Fact]
+    public void The_named_discretion_points_are_exactly_those_issue_96_calls_out()
+    {
+        Assert.Equal(4, Enum.GetValues<InjuryDecisionId>().Length);
+    }
+
+    [Fact]
+    public void The_default_adjudicator_returns_the_documented_minimal_assumption_answers()
+    {
+        var adjudicator = new DefaultInjuryAdjudicator();
+
+        Assert.Equal(0, adjudicator.DecideFallingSurface().DamageAdjustment);
+        Assert.Equal(new PoisonOnsetRuling(PoisonOnsetSpeed.FastActing, null), adjudicator.DecidePoisonOnset());
+        Assert.Equal(0, adjudicator.DecideAntidoteCrossTypePotency(crossTypeAntidotePotency: 8));
+        Assert.Equal(new CharacteristicId("CON"), adjudicator.DecideDiseaseAffectedCharacteristic());
+    }
+
+    [Fact]
+    public void A_deterministic_stub_drives_every_port_with_scripted_answers()
+    {
+        IInjuryAdjudicator adjudicator = new ScriptedInjuryAdjudicator(
+            fallingSurface: new FallingSurfaceRuling(DamageAdjustment: -3),
+            poisonOnset: new PoisonOnsetRuling(PoisonOnsetSpeed.SlowActing, GamemasterSpecifiedDelay: 5),
+            crossTypeAntidotePotency: 4,
+            diseaseCharacteristic: new CharacteristicId("STR"));
+
+        Assert.Equal(-3, adjudicator.DecideFallingSurface().DamageAdjustment);
+        Assert.Equal(
+            new PoisonOnsetRuling(PoisonOnsetSpeed.SlowActing, 5), adjudicator.DecidePoisonOnset());
+        Assert.Equal(4, adjudicator.DecideAntidoteCrossTypePotency(crossTypeAntidotePotency: 10));
+        Assert.Equal(new CharacteristicId("STR"), adjudicator.DecideDiseaseAffectedCharacteristic());
+    }
+
+    /// <summary>A deterministic test double returning pre-scripted rulings for each port.</summary>
+    private sealed class ScriptedInjuryAdjudicator(
+        FallingSurfaceRuling fallingSurface,
+        PoisonOnsetRuling poisonOnset,
+        int crossTypeAntidotePotency,
+        CharacteristicId diseaseCharacteristic) : IInjuryAdjudicator
+    {
+        public FallingSurfaceRuling DecideFallingSurface() => fallingSurface;
+
+        public PoisonOnsetRuling DecidePoisonOnset() => poisonOnset;
+
+        public int DecideAntidoteCrossTypePotency(int crossTypeAntidotePotency2) => crossTypeAntidotePotency;
+
+        public CharacteristicId DecideDiseaseAffectedCharacteristic() => diseaseCharacteristic;
+    }
+}

--- a/tests/Brp.Data.Tests/NoirInjuryRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirInjuryRulesetTests.cs
@@ -4,8 +4,8 @@ namespace Brp.Data.Tests;
 
 /// <summary>
 /// Confirms the shipped injury ruleset data loads and reproduces Ch 7: Spot Rules -- "Falling"
-/// (p.171), "Poison"/"Poison Antidotes" (pp.175-176), and "Disease"/"Illness Severity Table"
-/// (pp.169-170). The Illness Severity Table is reproduced row by row rather than sampled, per
+/// (pp.171-172), "Poison"/"Poison Antidotes" (p.176), and "Disease"/"Illness Severity Table"
+/// (p.170). The Illness Severity Table is reproduced row by row rather than sampled, per
 /// AGENTS.md's "table-backed rule" convention. See <c>docs/decisions/0019-injury-spot-rules.md</c>.
 /// </summary>
 public class NoirInjuryRulesetTests
@@ -13,7 +13,7 @@ public class NoirInjuryRulesetTests
     private static readonly InjuryRuleset Ruleset = NoirInjuryRuleset.Load();
 
     [Fact]
-    public void Falling_values_match_chapter_7_page_171()
+    public void Falling_values_match_chapter_7_pages_171_to_172()
     {
         var falling = Ruleset.Falling;
 
@@ -31,7 +31,7 @@ public class NoirInjuryRulesetTests
     }
 
     [Fact]
-    public void Poison_values_match_chapter_7_pages_175_to_176()
+    public void Poison_values_match_chapter_7_page_176()
     {
         var poison = Ruleset.Poison;
 
@@ -43,7 +43,7 @@ public class NoirInjuryRulesetTests
     }
 
     [Fact]
-    public void Disease_recovery_ladder_values_match_chapter_7_page_169()
+    public void Disease_recovery_ladder_values_match_chapter_7_page_170()
     {
         var disease = Ruleset.Disease;
 

--- a/tests/Brp.Data.Tests/NoirInjuryRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirInjuryRulesetTests.cs
@@ -1,0 +1,98 @@
+using Brp.Rules.Combat;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped injury ruleset data loads and reproduces Ch 7: Spot Rules -- "Falling"
+/// (p.171), "Poison"/"Poison Antidotes" (pp.175-176), and "Disease"/"Illness Severity Table"
+/// (pp.169-170). The Illness Severity Table is reproduced row by row rather than sampled, per
+/// AGENTS.md's "table-backed rule" convention. See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public class NoirInjuryRulesetTests
+{
+    private static readonly InjuryRuleset Ruleset = NoirInjuryRuleset.Load();
+
+    [Fact]
+    public void Falling_values_match_chapter_7_page_171()
+    {
+        var falling = Ruleset.Falling;
+
+        Assert.Equal("1D6", falling.BaseDamagePerIncrement.Notation);
+        Assert.Equal(3, falling.MetersPerDamageIncrement);
+        Assert.Equal(2, falling.ForceMultiplier);
+        Assert.Equal(5, falling.SmallSizeThreshold);
+        Assert.Equal("1D6", falling.SmallSizeReduction.Notation);
+        Assert.Equal(20, falling.LargeSizeThreshold);
+        Assert.Equal(20, falling.LargeSizeBand);
+        Assert.Equal("1D6", falling.LargeSizeExtraDamage.Notation);
+        Assert.Equal(3, falling.ArmorHalfProtectionMaxMeters);
+        Assert.Equal(1, falling.ArmorProtectionNumerator);
+        Assert.Equal(2, falling.ArmorProtectionDenominator);
+    }
+
+    [Fact]
+    public void Poison_values_match_chapter_7_pages_175_to_176()
+    {
+        var poison = Ruleset.Poison;
+
+        Assert.Equal(1, poison.NotOvercomeNumerator);
+        Assert.Equal(2, poison.NotOvercomeDenominator);
+        Assert.Equal(3, poison.OnsetFastActingRounds);
+        Assert.Equal(3, poison.OnsetSlowActingTurns);
+        Assert.Equal(6, poison.AntidoteWindowTurns);
+    }
+
+    [Fact]
+    public void Disease_recovery_ladder_values_match_chapter_7_page_169()
+    {
+        var disease = Ruleset.Disease;
+
+        Assert.Equal("1D2", disease.MinorDiseaseHitPointLoss.Notation);
+        Assert.Equal("1D6", disease.MinorDiseaseFatigueLoss.Notation);
+        Assert.Equal(2, disease.RecoveryLadderStartingMultiplier);
+        Assert.Equal(1, disease.RecoveryLadderMultiplierIncrementPerDay);
+        Assert.Equal(1, disease.RecoveryLadderFumbleMultiplierPenalty);
+        Assert.Equal(1, disease.RecoveryLadderStrenuousConditionPenalty);
+    }
+
+    public static IEnumerable<object?[]> IllnessSeverityRows()
+    {
+        // Ch 7, "Illness Severity Table" (p.170): Failures -> Degree of Illness.
+        yield return new object?[] { 0, 0, IllnessDegree.None, IllnessLossPeriod.None };
+        yield return new object?[] { 1, 1, IllnessDegree.Mild, IllnessLossPeriod.Week };
+        yield return new object?[] { 2, 2, IllnessDegree.Acute, IllnessLossPeriod.Day };
+        yield return new object?[] { 3, 3, IllnessDegree.Severe, IllnessLossPeriod.Hour };
+        yield return new object?[] { 4, null, IllnessDegree.Terminal, IllnessLossPeriod.Minute };
+    }
+
+    [Theory]
+    [MemberData(nameof(IllnessSeverityRows))]
+    public void Every_printed_illness_severity_row_matches_the_book(
+        int minimumFailures, int? maximumFailures, IllnessDegree expectedDegree, IllnessLossPeriod expectedPeriod)
+    {
+        var band = Ruleset.Disease.IllnessSeverityTable.Bands.Single(b => b.MinimumFailures == minimumFailures);
+
+        Assert.Equal(maximumFailures, band.MaximumFailures);
+        Assert.Equal(expectedDegree, band.Degree);
+        Assert.Equal(expectedPeriod, band.LossPeriod);
+    }
+
+    [Fact]
+    public void The_illness_severity_table_has_exactly_the_five_printed_rows()
+    {
+        Assert.Equal(5, Ruleset.Disease.IllnessSeverityTable.Bands.Count);
+    }
+
+    [Theory]
+    [InlineData(0, IllnessDegree.None)]
+    [InlineData(1, IllnessDegree.Mild)]
+    [InlineData(2, IllnessDegree.Acute)]
+    [InlineData(3, IllnessDegree.Severe)]
+    [InlineData(4, IllnessDegree.Terminal)]
+    [InlineData(9, IllnessDegree.Terminal)]
+    public void For_failures_resolves_to_the_printed_degree_including_the_open_ended_terminal_row(
+        int failures, IllnessDegree expected)
+    {
+        Assert.Equal(expected, Ruleset.Disease.IllnessSeverityTable.ForFailures(failures).Degree);
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/DamageResolverInjuryOverloadTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/DamageResolverInjuryOverloadTests.cs
@@ -1,0 +1,74 @@
+using Brp.Core.Abilities;
+using Brp.Data;
+using Brp.Rules.Characters;
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// The non-weapon <see cref="DamageResolver.ApplyDamage(AbilitySet, WoundTrack, int, DamageRuleset, string)"/>
+/// overload the injury spot rules (#96) use for falling and poison. Mirrors the weapon overload's
+/// hit-point tracking (Ch 2, p.13) and condition classification (Ch 2, p.13; Ch 6, p.156) without a
+/// fabricated <see cref="DamageRoll"/>. See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public class DamageResolverInjuryOverloadTests
+{
+    private static readonly DamageRuleset Ruleset = NoirDamageRuleset.Load();
+
+    private static AbilitySet MakeTarget(int con, int siz)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 12);
+        values[new CharacteristicId("CON")] = con;
+        values[new CharacteristicId("SIZ")] = siz;
+        return new AbilitySet(ruleset, values);
+    }
+
+    [Fact]
+    public void Applies_flat_damage_records_a_wound_and_reports_unaffected()
+    {
+        var target = MakeTarget(con: 14, siz: 12); // max HP 13.
+        var wounds = new WoundTrack();
+
+        var result = DamageResolver.ApplyDamage(target, wounds, hitPointDamage: 5, Ruleset, "Falling");
+
+        Assert.Equal(5, result.DamageDealt);
+        Assert.Equal(8, result.ResultingHitPoints);
+        Assert.Equal(HitPointCondition.Unaffected, result.Condition);
+        Assert.Single(wounds.Wounds);
+    }
+
+    [Fact]
+    public void Damage_to_two_or_fewer_hit_points_reports_unconscious()
+    {
+        var target = MakeTarget(con: 14, siz: 12); // max HP 13.
+        var wounds = new WoundTrack();
+
+        var result = DamageResolver.ApplyDamage(target, wounds, hitPointDamage: 12, Ruleset, "Poison");
+
+        Assert.Equal(1, result.ResultingHitPoints);
+        Assert.Equal(HitPointCondition.Unconscious, result.Condition);
+    }
+
+    [Fact]
+    public void Damage_to_zero_or_below_reports_fatally_wounded_and_allows_negative_hit_points()
+    {
+        var target = MakeTarget(con: 14, siz: 12); // max HP 13.
+        var wounds = new WoundTrack();
+
+        var result = DamageResolver.ApplyDamage(target, wounds, hitPointDamage: 20, Ruleset, "Falling");
+
+        Assert.Equal(-7, result.ResultingHitPoints);
+        Assert.Equal(HitPointCondition.FatallyWounded, result.Condition);
+    }
+
+    [Fact]
+    public void Negative_damage_is_rejected()
+    {
+        var target = MakeTarget(con: 14, siz: 12);
+        var wounds = new WoundTrack();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => DamageResolver.ApplyDamage(target, wounds, hitPointDamage: -1, Ruleset, "Falling"));
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/DiseaseResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/DiseaseResolverTests.cs
@@ -7,7 +7,7 @@ using Brp.Rules.Combat;
 namespace Brp.Rules.Tests.Combat;
 
 /// <summary>
-/// Ch 7: Spot Rules, "Disease" (pp.169-170). The Stamina contraction roll, the CON×N recovery
+/// Ch 7: Spot Rules, "Disease" (p.170). The Stamina contraction roll, the CON×N recovery
 /// ladder (rising multiplier, fumble and strenuous-condition reductions), and the Illness Severity
 /// Table drain routed through the characteristic-recompute path. See
 /// <c>docs/decisions/0019-injury-spot-rules.md</c>.
@@ -26,7 +26,7 @@ public class DiseaseResolverTests
     }
 
     [Fact]
-    public void A_failed_stamina_roll_contracts_the_disease_page_169()
+    public void A_failed_stamina_roll_contracts_the_disease_page_170()
     {
         // CON 10 => Stamina (CON×5) = 50; roll 90 fails => contracted.
         var contraction = DiseaseResolver.RollContraction(MakeTarget(con: 10), new FixedEntropySource(90));
@@ -35,7 +35,7 @@ public class DiseaseResolverTests
     }
 
     [Fact]
-    public void A_successful_stamina_roll_avoids_the_disease_page_169()
+    public void A_successful_stamina_roll_avoids_the_disease_page_170()
     {
         // CON 10 => 50; roll 10 succeeds => avoided.
         var contraction = DiseaseResolver.RollContraction(MakeTarget(con: 10), new FixedEntropySource(10));
@@ -44,7 +44,7 @@ public class DiseaseResolverTests
     }
 
     [Fact]
-    public void Recovering_on_the_first_day_yields_no_failures_page_169()
+    public void Recovering_on_the_first_day_yields_no_failures_page_170()
     {
         // Day 0 = CON×2 = 20; roll 10 succeeds.
         var ladder = DiseaseResolver.ResolveRecoveryLadder(
@@ -56,7 +56,7 @@ public class DiseaseResolverTests
     }
 
     [Fact]
-    public void The_multiplier_rises_by_one_each_day_until_recovery_page_169()
+    public void The_multiplier_rises_by_one_each_day_until_recovery_page_170()
     {
         // Day 0 CON×2=20 roll 50 fails; day 1 CON×3=30 roll 10 succeeds.
         var ladder = DiseaseResolver.ResolveRecoveryLadder(
@@ -69,7 +69,7 @@ public class DiseaseResolverTests
     }
 
     [Fact]
-    public void A_fumble_reduces_the_multiplier_by_one_page_169()
+    public void A_fumble_reduces_the_multiplier_by_one_page_170()
     {
         // Day 0 CON×2=20 roll 100 fumbles; day 1 base ×3 minus the fumble penalty => ×2; roll 10 succeeds.
         var ladder = DiseaseResolver.ResolveRecoveryLadder(
@@ -81,7 +81,7 @@ public class DiseaseResolverTests
     }
 
     [Fact]
-    public void Each_strenuous_condition_reduces_the_multiplier_by_one_page_169()
+    public void Each_strenuous_condition_reduces_the_multiplier_by_one_page_170()
     {
         // Day 0 base ×2 minus one strenuous condition => ×1 = 10; roll 5 succeeds.
         var ladder = DiseaseResolver.ResolveRecoveryLadder(
@@ -104,33 +104,41 @@ public class DiseaseResolverTests
     }
 
     [Theory]
-    [InlineData(0, IllnessDegree.None, 0)]
-    [InlineData(1, IllnessDegree.Mild, 1)]
-    [InlineData(2, IllnessDegree.Acute, 2)]
-    [InlineData(3, IllnessDegree.Severe, 3)]
-    [InlineData(5, IllnessDegree.Terminal, 5)]
-    public void Severity_drain_loses_one_point_per_failed_roll_at_the_tables_degree_page_170(
-        int failures, IllnessDegree expectedDegree, int expectedPointsLost)
+    [InlineData(0, IllnessDegree.None, IllnessLossPeriod.None)]
+    [InlineData(1, IllnessDegree.Mild, IllnessLossPeriod.Week)]
+    [InlineData(2, IllnessDegree.Acute, IllnessLossPeriod.Day)]
+    [InlineData(3, IllnessDegree.Severe, IllnessLossPeriod.Hour)]
+    [InlineData(5, IllnessDegree.Terminal, IllnessLossPeriod.Minute)]
+    public void Severity_is_a_rate_of_one_point_per_period_not_a_baked_quantity_page_170(
+        int failures, IllnessDegree expectedDegree, IllnessLossPeriod expectedPeriod)
     {
         var target = MakeTarget(con: 12, siz: 12);
+        var before = target.ValueOf(new CharacteristicId("STR"));
 
-        var outcome = DiseaseResolver.ApplySeverityDrain(target, new CharacteristicId("STR"), failures, Disease);
+        var severity = DiseaseResolver.ResolveSeverity(failures, Disease);
 
-        Assert.Equal(expectedDegree, outcome.Degree);
-        Assert.Equal(expectedPointsLost, outcome.PointsLost);
-        Assert.Equal(12 - expectedPointsLost, target.ValueOf(new CharacteristicId("STR")));
+        Assert.Equal(expectedDegree, severity.Degree);
+        Assert.Equal(expectedPeriod, severity.LossPeriod);
+
+        // ResolveSeverity reports the loss rate only -- it drains nothing itself; the wall-clock
+        // point loss is a clock-aware caller's job (ApplyCharacteristicLoss).
+        Assert.Equal(before, target.ValueOf(new CharacteristicId("STR")));
     }
 
     [Fact]
-    public void Severity_drain_recomputes_derived_values_when_it_hits_a_derived_characteristic_page_170()
+    public void A_lost_point_drained_by_a_clock_aware_caller_recomputes_derived_values_page_170()
     {
         var target = MakeTarget(con: 16, siz: 14);
         Assert.Equal(15, target.MaximumHitPoints);
 
-        // 2 failures => Acute => 2 CON points drained via AbilitySet.Set, so hit points recompute.
-        var outcome = DiseaseResolver.ApplySeverityDrain(target, new CharacteristicId("CON"), failures: 2, Disease);
+        // Acute is 1 point/day; a caller two days in has accrued 2 CON points. Applying them via
+        // AbilitySet.Set recomputes hit points -- the loss is not baked at severity-lookup time.
+        var severity = DiseaseResolver.ResolveSeverity(failures: 2, Disease);
+        Assert.Equal(IllnessLossPeriod.Day, severity.LossPeriod);
 
-        Assert.Equal(IllnessDegree.Acute, outcome.Degree);
+        var newValue = DiseaseResolver.ApplyCharacteristicLoss(target, new CharacteristicId("CON"), points: 2);
+
+        Assert.Equal(14, newValue);
         Assert.Equal(14, target.ValueOf(new CharacteristicId("CON")));
         Assert.Equal(14, target.MaximumHitPoints); // ceil((14 + 14) / 2)
     }
@@ -142,14 +150,14 @@ public class DiseaseResolverTests
         var adjudicator = new DefaultInjuryAdjudicator();
         var affected = adjudicator.DecideDiseaseAffectedCharacteristic();
 
-        DiseaseResolver.ApplySeverityDrain(target, affected, failures: 3, Disease);
+        DiseaseResolver.ApplyCharacteristicLoss(target, affected, points: 3);
 
         Assert.Equal(new CharacteristicId("CON"), affected);
         Assert.Equal(9, target.ValueOf(new CharacteristicId("CON")));
     }
 
     [Fact]
-    public void A_minor_disease_costs_hit_points_and_fatigue_page_169()
+    public void A_minor_disease_costs_hit_points_and_fatigue_page_170()
     {
         // 1D2 hit points then 1D6 fatigue.
         var effect = DiseaseResolver.RollMinorDiseaseEffect(Disease, new FixedEntropySource(2, 4));

--- a/tests/Brp.Rules.Tests/Combat/DiseaseResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/DiseaseResolverTests.cs
@@ -1,0 +1,160 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+using Brp.Core.Resolution;
+using Brp.Data;
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Ch 7: Spot Rules, "Disease" (pp.169-170). The Stamina contraction roll, the CON×N recovery
+/// ladder (rising multiplier, fumble and strenuous-condition reductions), and the Illness Severity
+/// Table drain routed through the characteristic-recompute path. See
+/// <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public class DiseaseResolverTests
+{
+    private static readonly DiseaseRuleset Disease = NoirInjuryRuleset.Load().Disease;
+
+    private static AbilitySet MakeTarget(int con = 10, int siz = 12)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 12);
+        values[new CharacteristicId("CON")] = con;
+        values[new CharacteristicId("SIZ")] = siz;
+        return new AbilitySet(ruleset, values);
+    }
+
+    [Fact]
+    public void A_failed_stamina_roll_contracts_the_disease_page_169()
+    {
+        // CON 10 => Stamina (CON×5) = 50; roll 90 fails => contracted.
+        var contraction = DiseaseResolver.RollContraction(MakeTarget(con: 10), new FixedEntropySource(90));
+
+        Assert.True(contraction.Contracted);
+    }
+
+    [Fact]
+    public void A_successful_stamina_roll_avoids_the_disease_page_169()
+    {
+        // CON 10 => 50; roll 10 succeeds => avoided.
+        var contraction = DiseaseResolver.RollContraction(MakeTarget(con: 10), new FixedEntropySource(10));
+
+        Assert.False(contraction.Contracted);
+    }
+
+    [Fact]
+    public void Recovering_on_the_first_day_yields_no_failures_page_169()
+    {
+        // Day 0 = CON×2 = 20; roll 10 succeeds.
+        var ladder = DiseaseResolver.ResolveRecoveryLadder(
+            MakeTarget(con: 10), strenuousConditionCount: 0, Disease, new FixedEntropySource(10), maxDays: 5);
+
+        Assert.True(ladder.Recovered);
+        Assert.Equal(0, ladder.Failures);
+        Assert.Single(ladder.Days);
+    }
+
+    [Fact]
+    public void The_multiplier_rises_by_one_each_day_until_recovery_page_169()
+    {
+        // Day 0 CON×2=20 roll 50 fails; day 1 CON×3=30 roll 10 succeeds.
+        var ladder = DiseaseResolver.ResolveRecoveryLadder(
+            MakeTarget(con: 10), strenuousConditionCount: 0, Disease, new FixedEntropySource(50, 10), maxDays: 5);
+
+        Assert.True(ladder.Recovered);
+        Assert.Equal(1, ladder.Failures);
+        Assert.Equal(2, ladder.Days[0].EffectiveMultiplier);
+        Assert.Equal(3, ladder.Days[1].EffectiveMultiplier);
+    }
+
+    [Fact]
+    public void A_fumble_reduces_the_multiplier_by_one_page_169()
+    {
+        // Day 0 CON×2=20 roll 100 fumbles; day 1 base ×3 minus the fumble penalty => ×2; roll 10 succeeds.
+        var ladder = DiseaseResolver.ResolveRecoveryLadder(
+            MakeTarget(con: 10), strenuousConditionCount: 0, Disease, new FixedEntropySource(100, 10), maxDays: 5);
+
+        Assert.Equal(SuccessLevel.Fumble, ladder.Days[0].Roll.Level);
+        Assert.Equal(2, ladder.Days[1].EffectiveMultiplier);
+        Assert.True(ladder.Recovered);
+    }
+
+    [Fact]
+    public void Each_strenuous_condition_reduces_the_multiplier_by_one_page_169()
+    {
+        // Day 0 base ×2 minus one strenuous condition => ×1 = 10; roll 5 succeeds.
+        var ladder = DiseaseResolver.ResolveRecoveryLadder(
+            MakeTarget(con: 10), strenuousConditionCount: 1, Disease, new FixedEntropySource(5), maxDays: 5);
+
+        Assert.Equal(1, ladder.Days[0].EffectiveMultiplier);
+        Assert.True(ladder.Recovered);
+        Assert.Equal(0, ladder.Failures);
+    }
+
+    [Fact]
+    public void The_ladder_gives_up_after_the_day_budget_without_recovering()
+    {
+        // CON 3: day 0 ×2=6, day 1 ×3=9; rolls 50, 50 both fail within a two-day budget.
+        var ladder = DiseaseResolver.ResolveRecoveryLadder(
+            MakeTarget(con: 3), strenuousConditionCount: 0, Disease, new FixedEntropySource(50, 50), maxDays: 2);
+
+        Assert.False(ladder.Recovered);
+        Assert.Equal(2, ladder.Failures);
+    }
+
+    [Theory]
+    [InlineData(0, IllnessDegree.None, 0)]
+    [InlineData(1, IllnessDegree.Mild, 1)]
+    [InlineData(2, IllnessDegree.Acute, 2)]
+    [InlineData(3, IllnessDegree.Severe, 3)]
+    [InlineData(5, IllnessDegree.Terminal, 5)]
+    public void Severity_drain_loses_one_point_per_failed_roll_at_the_tables_degree_page_170(
+        int failures, IllnessDegree expectedDegree, int expectedPointsLost)
+    {
+        var target = MakeTarget(con: 12, siz: 12);
+
+        var outcome = DiseaseResolver.ApplySeverityDrain(target, new CharacteristicId("STR"), failures, Disease);
+
+        Assert.Equal(expectedDegree, outcome.Degree);
+        Assert.Equal(expectedPointsLost, outcome.PointsLost);
+        Assert.Equal(12 - expectedPointsLost, target.ValueOf(new CharacteristicId("STR")));
+    }
+
+    [Fact]
+    public void Severity_drain_recomputes_derived_values_when_it_hits_a_derived_characteristic_page_170()
+    {
+        var target = MakeTarget(con: 16, siz: 14);
+        Assert.Equal(15, target.MaximumHitPoints);
+
+        // 2 failures => Acute => 2 CON points drained via AbilitySet.Set, so hit points recompute.
+        var outcome = DiseaseResolver.ApplySeverityDrain(target, new CharacteristicId("CON"), failures: 2, Disease);
+
+        Assert.Equal(IllnessDegree.Acute, outcome.Degree);
+        Assert.Equal(14, target.ValueOf(new CharacteristicId("CON")));
+        Assert.Equal(14, target.MaximumHitPoints); // ceil((14 + 14) / 2)
+    }
+
+    [Fact]
+    public void The_gamemaster_chosen_characteristic_is_the_one_drained()
+    {
+        var target = MakeTarget(con: 12, siz: 12);
+        var adjudicator = new DefaultInjuryAdjudicator();
+        var affected = adjudicator.DecideDiseaseAffectedCharacteristic();
+
+        DiseaseResolver.ApplySeverityDrain(target, affected, failures: 3, Disease);
+
+        Assert.Equal(new CharacteristicId("CON"), affected);
+        Assert.Equal(9, target.ValueOf(new CharacteristicId("CON")));
+    }
+
+    [Fact]
+    public void A_minor_disease_costs_hit_points_and_fatigue_page_169()
+    {
+        // 1D2 hit points then 1D6 fatigue.
+        var effect = DiseaseResolver.RollMinorDiseaseEffect(Disease, new FixedEntropySource(2, 4));
+
+        Assert.Equal(2, effect.HitPointLoss);
+        Assert.Equal(4, effect.FatigueLoss);
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/FallingResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/FallingResolverTests.cs
@@ -7,7 +7,7 @@ using Brp.Rules.Combat;
 namespace Brp.Rules.Tests.Combat;
 
 /// <summary>
-/// Ch 7: Spot Rules, "Falling" (p.171). Deterministic falling damage by distance, force, and SIZ,
+/// Ch 7: Spot Rules, "Falling" (pp.171-172). Deterministic falling damage by distance, force, and SIZ,
 /// then armor/surface mitigation, applied through the non-weapon <see cref="DamageResolver"/>
 /// overload. See <c>docs/decisions/0019-injury-spot-rules.md</c>.
 /// </summary>
@@ -107,7 +107,7 @@ public class FallingResolverTests
     }
 
     [Fact]
-    public void Armor_gives_half_protection_up_to_three_meters_page_171()
+    public void Armor_gives_half_protection_up_to_three_meters_page_172()
     {
         var roll = new FallingDamageRoll(DamageBeforeMitigation: 6, BaseDiceCount: 1, LargeSizeBands: 0, false, false);
 

--- a/tests/Brp.Rules.Tests/Combat/FallingResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/FallingResolverTests.cs
@@ -1,0 +1,162 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+using Brp.Data;
+using Brp.Rules.Characters;
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Ch 7: Spot Rules, "Falling" (p.171). Deterministic falling damage by distance, force, and SIZ,
+/// then armor/surface mitigation, applied through the non-weapon <see cref="DamageResolver"/>
+/// overload. See <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public class FallingResolverTests
+{
+    private static readonly FallingRuleset Falling = NoirInjuryRuleset.Load().Falling;
+    private static readonly DamageRuleset Damage = NoirDamageRuleset.Load();
+
+    private static AbilitySet MakeTarget(int con, int siz)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 12);
+        values[new CharacteristicId("CON")] = con;
+        values[new CharacteristicId("SIZ")] = siz;
+        return new AbilitySet(ruleset, values);
+    }
+
+    [Fact]
+    public void Base_damage_is_one_die_per_three_meters_page_171()
+    {
+        // 9 m => 3 base dice; SIZ 12 is neither small nor large; no force.
+        var entropy = new FixedEntropySource(4, 5, 6);
+
+        var roll = FallingResolver.RollFallingDamage(metersFallen: 9, size: 12, thrownWithForce: false, Falling, entropy);
+
+        Assert.Equal(3, roll.BaseDiceCount);
+        Assert.Equal(15, roll.DamageBeforeMitigation);
+        Assert.Equal(0, roll.LargeSizeBands);
+        Assert.False(roll.SmallSizeReductionApplied);
+    }
+
+    [Fact]
+    public void Thrown_with_considerable_force_doubles_the_dice_page_171()
+    {
+        // 6 m => 2 base dice, doubled to 4 by force.
+        var entropy = new FixedEntropySource(1, 1, 1, 1);
+
+        var roll = FallingResolver.RollFallingDamage(metersFallen: 6, size: 12, thrownWithForce: true, Falling, entropy);
+
+        Assert.Equal(4, roll.BaseDiceCount);
+        Assert.Equal(4, roll.DamageBeforeMitigation);
+        Assert.True(roll.ThrownWithForce);
+    }
+
+    [Fact]
+    public void Small_size_subtracts_one_die_page_171()
+    {
+        // 9 m => 3 base dice (2+2+2=6); SIZ 5 subtracts a 1D6 (5) => 1.
+        var entropy = new FixedEntropySource(2, 2, 2, 5);
+
+        var roll = FallingResolver.RollFallingDamage(metersFallen: 9, size: 5, thrownWithForce: false, Falling, entropy);
+
+        Assert.True(roll.SmallSizeReductionApplied);
+        Assert.Equal(1, roll.DamageBeforeMitigation);
+    }
+
+    [Fact]
+    public void Small_size_reduction_floors_the_damage_at_zero()
+    {
+        // 3 m => 1 base die (2); SIZ 5 subtracts a 1D6 (6) => -4, floored to 0.
+        var entropy = new FixedEntropySource(2, 6);
+
+        var roll = FallingResolver.RollFallingDamage(metersFallen: 3, size: 5, thrownWithForce: false, Falling, entropy);
+
+        Assert.Equal(0, roll.DamageBeforeMitigation);
+    }
+
+    [Theory]
+    [InlineData(21, 1)]
+    [InlineData(40, 1)]
+    [InlineData(41, 2)]
+    [InlineData(60, 2)]
+    [InlineData(61, 3)]
+    public void Large_size_adds_one_die_per_started_band_of_twenty_page_171(int size, int expectedBands)
+    {
+        // 3 m => 1 base die (fixed at 1), then expectedBands large dice (each fixed at 1).
+        var faces = Enumerable.Repeat(1, 1 + expectedBands).ToArray();
+        var entropy = new FixedEntropySource(faces);
+
+        var roll = FallingResolver.RollFallingDamage(metersFallen: 3, size, thrownWithForce: false, Falling, entropy);
+
+        Assert.Equal(expectedBands, roll.LargeSizeBands);
+        Assert.Equal(1 + expectedBands, roll.DamageBeforeMitigation);
+    }
+
+    [Fact]
+    public void Large_size_is_cumulative_with_the_force_doubling_page_171()
+    {
+        // 6 m => 2 base dice doubled to 4 by force (all 1s = 4), plus one large band (6) for SIZ 21.
+        var entropy = new FixedEntropySource(1, 1, 1, 1, 6);
+
+        var roll = FallingResolver.RollFallingDamage(metersFallen: 6, size: 21, thrownWithForce: true, Falling, entropy);
+
+        Assert.Equal(4, roll.BaseDiceCount);
+        Assert.Equal(1, roll.LargeSizeBands);
+        Assert.Equal(10, roll.DamageBeforeMitigation);
+    }
+
+    [Fact]
+    public void Armor_gives_half_protection_up_to_three_meters_page_171()
+    {
+        var roll = new FallingDamageRoll(DamageBeforeMitigation: 6, BaseDiceCount: 1, LargeSizeBands: 0, false, false);
+
+        // armor 4 => half is 2; 6 - 2 = 4.
+        var final = FallingResolver.MitigateFallingDamage(
+            roll, armorValue: 4, metersFallen: 3, new FallingSurfaceRuling(0), Falling);
+
+        Assert.Equal(4, final);
+    }
+
+    [Fact]
+    public void Armor_does_not_apply_beyond_three_meters()
+    {
+        var roll = new FallingDamageRoll(DamageBeforeMitigation: 6, BaseDiceCount: 2, LargeSizeBands: 0, false, false);
+
+        var final = FallingResolver.MitigateFallingDamage(
+            roll, armorValue: 10, metersFallen: 6, new FallingSurfaceRuling(0), Falling);
+
+        Assert.Equal(6, final);
+    }
+
+    [Theory]
+    [InlineData(-10, 0)]
+    [InlineData(2, 8)]
+    public void The_falling_surface_ruling_adjusts_the_final_damage_and_floors_at_zero(int adjustment, int expected)
+    {
+        var roll = new FallingDamageRoll(DamageBeforeMitigation: 6, BaseDiceCount: 2, LargeSizeBands: 0, false, false);
+
+        var final = FallingResolver.MitigateFallingDamage(
+            roll, armorValue: 0, metersFallen: 6, new FallingSurfaceRuling(adjustment), Falling);
+
+        Assert.Equal(expected, final);
+    }
+
+    [Fact]
+    public void Falling_damage_flows_through_the_hit_point_path_and_records_a_wound()
+    {
+        var target = MakeTarget(con: 14, siz: 12);
+        var startingHitPoints = target.CurrentHitPoints;
+        var wounds = new WoundTrack();
+        var entropy = new FixedEntropySource(5, 5, 5); // 9 m => 3 dice = 15.
+
+        var roll = FallingResolver.RollFallingDamage(metersFallen: 9, size: 12, thrownWithForce: false, Falling, entropy);
+        var final = FallingResolver.MitigateFallingDamage(roll, armorValue: 0, metersFallen: 9, new FallingSurfaceRuling(0), Falling);
+        var result = DamageResolver.ApplyDamage(target, wounds, final, Damage, "Falling: 9 m");
+
+        Assert.Equal(15, final);
+        Assert.Equal(15, result.DamageDealt);
+        Assert.Equal(startingHitPoints - 15, target.CurrentHitPoints);
+        Assert.Single(wounds.Wounds);
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/PoisonResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/PoisonResolverTests.cs
@@ -1,0 +1,178 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+using Brp.Data;
+using Brp.Rules.Characters;
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (pp.175-176). POT vs CON on the resistance
+/// table (full POT if overcome, else half round-up), antidote subtraction, two-dose independence,
+/// and drain routed through the characteristic-recompute path. See
+/// <c>docs/decisions/0019-injury-spot-rules.md</c>.
+/// </summary>
+public class PoisonResolverTests
+{
+    private static readonly PoisonRuleset Poison = NoirInjuryRuleset.Load().Poison;
+    private static readonly DamageRuleset Damage = NoirDamageRuleset.Load();
+
+    private static AbilitySet MakeTarget(int con = 12, int siz = 12, int strength = 12)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 12);
+        values[new CharacteristicId("CON")] = con;
+        values[new CharacteristicId("SIZ")] = siz;
+        values[new CharacteristicId("STR")] = strength;
+        return new AbilitySet(ruleset, values);
+    }
+
+    [Fact]
+    public void Overcoming_con_deals_the_full_pot_page_175()
+    {
+        // POT 15 vs CON 10 => chance 75; roll 50 succeeds (poison overcomes CON).
+        var outcome = PoisonResolver.ResolvePoison(
+            poisonPotency: 15, constitution: 10, effectiveAntidotePotency: 0, Poison, new FixedEntropySource(50));
+
+        Assert.True(outcome.Overcame);
+        Assert.Equal(15, outcome.Damage);
+    }
+
+    [Fact]
+    public void Failing_to_overcome_con_deals_half_pot_rounded_up_page_175()
+    {
+        // POT 15 vs CON 10 => chance 75; roll 90 fails; half of 15 rounds up to 8.
+        var outcome = PoisonResolver.ResolvePoison(
+            poisonPotency: 15, constitution: 10, effectiveAntidotePotency: 0, Poison, new FixedEntropySource(90));
+
+        Assert.False(outcome.Overcame);
+        Assert.Equal(8, outcome.Damage);
+    }
+
+    [Fact]
+    public void An_in_window_same_type_antidote_subtracts_its_full_pot_page_176()
+    {
+        var effective = PoisonResolver.EffectiveAntidotePotency(
+            antidotePotency: 8, turnsBeforePoisoning: 6, sameType: true, Poison, new DefaultInjuryAdjudicator());
+
+        Assert.Equal(8, effective);
+    }
+
+    [Fact]
+    public void An_antidote_taken_outside_the_six_turn_window_gives_no_benefit_page_176()
+    {
+        var effective = PoisonResolver.EffectiveAntidotePotency(
+            antidotePotency: 8, turnsBeforePoisoning: 7, sameType: true, Poison, new DefaultInjuryAdjudicator());
+
+        Assert.Equal(0, effective);
+    }
+
+    [Fact]
+    public void A_cross_type_antidote_gives_the_gamemasters_lessened_benefit_page_176()
+    {
+        var adjudicator = new StubAdjudicator(crossTypePotency: 3);
+
+        var effective = PoisonResolver.EffectiveAntidotePotency(
+            antidotePotency: 8, turnsBeforePoisoning: 2, sameType: false, Poison, adjudicator);
+
+        Assert.Equal(3, effective);
+    }
+
+    [Fact]
+    public void The_antidote_pot_is_subtracted_before_the_resistance_roll_page_176()
+    {
+        // Poison POT 20, antidote 8 => effective POT 12 vs CON 10 => chance 60; roll 50 overcomes.
+        var outcome = PoisonResolver.ResolvePoison(
+            poisonPotency: 20, constitution: 10, effectiveAntidotePotency: 8, Poison, new FixedEntropySource(50));
+
+        Assert.Equal(12, outcome.EffectivePotency);
+        Assert.True(outcome.Overcame);
+        Assert.Equal(12, outcome.Damage);
+    }
+
+    [Fact]
+    public void A_fully_neutralizing_antidote_draws_no_roll_and_deals_no_damage()
+    {
+        var entropy = new FixedEntropySource();
+
+        var outcome = PoisonResolver.ResolvePoison(
+            poisonPotency: 10, constitution: 10, effectiveAntidotePotency: 10, Poison, entropy);
+
+        Assert.Equal(0, outcome.EffectivePotency);
+        Assert.Null(outcome.Resistance);
+        Assert.Equal(0, outcome.Damage);
+        Assert.Equal(0, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void Two_doses_are_two_separate_rolls_not_one_of_double_pot_page_175()
+    {
+        // Two POT 10 doses vs CON 10 => each chance 50; rolls 90 and 90 both fail => 5 + 5.
+        var doses = new FixedEntropySource(90, 90);
+        var first = PoisonResolver.ResolvePoison(10, 10, 0, Poison, doses);
+        var second = PoisonResolver.ResolvePoison(10, 10, 0, Poison, doses);
+
+        Assert.False(first.Overcame);
+        Assert.False(second.Overcame);
+        Assert.Equal(10, first.Damage + second.Damage);
+
+        // One POT 20 dose vs CON 10 => chance 100, automatic success (a different result entirely).
+        var single = PoisonResolver.ResolvePoison(20, 10, 0, Poison, new FixedEntropySource(90));
+        Assert.True(single.Resistance!.IsAutomaticSuccess);
+        Assert.Equal(20, single.Damage);
+    }
+
+    [Fact]
+    public void Hit_point_damage_flows_through_the_damage_path()
+    {
+        var target = MakeTarget(con: 13, siz: 12);
+        var wounds = new WoundTrack();
+        // POT 8 vs CON 13 => chance 25; roll 20 overcomes => 8 damage.
+        var outcome = PoisonResolver.ResolvePoison(8, 13, 0, Poison, new FixedEntropySource(20));
+
+        var result = PoisonResolver.ApplyHitPointDamage(target, wounds, outcome, Damage, "Poison POT 8");
+
+        Assert.Equal(8, outcome.Damage);
+        Assert.Equal(target.MaximumHitPoints - 8, result.ResultingHitPoints);
+        Assert.Single(wounds.Wounds);
+    }
+
+    [Fact]
+    public void Characteristic_drain_recomputes_derived_values()
+    {
+        var target = MakeTarget(con: 13, siz: 12);
+        Assert.Equal(13, target.MaximumHitPoints);
+
+        // POT 8 vs CON 13 => chance 25; roll 20 overcomes => 8 points drained from CON.
+        var outcome = PoisonResolver.ResolvePoison(8, 13, 0, Poison, new FixedEntropySource(20));
+        var newValue = PoisonResolver.ApplyCharacteristicDrain(target, new CharacteristicId("CON"), outcome);
+
+        Assert.Equal(5, newValue);
+        Assert.Equal(5, target.ValueOf(new CharacteristicId("CON")));
+        Assert.Equal(9, target.MaximumHitPoints); // ceil((5 + 12) / 2)
+    }
+
+    [Fact]
+    public void Onset_uses_the_printed_default_for_the_gamemasters_speed_page_175()
+    {
+        var fast = PoisonResolver.ResolveOnset(new PoisonOnsetRuling(PoisonOnsetSpeed.FastActing, null), Poison);
+        Assert.Equal(new PoisonOnset(3, PoisonOnsetUnit.CombatRounds), fast);
+
+        var slow = PoisonResolver.ResolveOnset(new PoisonOnsetRuling(PoisonOnsetSpeed.SlowActing, null), Poison);
+        Assert.Equal(new PoisonOnset(3, PoisonOnsetUnit.FullTurns), slow);
+
+        var overridden = PoisonResolver.ResolveOnset(new PoisonOnsetRuling(PoisonOnsetSpeed.FastActing, 1), Poison);
+        Assert.Equal(new PoisonOnset(1, PoisonOnsetUnit.CombatRounds), overridden);
+    }
+
+    private sealed class StubAdjudicator(int crossTypePotency) : IInjuryAdjudicator
+    {
+        public FallingSurfaceRuling DecideFallingSurface() => new(0);
+
+        public PoisonOnsetRuling DecidePoisonOnset() => new(PoisonOnsetSpeed.FastActing, null);
+
+        public int DecideAntidoteCrossTypePotency(int crossTypeAntidotePotency) => crossTypePotency;
+
+        public CharacteristicId DecideDiseaseAffectedCharacteristic() => new("CON");
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/PoisonResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/PoisonResolverTests.cs
@@ -7,7 +7,7 @@ using Brp.Rules.Combat;
 namespace Brp.Rules.Tests.Combat;
 
 /// <summary>
-/// Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (pp.175-176). POT vs CON on the resistance
+/// Ch 7: Spot Rules, "Poison" and "Poison Antidotes" (p.176). POT vs CON on the resistance
 /// table (full POT if overcome, else half round-up), antidote subtraction, two-dose independence,
 /// and drain routed through the characteristic-recompute path. See
 /// <c>docs/decisions/0019-injury-spot-rules.md</c>.
@@ -28,7 +28,7 @@ public class PoisonResolverTests
     }
 
     [Fact]
-    public void Overcoming_con_deals_the_full_pot_page_175()
+    public void Overcoming_con_deals_the_full_pot_page_176()
     {
         // POT 15 vs CON 10 => chance 75; roll 50 succeeds (poison overcomes CON).
         var outcome = PoisonResolver.ResolvePoison(
@@ -39,7 +39,7 @@ public class PoisonResolverTests
     }
 
     [Fact]
-    public void Failing_to_overcome_con_deals_half_pot_rounded_up_page_175()
+    public void Failing_to_overcome_con_deals_half_pot_rounded_up_page_176()
     {
         // POT 15 vs CON 10 => chance 75; roll 90 fails; half of 15 rounds up to 8.
         var outcome = PoisonResolver.ResolvePoison(
@@ -105,7 +105,7 @@ public class PoisonResolverTests
     }
 
     [Fact]
-    public void Two_doses_are_two_separate_rolls_not_one_of_double_pot_page_175()
+    public void Two_doses_are_two_separate_rolls_not_one_of_double_pot_page_176()
     {
         // Two POT 10 doses vs CON 10 => each chance 50; rolls 90 and 90 both fail => 5 + 5.
         var doses = new FixedEntropySource(90, 90);
@@ -153,7 +153,7 @@ public class PoisonResolverTests
     }
 
     [Fact]
-    public void Onset_uses_the_printed_default_for_the_gamemasters_speed_page_175()
+    public void Onset_uses_the_printed_default_for_the_gamemasters_speed_page_176()
     {
         var fast = PoisonResolver.ResolveOnset(new PoisonOnsetRuling(PoisonOnsetSpeed.FastActing, null), Poison);
         Assert.Equal(new PoisonOnset(3, PoisonOnsetUnit.CombatRounds), fast);


### PR DESCRIPTION
## Linked Issue

Closes #96

## Exact behavioral claim

The injury/environmental half of the Ch 7 spot rules — **falling, poison, and disease** — now
resolve as data-driven rules that flow through the existing damage/HP path and the Layer-1
derived-characteristic recompute, and every "gamemaster's discretion" point is a named
`IInjuryAdjudicator` decision. This is the sibling of #50 (which did the situational-modifier
half) and completes the Ch 7 spot-rules surface for Layer 4.

## Scope

New: `FallingResolver` / `PoisonResolver` / `DiseaseResolver` and their rulesets (`Brp.Rules`),
the `injury-ruleset.json` + `NoirInjuryRuleset` loader (`Brp.Data`), the `IInjuryAdjudicator`
port (`Brp.Core.Contests`), and ADR 0019. One reused seam extended: a public plain-int
`DamageResolver.ApplyDamage(AbilitySet, WoundTrack, int, DamageRuleset, string)` overload so
non-weapon damage (falling/poison) applies HP loss without fabricating a combat `DamageRoll`.
Damage/drain reuse the existing machinery — `ResistanceResolver` (POT vs CON), `AbilitySet.Set`
(drain → live recompute), `AbilityResolver` (CON×N recovery ladder).

## Rules conformance

Source: **Ch 7** of `BasicRoleplaying-ORC-Content-Document.pdf`. Every value verified adversarially
by the `rules-conformance` pass against the printed text:

- **Falling** — 1D6 per 3 m; thrown-with-force doubles the dice; SIZ ≤5 → −1D6; SIZ >20 → +1D6 per fraction of 20 above (`ceil((SIZ−20)/20)`); armor half up to 3 m. *p.171 (base/force/SIZ), p.172 (armor).*
- **Poison** — POT vs CON on the resistance table; overcome → full POT damage, else half **round up**; onset 3 rounds (fast) / 3 turns (slow); two doses = two rolls; antidote taken ≤6 turns before subtracts its POT before damage. *p.176.*
- **Disease** — Stamina (CON×5) to contract; minor = 1D2 HP + 1D6 fatigue (reported, not applied — no fatigue subsystem); recovery ladder CON×2, CON×3, +1/day, fumble −×1, strenuous −×1/condition; the **Illness Severity Table** (0 None / 1 Mild-wk / 2 Acute-day / 3 Severe-hr / 4+ Terminal-min) reproduced row-by-row with an exact-count test. *p.170.*

All numeric values live in `injury-ruleset.json` (invariant 7); the Illness Severity Table is a
printed table reproduced per-row.

## Tests and evidence

- `dotnet build NoiRPG.slnx` → 0 warnings (warnings-as-errors), 0 errors.
- `dotnet test NoiRPG.slnx` → **2080 passed, 0 failed** (Core 1533, Rules 264, Data 232, Cli 51) — +67 over the 2013 baseline. Re-run independently by the orchestrator after each verification round.
- `dotnet format NoiRPG.slnx --verify-no-changes` → exit 0.

## Decisions and tradeoffs

- **Disease severity is a rate, not a baked quantity** (this was caught and fixed in review). The
  failure count selects a *degree* whose loss is a rate over wall-clock time (Severe = 1 pt/hour,
  Terminal = 1 pt/minute). `DiseaseResolver.ResolveSeverity` reports the degree + `IllnessLossPeriod`
  and touches no characteristic; `ApplyCharacteristicLoss` drains the points a clock-aware caller has
  accrued, via `AbilitySet.Set` → live recompute. This mirrors the poison-onset seam (resolver
  reports timing/rate; a time-aware caller applies it) — there is no campaign clock in this layer.
- Two book-silent readings, both judged acceptable by conformance and marked **house** in ADR 0019:
  large-SIZ falling bands as `ceil((SIZ−20)/20)` dice (no double-count), and no armor benefit beyond 3 m.

## Known limitations

- Wall-clock accrual for disease drain (rate × elapsed time → points) and poison onset delay are
  **caller seams**, not simulated here — the same deferral pattern as #50's turn-economy effects,
  recorded in ADR 0019.
- Deferred/named-only (out of scope per #96): falling hit-location split, a fatigue-point subsystem,
  disease combined-effects, poison hit-location onset, stake/trap damage. Radiation, fire/heat, and
  prone are separate rules and not touched.

## Agent provenance

Implemented by a build agent as the repo's **`engine-dev`** (Claude, via Claude Code) from a cited
Ch 7 source extract and a reuse map. Verified by adversarial **`rules-conformance`** — which
**FAILED** the first pass on the disease drain quantity and citation off-by-ones; both were
remediated and the re-check is clean — and **`scope-warden`** (no out-of-scope content, data-driven,
drain via recompute, layer invariants — PASS). Orchestrated at the repository owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
