### PR TITLE
Add the four combat fumble tables + resolver

### DIFF
--- a/docs/decisions/0020-fumble-tables.md
+++ b/docs/decisions/0020-fumble-tables.md
@@ -1,0 +1,143 @@
+# 0020. Combat fumble tables: the four D100 consequence tables, a table-selecting resolver, and the ally/reroll seams
+
+## Status
+
+Accepted — 2026-08-31. Resolves #97 (Layer 4, the combat fumble tables). Completes the Ch 6 combat
+surface begun by the attack/defense matrix (ADR 0016): the matrix flags *that* a fumble forces a
+roll on the relevant table (`AttackDefenseOutcome.AttackerRollsOnFumbleTable` /
+`DefenderRollsOnFumbleTable`), and this record delivers the tables that roll consults — piece F.
+
+## Context
+
+On a fumble (`SuccessLevel.Fumble`, decided by the resolution kernel #10 — **reused, not touched**,
+along with its pinned errata test), Ch 6: Combat directs a D100 roll on "the relevant fumble table"
+(p.146). The book prints **four** such tables, not one:
+
+- **Melee Weapon Attack Fumbles** (p.148) — 12 rows
+- **Melee Weapon Parry Fumbles** (p.148) — 10 rows
+- **Missile Weapon Attack Fumbles** (p.148) — 12 rows
+- **Natural Weapon Attack and Parry Fumbles** (p.149) — 11 rows
+
+The #97 issue text guessed "the combat fumble table" (singular) and mislocated it in "Ch 7 / Ch 5";
+the source extract handed to implementation had the right rows but the wrong pages (pp.147-148). The
+**book is authoritative** (AGENTS.md invariant 1): all four tables were verified against the PDF and
+sit on **pp.148-149** (printed p.147 holds the Attack/Defense Matrix). This is the recurring
+**prose/issue-over-table** and **misattributed-citation** defect class named in
+`docs/source-handling.md` — the printed tables win, and the page must match the print.
+
+## Decision
+
+### The four tables are data, reproduced row-by-row — sourced
+
+All four tables live in `Brp.Data/fumble-ruleset.json` (loaded by `NoirFumbleRuleset` into the
+immutable `FumbleRuleset`), per AGENTS.md invariant 7 — no row content hardcoded in C#. Each table is
+a banded D100 lookup (`FumbleConsequenceTable` / `FumbleConsequenceRow`) mirroring the
+`DamageModifierTable`/`IllnessSeverityTable` band structure. A percentile roll of **00 reads as 100**
+(the engine-wide `IEntropySource.NextD100` convention), so the "00" row is stored with bounds of 100.
+
+Every row is reproduced cell-by-cell in `NoirFumbleRulesetTests` — a `[Theory]` over all 45 rows plus
+an exact-count `[Fact]` per table (12 / 10 / 12 / 11). The `FumbleConsequenceTable` constructor
+additionally pins that the rows **tile [1,100] with no gap or overlap** and that every "use result
+NN-NN" fallback names a real row on the same table; a transcription slip fails loudly rather than
+mapping a roll to the wrong row.
+
+Each printed effect is carried as (a) a `FumbleEffectKind` a caller dispatches on, (b) the exact
+printed effect text for citation, and (c) structured quantities — an unrolled `DiceExpression`
+`Amount` (rounds lost, meters thrown/scattered, weapon hit points), a flat `Magnitude` (the −30%
+vision penalty, the −1 MOV twist, the 1 HP strain), a `LandedGrade` `HitGrade` for graded hits, and a
+`Fallback`. **No effect is applied and no embedded die is rolled here** — dropping/throwing a weapon,
+weapon hit-point loss, −MOV, hitting an ally or oneself are all structured outcomes returned to the
+caller (the same caller seam as #50/#96; no encounter model lives in this layer).
+
+### Selecting the table reuses the existing combat context — sourced routing
+
+`FumbleResolver.SelectTable(WeaponClass, DefenseType)` maps the existing combat vocabulary onto the
+four tables rather than inventing a parallel context enum:
+
+- **`WeaponClass.Brawl`** (unarmed/natural) → **Natural** table (which combines attack and parry, so
+  the defense is irrelevant).
+- **Missile classes** (`Missile`, `Pistol`, `Revolver`, `Rifle`, `Shotgun`, `SubmachineGun`) →
+  **MissileAttack**. A missile weapon has no parry table, so `DefenseType.Parry` is rejected.
+- **Melee classes** (`Club`, `Dagger`) → `DefenseType.Parry` → **MeleeParry**, otherwise
+  **MeleeAttack**. `DefenseType.None` reads as "the fumbled roll was an attack."
+
+`DefenseType.Dodge` is rejected: the book prints no dodge fumble table. `FumbleTable` (the four-value
+key the JSON files each table under) is the tables' *identity*, not a redundant re-encoding of the
+context — the routing above is derivation logic, not book numbers.
+
+### The reroll chain — sourced
+
+The "**Blow it**" (99, roll twice more) and "**Blow it badly**" (00, roll three times more) rows are
+followed **cumulatively**: the resolver tracks an outstanding-rolls count, and a reroll that itself
+lands on 99/00 adds further rolls ("cumulative if rolled again"). Every roll — initial and reroll —
+consumes one injected D100 draw; the resolver is otherwise pure, so the same seed reproduces the
+identical step chain (AGENTS.md invariant 5). Each roll is recorded as a `FumbleStep` (the `Reroll`
+markers included, as the audit trail of why more rolls followed); a caller applies the non-reroll
+steps.
+
+### The ally / fallback branch — sourced rows, named discretion port
+
+The "hit nearest ally for normal/special/critical damage, **or use result NN-NN if no ally nearby**"
+rows branch on a fact this layer does not hold. Following the `ISpotRuleAdjudicator` (ADR 0018) and
+`IInjuryAdjudicator` (ADR 0019) precedent, "is an ally nearby" becomes the first-class port
+`IFumbleAdjudicator.IsAllyInRange()` (in `Brp.Core.Contests`, returning a plain `bool` so no
+`Brp.Rules` dependency inverts the layers — invariant 6), with the `FumbleDecisionId.AllyInRange`
+id (`fumble-ally-in-range`) and a `DefaultFumbleAdjudicator`. The resolver reports **both** branches
+in the returned `FumbleBranchSelection` (the ally-hit grade and the resolved fallback row) so a caller
+sees the whole rule, and marks which applies from the adjudicator's answer. Resolving a fallback
+consumes **no** entropy — "use result 41-50" is a lookup of that row, not a reroll. Tests drive the
+port with a deterministic stub.
+
+| Decision id | What the book leaves open | Timing | Default | Source |
+|---|---|---|---|---|
+| `fumble-ally-in-range` | Whether a friendly target is within reach of the fumbled blow | pre-effect | no ally in range (fallback used) | **sourced** — Ch 6 pp.148-149 |
+
+The port is **sourced** to the rows that leave the call open; the default answer (no ally in range) is
+a **house choice** of the most neutral reading — it invents no bystander the caller has not placed on
+the field — documented on `DefaultFumbleAdjudicator`.
+
+### The four tables, transcribed
+
+| Table | Rows | Page |
+|---|---|---|
+| Melee Weapon Attack Fumbles | 12 | Ch 6, p.148 — **sourced**, row-by-row |
+| Melee Weapon Parry Fumbles | 10 | Ch 6, p.148 — **sourced**, row-by-row |
+| Missile Weapon Attack Fumbles | 12 | Ch 6, p.148 — **sourced**, row-by-row |
+| Natural Weapon Attack and Parry Fumbles | 11 | Ch 6, p.149 — **sourced**, row-by-row |
+
+Details worth recording:
+
+- **The missile "weapon has no hit points" fallback is caller-decided, not adjudicated — house
+  reading.** The missile row 66-80 ("do 1D6 damage to weapon's hit points, or use 81-85 if the weapon
+  has no hit points") is a fallback of the same shape as the ally rows, but weapon hit points are not
+  modeled in this layer. Rather than invent a second adjudicator port for a fact no current weapon
+  data carries, the resolver reports both branches with `PrimaryApplies = null` (caller decides). If a
+  weapon hit-point subsystem later lands, this can become a named port then.
+- **`LandedGrade` is reused for the ally/foe/self hit grade — sourced vocabulary.** "Hit ... for
+  normal/special/critical damage," "foe automatically hits with normal/special/critical hit," and
+  "do normal damage to self" all use the same Normal/Special/Critical grades the attack/defense
+  matrix already produces (ADR 0016), so the row carries a `LandedGrade` rather than a new enum.
+
+## Out of scope (per `orc-scope-filter.md` and the issue)
+
+Not implemented here: **weapon malfunctions** (e.g. a musket's 95-00 misfire — a weapon-data concern
+that can co-occur with a fumble but is separate); the fumble **range** (which rolls fumble — kernel
+#10, reused via `SuccessLevel.Fumble`, untouched); **applying** any ally/self damage, −MOV, weapon
+hit-point loss, or lost-round turn-economy effect (all returned as structured outcomes for a
+caller); **hit-location** damage (the "in the attacking limb if hit locations used" clauses — hit
+locations remain a deferred, out-of-scope subsystem, so the resolver reports the grade to total hit
+points as the book also does without hit locations); and any fantastical results.
+
+## Consequences
+
+- `Brp.Rules.Combat` gains `FumbleRuleset` (+ `FumbleConsequenceTable`/`FumbleConsequenceRow`/
+  `FumbleFallback`), `FumbleResolver`, the `FumbleResolution`/`FumbleStep`/`FumbleBranchSelection`
+  outcome records, and the `FumbleTable`/`FumbleEffectKind`/`FumbleFallbackCondition` enums.
+  `Brp.Data` gains `fumble-ruleset.json` and `NoirFumbleRuleset`. `Brp.Core.Contests` gains
+  `IFumbleAdjudicator`, `FumbleDecisionId`/`FumbleDecisionIds`, and `DefaultFumbleAdjudicator`.
+- The applied effects (dropped/thrown weapons, weapon hit points, −MOV and lost rounds, ally/self
+  damage, hit locations) all need caller/round/encounter state this resolver does not hold. As in
+  ADR 0018/0019, the resolver names and structures the consequences; whichever piece orchestrates a
+  running encounter wires the outcomes and the `fumble-ally-in-range` port into a live fight.
+- With #96 (injury spot rules) and #97 (fumble tables) done, Layer 4's combat surface is complete;
+  Layer 5 (the noir game layer, epic #98) is next per `ROADMAP.md`.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -42,3 +42,4 @@ supersedes it — the original is not edited or deleted.
 | [0017](0017-damage.md) | Damage: normal/special/critical arithmetic, hit-point conditions, and knockout attacks | Accepted |
 | [0018](0018-spot-rules.md) | Situational combat spot rules: five modifier producers and named adjudication ports | Accepted |
 | [0019](0019-injury-spot-rules.md) | Injury/effect spot rules: falling, poison, and disease through the damage and characteristic-drain paths | Accepted |
+| [0020](0020-fumble-tables.md) | Combat fumble tables: the four D100 consequence tables, a context-selecting resolver, and the ally/reroll seams | Accepted |

--- a/src/Brp.Core/Contests/IFumbleAdjudicator.cs
+++ b/src/Brp.Core/Contests/IFumbleAdjudicator.cs
@@ -1,0 +1,77 @@
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// The named gamemaster-adjudication points the Ch 6 combat fumble tables leave open. Like
+/// <see cref="SpotRuleDecisionId"/> (#50, ADR 0018) and <see cref="InjuryDecisionId"/> (#96,
+/// ADR 0019), each member is a decision the source book explicitly hands to the situation rather
+/// than resolving mechanically. The four D100 fumble tables (Ch 6, pp.148-149) each carry rows of
+/// the form "hit nearest ally ... <em>or use result NN-NN if no ally nearby</em>"; whether a
+/// friendly target is actually in range is a fact about the encounter this rules layer does not
+/// model, so it is named as a first-class id rather than silently assumed. The canonical
+/// kebab-case id is given in the summary and returned by <see cref="FumbleDecisionIds.CanonicalId"/>.
+/// See <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public enum FumbleDecisionId
+{
+    /// <summary>
+    /// Canonical id <c>fumble-ally-in-range</c>. Ch 6, the fumble tables (pp.148-149): the
+    /// "hit nearest ally for normal/special/critical damage, or use result NN-NN if no ally nearby"
+    /// rows branch on whether a friendly target is within reach of the fumbled blow. Whether an ally
+    /// is nearby is an encounter fact (position, who is adjacent) this combat-rules layer does not
+    /// hold, so it is a caller/gamemaster call. A pre-effect ruling: it selects which branch of the
+    /// row applies before any damage is figured (damage itself is never applied here — no encounter
+    /// model in this layer).
+    /// </summary>
+    AllyInRange,
+}
+
+/// <summary>Canonical kebab-case ids for the <see cref="FumbleDecisionId"/> ports.</summary>
+public static class FumbleDecisionIds
+{
+    /// <summary>
+    /// The canonical kebab-case id for <paramref name="decisionId"/> -- the stable string a GM
+    /// tool, authored policy, or log keys on (e.g. <c>fumble-ally-in-range</c>), matching the id
+    /// named in Issue #97 and ADR 0020.
+    /// </summary>
+    public static string CanonicalId(FumbleDecisionId decisionId) => decisionId switch
+    {
+        FumbleDecisionId.AllyInRange => "fumble-ally-in-range",
+        _ => throw new ArgumentOutOfRangeException(nameof(decisionId), decisionId, "Unknown fumble decision id."),
+    };
+}
+
+/// <summary>
+/// A gamemaster-discretion port for the Ch 6 combat fumble tables (pp.148-149), modeled -- like
+/// <see cref="ISpotRuleAdjudicator"/> and <see cref="IInjuryAdjudicator"/> -- as a first-class
+/// interface rather than a set of silent hardcoded choices. Its single method answers the one
+/// <see cref="FumbleDecisionId"/> the tables leave open. A GM tool can prompt a human; an unattended
+/// simulation can supply an authored policy; tests supply a deterministic stub. The return type is a
+/// plain <c>bool</c>, so this port stays within <c>Brp.Core</c> and does not invert the layer
+/// dependency (AGENTS.md invariant 6). See <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public interface IFumbleAdjudicator
+{
+    /// <summary>
+    /// Decides whether a friendly target is within reach of a fumbled blow, for the
+    /// <see cref="FumbleDecisionId.AllyInRange"/> rows. Pre-effect: <see langword="true"/> selects
+    /// the "hit nearest ally" branch, <see langword="false"/> the printed "no ally nearby" fallback.
+    /// </summary>
+    bool IsAllyInRange();
+}
+
+/// <summary>
+/// The documented default policy for <see cref="FumbleDecisionId.AllyInRange"/>: the most
+/// minimal-assumption answer to "the book does not say," mirroring <see cref="DefaultInjuryAdjudicator"/>
+/// and <see cref="DefaultSpotRuleAdjudicator"/>. A table with a house rule or a human gamemaster
+/// should supply its own <see cref="IFumbleAdjudicator"/> instead.
+/// </summary>
+public sealed class DefaultFumbleAdjudicator : IFumbleAdjudicator
+{
+    /// <summary>
+    /// Defaults to <see langword="false"/> -- no ally in range. The safest neutral reading for an
+    /// unattended run: it asserts no friendly bystander the caller has not placed on the field, so a
+    /// fumble that could hit an ally falls back to the printed self-affecting result instead of
+    /// inventing collateral damage.
+    /// </summary>
+    public bool IsAllyInRange() => false;
+}

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -25,6 +25,7 @@
     <EmbeddedResource Include="damage-ruleset.json" />
     <EmbeddedResource Include="spot-rule-ruleset.json" />
     <EmbeddedResource Include="injury-ruleset.json" />
+    <EmbeddedResource Include="fumble-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirFumbleRuleset.cs
+++ b/src/Brp.Data/NoirFumbleRuleset.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using Brp.Core.Dice;
+using Brp.Rules.Combat;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's four D100 fumble consequence tables from embedded JSON. Sourced: Ch 6: Combat --
+/// "Melee Weapon Attack Fumbles", "Melee Weapon Parry Fumbles", "Missile Weapon Attack Fumbles"
+/// (p.148), and "Natural Weapon Attack and Parry Fumbles" (p.149). Recorded in
+/// <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public static class NoirFumbleRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable fumble ruleset from the shipped data.</summary>
+    public static FumbleRuleset Load()
+    {
+        var assembly = typeof(NoirFumbleRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.fumble-ruleset.json")
+            ?? throw new InvalidOperationException("The fumble ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<FumbleRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The fumble ruleset data is empty.");
+
+        var tables = data.Tables.Select(entry => BuildTable(Enum.Parse<FumbleTable>(entry.Key), entry.Value));
+        return new FumbleRuleset(tables);
+    }
+
+    private static FumbleConsequenceTable BuildTable(FumbleTable table, FumbleTableData data)
+    {
+        var rows = data.Rows.Select(row => new FumbleConsequenceRow(
+            row.MinRoll,
+            row.MaxRoll,
+            Enum.Parse<FumbleEffectKind>(row.Kind),
+            row.Effect,
+            row.Amount is null ? null : DiceExpression.Parse(row.Amount),
+            row.Magnitude,
+            row.HitGrade is null ? null : Enum.Parse<LandedGrade>(row.HitGrade),
+            row.Fallback is null
+                ? null
+                : new FumbleFallback(
+                    Enum.Parse<FumbleFallbackCondition>(row.Fallback.Condition),
+                    row.Fallback.MinRoll,
+                    row.Fallback.MaxRoll),
+            row.RerollCount));
+
+        return new FumbleConsequenceTable(table, rows);
+    }
+
+    private sealed class FumbleRulesetData
+    {
+        public required IReadOnlyDictionary<string, FumbleTableData> Tables { get; init; }
+    }
+
+    private sealed class FumbleTableData
+    {
+        public required IReadOnlyList<FumbleRowData> Rows { get; init; }
+    }
+
+    private sealed class FumbleRowData
+    {
+        public required int MinRoll { get; init; }
+
+        public required int MaxRoll { get; init; }
+
+        public required string Kind { get; init; }
+
+        public required string Effect { get; init; }
+
+        public string? Amount { get; init; }
+
+        public int? Magnitude { get; init; }
+
+        public string? HitGrade { get; init; }
+
+        public FumbleFallbackData? Fallback { get; init; }
+
+        public int? RerollCount { get; init; }
+    }
+
+    private sealed class FumbleFallbackData
+    {
+        public required string Condition { get; init; }
+
+        public required int MinRoll { get; init; }
+
+        public required int MaxRoll { get; init; }
+    }
+}

--- a/src/Brp.Data/fumble-ruleset.json
+++ b/src/Brp.Data/fumble-ruleset.json
@@ -1,0 +1,74 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 6: Combat",
+    "notes": "The four printed D100 fumble consequence tables: Melee Weapon Attack Fumbles (p.148), Melee Weapon Parry Fumbles (p.148), Missile Weapon Attack Fumbles (p.148), and Natural Weapon Attack and Parry Fumbles (p.149). A fumble (SuccessLevel.Fumble, kernel #10) forces a roll on the relevant table (Ch 6, p.146). Weapon malfunctions are a separate, out-of-scope weapon-data concern. A percentile roll of 00 is read as 100. See docs/decisions/0020-fumble-tables.md."
+  },
+  "tables": {
+    "MeleeAttack": {
+      "page": "148",
+      "rows": [
+        { "minRoll": 1, "maxRoll": 15, "kind": "LoseNextCombatRound", "effect": "Lose the next combat round; effectively helpless." },
+        { "minRoll": 16, "maxRoll": 25, "kind": "LoseMultipleCombatRounds", "amount": "1D3", "effect": "Lose the next 1D3 combat rounds; effectively helpless." },
+        { "minRoll": 26, "maxRoll": 40, "kind": "FallProne", "effect": "Fall prone." },
+        { "minRoll": 41, "maxRoll": 50, "kind": "DropWeapon", "effect": "Drop the weapon being used." },
+        { "minRoll": 51, "maxRoll": 60, "kind": "ThrowWeapon", "amount": "1D10", "effect": "Throw weapon 1D10 meters away." },
+        { "minRoll": 61, "maxRoll": 65, "kind": "LoseWeaponHitPoints", "amount": "1D10", "effect": "Lose 1D10 points of weapon's hit points." },
+        { "minRoll": 66, "maxRoll": 75, "kind": "VisionObscured", "amount": "1D3", "magnitude": -30, "effect": "Vision obscured; -30% to all appropriate skills for 1D3 combat rounds." },
+        { "minRoll": 76, "maxRoll": 85, "kind": "HitNearestAlly", "hitGrade": "Normal", "fallback": { "condition": "NoAllyNearby", "minRoll": 41, "maxRoll": 50 }, "effect": "Hit nearest ally for normal damage, or use result 41-50 if no ally nearby." },
+        { "minRoll": 86, "maxRoll": 90, "kind": "HitNearestAlly", "hitGrade": "Special", "fallback": { "condition": "NoAllyNearby", "minRoll": 51, "maxRoll": 60 }, "effect": "Hit nearest ally for special damage, or use result 51-60 if no ally nearby." },
+        { "minRoll": 91, "maxRoll": 98, "kind": "HitNearestAlly", "hitGrade": "Critical", "fallback": { "condition": "NoAllyNearby", "minRoll": 61, "maxRoll": 65 }, "effect": "Hit nearest ally for critical damage, or use result 61-65 if no ally nearby." },
+        { "minRoll": 99, "maxRoll": 99, "kind": "Reroll", "rerollCount": 2, "effect": "Blow it; roll twice more on this table (cumulative if rolled again)." },
+        { "minRoll": 100, "maxRoll": 100, "kind": "Reroll", "rerollCount": 3, "effect": "Blow it badly; roll three times more on this table (cumulative if rolled again)." }
+      ]
+    },
+    "MeleeParry": {
+      "page": "148",
+      "rows": [
+        { "minRoll": 1, "maxRoll": 20, "kind": "LoseNextCombatRound", "effect": "Lose the next combat round (or this one if no action taken); effectively helpless." },
+        { "minRoll": 21, "maxRoll": 40, "kind": "FallProne", "effect": "Fall prone." },
+        { "minRoll": 41, "maxRoll": 50, "kind": "DropWeapon", "effect": "Drop weapon being used." },
+        { "minRoll": 51, "maxRoll": 60, "kind": "ThrowWeapon", "amount": "1D10", "effect": "Throw weapon 1D10 meters away." },
+        { "minRoll": 61, "maxRoll": 75, "kind": "VisionObscured", "amount": "1D3", "magnitude": -30, "effect": "Vision obscured; -30% to all appropriate skills for 1D3 combat rounds." },
+        { "minRoll": 76, "maxRoll": 85, "kind": "FoeAutomaticHit", "hitGrade": "Normal", "effect": "Wide open; foe automatically hits with normal hit." },
+        { "minRoll": 86, "maxRoll": 90, "kind": "FoeAutomaticHit", "hitGrade": "Special", "effect": "Wide open; foe automatically hits with special hit." },
+        { "minRoll": 91, "maxRoll": 93, "kind": "FoeAutomaticHit", "hitGrade": "Critical", "effect": "Wide open; foe automatically hits with critical hit." },
+        { "minRoll": 94, "maxRoll": 98, "kind": "Reroll", "rerollCount": 2, "effect": "Blow it; roll twice more on this table (cumulative)." },
+        { "minRoll": 99, "maxRoll": 100, "kind": "Reroll", "rerollCount": 3, "effect": "Blow it badly; roll three times more on this table (cumulative)." }
+      ]
+    },
+    "MissileAttack": {
+      "page": "148",
+      "rows": [
+        { "minRoll": 1, "maxRoll": 15, "kind": "LoseNextCombatRound", "effect": "Lose the next attack or other activity." },
+        { "minRoll": 16, "maxRoll": 25, "kind": "LoseMultipleCombatRounds", "amount": "1D3", "effect": "Lose the next 1D3 combat rounds or other activity." },
+        { "minRoll": 26, "maxRoll": 40, "kind": "FallProne", "effect": "Fall prone." },
+        { "minRoll": 41, "maxRoll": 55, "kind": "VisionObscured", "amount": "1D3", "magnitude": -30, "effect": "Vision obscured; -30% to all appropriate skills for 1D3 combat rounds." },
+        { "minRoll": 56, "maxRoll": 65, "kind": "DropWeaponAndScatter", "amount": "1D6-1", "effect": "Drop weapon; slides/bounces 1D6-1 meters away." },
+        { "minRoll": 66, "maxRoll": 80, "kind": "LoseWeaponHitPoints", "amount": "1D6", "fallback": { "condition": "WeaponHasNoHitPoints", "minRoll": 81, "maxRoll": 85 }, "effect": "Do 1D6 damage to weapon's hit points (or use 81-85 if the weapon has no hit points)." },
+        { "minRoll": 81, "maxRoll": 85, "kind": "BreakWeapon", "effect": "Break weapon; regardless of current hit points." },
+        { "minRoll": 86, "maxRoll": 90, "kind": "HitNearestAlly", "hitGrade": "Normal", "fallback": { "condition": "NoAllyNearby", "minRoll": 56, "maxRoll": 65 }, "effect": "Hit nearest ally for normal damage, or use 56-65 if no ally nearby." },
+        { "minRoll": 91, "maxRoll": 95, "kind": "HitNearestAlly", "hitGrade": "Special", "fallback": { "condition": "NoAllyNearby", "minRoll": 66, "maxRoll": 80 }, "effect": "Hit nearest ally for special damage, or use 66-80 if no ally nearby." },
+        { "minRoll": 96, "maxRoll": 98, "kind": "HitNearestAlly", "hitGrade": "Critical", "fallback": { "condition": "NoAllyNearby", "minRoll": 81, "maxRoll": 85 }, "effect": "Hit nearest ally for critical damage, or use 81-85 if no ally nearby." },
+        { "minRoll": 99, "maxRoll": 99, "kind": "Reroll", "rerollCount": 2, "effect": "Blow it; roll twice more on this table (cumulative)." },
+        { "minRoll": 100, "maxRoll": 100, "kind": "Reroll", "rerollCount": 3, "effect": "Blow it badly; roll three times more on this table (cumulative)." }
+      ]
+    },
+    "Natural": {
+      "page": "149",
+      "rows": [
+        { "minRoll": 1, "maxRoll": 25, "kind": "LoseNextCombatRound", "effect": "Lose the next combat round (or this one if no action taken)." },
+        { "minRoll": 26, "maxRoll": 30, "kind": "LoseMultipleCombatRounds", "amount": "1D3", "effect": "Lose the next 1D3 combat rounds (including this one if no action taken)." },
+        { "minRoll": 31, "maxRoll": 50, "kind": "FallProne", "effect": "Fall prone." },
+        { "minRoll": 51, "maxRoll": 60, "kind": "FallProneAndTwistAnkle", "amount": "1D10", "magnitude": -1, "effect": "Fall prone and twist ankle; -1 MOV for 1D10 full turns (and combat turns within them)." },
+        { "minRoll": 61, "maxRoll": 75, "kind": "VisionObscured", "amount": "1D3", "magnitude": -30, "effect": "Vision obscured; -30% to all appropriate skills for 1D3 combat rounds." },
+        { "minRoll": 76, "maxRoll": 85, "kind": "StrainSelf", "magnitude": 1, "effect": "Miss and strain something; lose 1 hit point (in the attacking limb if hit locations used)." },
+        { "minRoll": 86, "maxRoll": 90, "kind": "HitNearestAlly", "hitGrade": "Normal", "fallback": { "condition": "NoAllyNearby", "minRoll": 76, "maxRoll": 85 }, "effect": "Hit nearest ally for normal damage, or use 76-85 if no ally nearby." },
+        { "minRoll": 91, "maxRoll": 94, "kind": "HitNearestAlly", "hitGrade": "Special", "fallback": { "condition": "NoAllyNearby", "minRoll": 76, "maxRoll": 85 }, "effect": "Hit nearest ally for special damage, or use 76-85 if no ally nearby." },
+        { "minRoll": 95, "maxRoll": 98, "kind": "HitHardSurface", "hitGrade": "Normal", "effect": "Hit hard surface; do normal damage to self (in the attacking limb if hit locations used)." },
+        { "minRoll": 99, "maxRoll": 99, "kind": "Reroll", "rerollCount": 2, "effect": "Blow it; roll twice more on this table (cumulative)." },
+        { "minRoll": 100, "maxRoll": 100, "kind": "Reroll", "rerollCount": 3, "effect": "Blow it badly; roll three times more on this table (cumulative)." }
+      ]
+    }
+  }
+}

--- a/src/Brp.Rules/Combat/FumbleConsequenceRow.cs
+++ b/src/Brp.Rules/Combat/FumbleConsequenceRow.cs
@@ -1,0 +1,65 @@
+using Brp.Core.Dice;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// One printed row of one of the four D100 fumble tables of Ch 6: Combat (pp.148-149), as a banded
+/// D100 lookup. Mirrors <see cref="Core.Abilities.DamageModifierBand"/> / <see cref="IllnessSeverityBand"/>:
+/// an inclusive roll band, plus the structured pieces of the printed effect. A percentile roll of
+/// <c>00</c> is read as <c>100</c> (per <see cref="Core.Randomness.IEntropySource.NextD100"/>), so the
+/// tables' "00" row is stored with bounds of 100. Every numeric rules value the row carries lives in
+/// ruleset data (AGENTS.md invariant 7); this record only shapes it.
+/// </summary>
+/// <param name="MinimumRoll">The lowest D100 result this row covers (1-100).</param>
+/// <param name="MaximumRoll">The highest D100 result this row covers (1-100), with 00 stored as 100.</param>
+/// <param name="Kind">Which kind of consequence this row inflicts.</param>
+/// <param name="Effect">The exact printed effect text, kept for citation and row identity.</param>
+/// <param name="Amount">
+/// The row's rolled quantity, if any -- combat rounds lost (1D3), meters thrown/scattered (1D10,
+/// 1D6-1), or weapon hit points lost (1D10, 1D6). Left unrolled: the resolver returns it for a caller
+/// to roll and apply, never rolling it here.
+/// </param>
+/// <param name="Magnitude">
+/// The row's flat numeric value, if any -- the vision skill penalty (-30), the twisted-ankle
+/// movement penalty (-1), or the strain hit-point loss (1).
+/// </param>
+/// <param name="HitGrade">
+/// The grade of hit the row inflicts, if any -- on an ally (<see cref="FumbleEffectKind.HitNearestAlly"/>),
+/// on oneself against a hard surface (<see cref="FumbleEffectKind.HitHardSurface"/>), or from a foe
+/// left an opening (<see cref="FumbleEffectKind.FoeAutomaticHit"/>). Reuses <see cref="LandedGrade"/>
+/// (Normal/Special/Critical) -- the same hit-grade vocabulary the attack/defense matrix produces.
+/// </param>
+/// <param name="Fallback">
+/// The printed "or use result NN-NN" alternative, if any, and the caller-known condition that
+/// selects it (no ally nearby; weapon has no hit points). Present on the hit-ally rows and the one
+/// missile weapon-hit-point row.
+/// </param>
+/// <param name="RerollCount">
+/// For a <see cref="FumbleEffectKind.Reroll"/> row, how many further rolls to make on this table
+/// (two for "blow it," three for "blow it badly").
+/// </param>
+public sealed record FumbleConsequenceRow(
+    int MinimumRoll,
+    int MaximumRoll,
+    FumbleEffectKind Kind,
+    string Effect,
+    DiceExpression? Amount = null,
+    int? Magnitude = null,
+    LandedGrade? HitGrade = null,
+    FumbleFallback? Fallback = null,
+    int? RerollCount = null)
+{
+    /// <summary>Whether this row covers the given D100 result (1-100, with 00 read as 100).</summary>
+    public bool Contains(int roll) => roll >= MinimumRoll && roll <= MaximumRoll;
+}
+
+/// <summary>
+/// A fumble row's printed "or use result NN-NN" alternative, per Ch 6 (pp.148-149), and the
+/// caller-known condition under which it applies instead of the row's primary effect. The range
+/// names another row on the same table (by that row's own roll band); the resolver looks it up
+/// without consuming entropy -- "use result 41-50" applies that row's effect, it does not reroll.
+/// </summary>
+/// <param name="Condition">The caller fact that selects the fallback over the primary effect.</param>
+/// <param name="MinimumRoll">The low end of the referenced result band.</param>
+/// <param name="MaximumRoll">The high end of the referenced result band.</param>
+public sealed record FumbleFallback(FumbleFallbackCondition Condition, int MinimumRoll, int MaximumRoll);

--- a/src/Brp.Rules/Combat/FumbleConsequenceTable.cs
+++ b/src/Brp.Rules/Combat/FumbleConsequenceTable.cs
@@ -1,0 +1,87 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// One of the four printed D100 fumble tables of Ch 6: Combat (pp.148-149), as an immutable, banded
+/// D100 lookup. Mirrors <see cref="IllnessSeverityTable"/> in shape. The validating constructor
+/// pins the invariants that make a transcription error surface as a failure rather than a silent
+/// misread: the rows must tile the whole <c>[1, 100]</c> percentile range with no gap or overlap,
+/// and every "use result NN-NN" fallback must name a band an actual row covers.
+/// </summary>
+public sealed class FumbleConsequenceTable
+{
+    private readonly List<FumbleConsequenceRow> _rows;
+
+    /// <summary>Creates a table from ordered ruleset rows.</summary>
+    /// <param name="table">Which of the four tables this is.</param>
+    /// <param name="rows">The printed rows, in ascending roll order.</param>
+    public FumbleConsequenceTable(FumbleTable table, IEnumerable<FumbleConsequenceRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        Table = table;
+        _rows = rows.ToList();
+
+        if (_rows.Count == 0)
+        {
+            throw new ArgumentException($"Fumble table '{table}' must contain at least one row.", nameof(rows));
+        }
+
+        // The rows must tile [1, 100] exactly: each starts where the previous ended, no gap, no
+        // overlap. A dropped or mistyped band shows up here instead of as a roll that silently
+        // matches the wrong row (or none).
+        var expectedNext = 1;
+        foreach (var row in _rows)
+        {
+            if (row.MinimumRoll != expectedNext)
+            {
+                throw new ArgumentException(
+                    $"Fumble table '{table}' has a gap or overlap: expected the next row to start at " +
+                    $"{expectedNext} but it starts at {row.MinimumRoll}.",
+                    nameof(rows));
+            }
+
+            if (row.MaximumRoll < row.MinimumRoll || row.MaximumRoll > 100)
+            {
+                throw new ArgumentException(
+                    $"Fumble table '{table}' has an invalid band {row.MinimumRoll}-{row.MaximumRoll}.",
+                    nameof(rows));
+            }
+
+            expectedNext = row.MaximumRoll + 1;
+        }
+
+        if (expectedNext != 101)
+        {
+            throw new ArgumentException(
+                $"Fumble table '{table}' does not cover the full 1-100 range (stops at {expectedNext - 1}).",
+                nameof(rows));
+        }
+
+        // Every fallback must point at a band a row actually covers -- "use result 41-50" has to be a
+        // real row, or the resolver would have nothing to resolve the fallback to.
+        foreach (var row in _rows.Where(r => r.Fallback is not null))
+        {
+            var fallback = row.Fallback!;
+            if (!_rows.Any(r => r.MinimumRoll == fallback.MinimumRoll && r.MaximumRoll == fallback.MaximumRoll))
+            {
+                throw new ArgumentException(
+                    $"Fumble table '{table}' row {row.MinimumRoll}-{row.MaximumRoll} names fallback result " +
+                    $"{fallback.MinimumRoll}-{fallback.MaximumRoll}, which is not a row on this table.",
+                    nameof(rows));
+            }
+        }
+    }
+
+    /// <summary>Which of the four tables this is.</summary>
+    public FumbleTable Table { get; }
+
+    /// <summary>Every printed row, in ascending roll order.</summary>
+    public IReadOnlyList<FumbleConsequenceRow> Rows => _rows;
+
+    /// <summary>Returns the row that covers the given D100 result (1-100, with 00 read as 100).</summary>
+    public FumbleConsequenceRow ForRoll(int roll)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(roll, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(roll, 100);
+        return _rows.Single(row => row.Contains(roll));
+    }
+}

--- a/src/Brp.Rules/Combat/FumbleEffectKind.cs
+++ b/src/Brp.Rules/Combat/FumbleEffectKind.cs
@@ -1,0 +1,90 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The kind of consequence a single fumble-table row inflicts, per the four D100 fumble tables of
+/// Ch 6: Combat (pp.148-149). This categorizes each printed row so a caller can dispatch on it
+/// without parsing the row's prose; the row also carries the exact printed effect text (for
+/// citation) and any structured quantities (dice, magnitudes, hit grade, fallback). Every effect
+/// that touches another subsystem -- dropping or throwing a weapon, weapon hit-point loss, a
+/// movement penalty, hitting an ally or oneself -- is returned as one of these named outcomes for a
+/// caller to apply; this layer applies none of it (no encounter model here, the same caller seam as
+/// #50/#96). See <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public enum FumbleEffectKind
+{
+    /// <summary>
+    /// Lose the next combat round (or this one if no action has been taken yet), often "effectively
+    /// helpless" -- and, on the missile table, phrased as losing the next attack or activity. The
+    /// exact wording is in the row's effect text.
+    /// </summary>
+    LoseNextCombatRound,
+
+    /// <summary>Lose the next several combat rounds; the count is the row's rolled quantity (1D3).</summary>
+    LoseMultipleCombatRounds,
+
+    /// <summary>Fall prone.</summary>
+    FallProne,
+
+    /// <summary>
+    /// Fall prone and twist an ankle: a movement penalty (the row's magnitude, -1 MOV) for the row's
+    /// rolled duration (1D10 full turns). Natural-weapon table only (p.149).
+    /// </summary>
+    FallProneAndTwistAnkle,
+
+    /// <summary>Drop the weapon being used, where it falls.</summary>
+    DropWeapon,
+
+    /// <summary>
+    /// Drop the weapon and have it slide or bounce away by the row's rolled distance (1D6-1 meters).
+    /// Missile-attack table only (p.148).
+    /// </summary>
+    DropWeaponAndScatter,
+
+    /// <summary>Throw the weapon away by the row's rolled distance (1D10 meters).</summary>
+    ThrowWeapon,
+
+    /// <summary>Lose weapon hit points equal to the row's rolled quantity (1D10 or 1D6).</summary>
+    LoseWeaponHitPoints,
+
+    /// <summary>Break the weapon regardless of its current hit points.</summary>
+    BreakWeapon,
+
+    /// <summary>
+    /// Vision obscured: a skill penalty (the row's magnitude, -30%) to all appropriate skills for the
+    /// row's rolled duration (1D3 combat rounds).
+    /// </summary>
+    VisionObscured,
+
+    /// <summary>
+    /// Miss and strain something: lose hit points equal to the row's magnitude (1 HP), in the
+    /// attacking limb if hit locations are used. Natural-weapon table only (p.149).
+    /// </summary>
+    StrainSelf,
+
+    /// <summary>
+    /// Hit a hard surface and take the row's hit grade (normal) damage to oneself, in the attacking
+    /// limb if hit locations are used. Natural-weapon table only (p.149).
+    /// </summary>
+    HitHardSurface,
+
+    /// <summary>
+    /// Hit the nearest ally for the row's hit grade (normal/special/critical) of damage, or -- if no
+    /// ally is nearby -- use the printed fallback result (the row's <see cref="FumbleConsequenceRow.Fallback"/>).
+    /// Whether an ally is in range is the <see cref="Core.Contests.FumbleDecisionId.AllyInRange"/>
+    /// call. No damage is applied here.
+    /// </summary>
+    HitNearestAlly,
+
+    /// <summary>
+    /// Left wide open: the foe automatically hits with the row's hit grade
+    /// (normal/special/critical). Melee-parry table only (p.148).
+    /// </summary>
+    FoeAutomaticHit,
+
+    /// <summary>
+    /// Blow it: roll on the same table again the row's <see cref="FumbleConsequenceRow.RerollCount"/>
+    /// times more (two for "blow it," three for "blow it badly"), cumulatively -- a reroll landing
+    /// here again adds further rolls. Not itself a consequence to apply.
+    /// </summary>
+    Reroll,
+}

--- a/src/Brp.Rules/Combat/FumbleFallbackCondition.cs
+++ b/src/Brp.Rules/Combat/FumbleFallbackCondition.cs
@@ -1,0 +1,26 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The caller-known condition that selects between a fumble row's primary effect and its printed
+/// "use result NN-NN" fallback, per Ch 6: Combat (pp.148-149). Both conditions are facts this
+/// combat-rules layer does not model (who is standing where; whether a weapon has hit points), so a
+/// row carrying a <see cref="FumbleFallback"/> names its condition and the resolver reports both
+/// branches. See <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public enum FumbleFallbackCondition
+{
+    /// <summary>
+    /// The "hit nearest ally ... or use result NN-NN if no ally nearby" rows. Resolved through the
+    /// <see cref="Core.Contests.FumbleDecisionId.AllyInRange"/> adjudicator port: an ally in range
+    /// selects the hit-ally primary; no ally selects the fallback.
+    /// </summary>
+    NoAllyNearby,
+
+    /// <summary>
+    /// The missile "do 1D6 damage to weapon's hit points (or use 81-85 if the weapon has no hit
+    /// points)" row (p.148). Whether the weapon has hit points is a weapon-data fact this layer does
+    /// not hold (weapon hit points are not modeled here), so the resolver names both branches and
+    /// leaves the selection to the caller rather than routing it through an adjudicator.
+    /// </summary>
+    WeaponHasNoHitPoints,
+}

--- a/src/Brp.Rules/Combat/FumbleResolution.cs
+++ b/src/Brp.Rules/Combat/FumbleResolution.cs
@@ -1,0 +1,54 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The full result of resolving a fumble on one of the four Ch 6 tables (pp.148-149): the table
+/// used and every consequence that accrued. Usually a single <see cref="FumbleStep"/>, but a
+/// "blow it" (99) or "blow it badly" (00) result rolls further times on the same table and each
+/// resulting step is accumulated here in roll order -- cumulatively, so a reroll that lands on
+/// 99/00 again adds still more. See <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+/// <param name="Table">Which of the four tables was rolled on.</param>
+/// <param name="Steps">
+/// Every roll made, in order: the initial roll first, then any reroll markers and the rolls they
+/// triggered. A caller applies each step's effect; the <see cref="FumbleEffectKind.Reroll"/> steps
+/// are the audit trail of why more rolls followed and carry no effect of their own.
+/// </param>
+public sealed record FumbleResolution(FumbleTable Table, IReadOnlyList<FumbleStep> Steps);
+
+/// <summary>
+/// One D100 roll on a fumble table and the row it landed on, plus -- for the rows that branch on a
+/// caller fact -- which branch applies. No dice inside the effect (rounds lost, meters, weapon hit
+/// points) are rolled here, and no damage is applied: every effect is a structured outcome the
+/// caller applies (the #50/#96 caller seam).
+/// </summary>
+/// <param name="Roll">The D100 result that selected this row (1-100, with 00 read as 100).</param>
+/// <param name="Row">The matched ruleset row, carrying the effect and any structured quantities.</param>
+/// <param name="Branch">
+/// For a row with a <see cref="FumbleConsequenceRow.Fallback"/> (the hit-ally rows and the one
+/// missile weapon-hit-point row), the resolved branch selection -- which of the primary effect and
+/// the printed fallback applies, and the fallback row itself. <see langword="null"/> for every other
+/// row.
+/// </param>
+public sealed record FumbleStep(int Roll, FumbleConsequenceRow Row, FumbleBranchSelection? Branch = null);
+
+/// <summary>
+/// The resolution of a fumble row's "primary effect, or use result NN-NN if ..." branch (Ch 6,
+/// pp.148-149). Both branches are always named so a caller can see the whole rule; which one applies
+/// depends on the row's <see cref="FumbleFallbackCondition"/>.
+/// </summary>
+/// <param name="Condition">The caller fact that selects between the two branches.</param>
+/// <param name="PrimaryApplies">
+/// Whether the row's primary effect (hit the ally; damage the weapon's hit points) applies rather
+/// than the fallback. For <see cref="FumbleFallbackCondition.NoAllyNearby"/> this is the
+/// <see cref="Core.Contests.IFumbleAdjudicator.IsAllyInRange"/> answer. For
+/// <see cref="FumbleFallbackCondition.WeaponHasNoHitPoints"/> it is <see langword="null"/> -- this
+/// layer does not model weapon hit points, so the caller decides; both branches are reported.
+/// </param>
+/// <param name="FallbackRow">
+/// The row the fallback names ("use result NN-NN"), resolved on the same table. This is the effect
+/// that applies when the primary does not.
+/// </param>
+public sealed record FumbleBranchSelection(
+    FumbleFallbackCondition Condition,
+    bool? PrimaryApplies,
+    FumbleConsequenceRow FallbackRow);

--- a/src/Brp.Rules/Combat/FumbleResolver.cs
+++ b/src/Brp.Rules/Combat/FumbleResolver.cs
@@ -1,0 +1,166 @@
+using Brp.Core.Contests;
+using Brp.Core.Randomness;
+using Brp.Rules.Gear;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Resolves a fumble by rolling D100 on the appropriate one of Ch 6's four fumble tables
+/// (pp.148-149) and returning the structured consequence. A fumble is a
+/// <see cref="Core.Resolution.SuccessLevel.Fumble"/> the resolution kernel (#10) has already
+/// determined; this piece (F) turns that into a named outcome. It is the fumble-table half of the
+/// combat surface whose flag <see cref="AttackDefenseOutcome.AttackerRollsOnFumbleTable"/> /
+/// <see cref="AttackDefenseOutcome.DefenderRollsOnFumbleTable"/> raises.
+/// <para>
+/// Deliberately data-driven (AGENTS.md invariant 7): the tables' rows live in
+/// <see cref="FumbleRuleset"/>; this resolver only selects the table, draws rolls, walks the reroll
+/// chain, and reports the ally/fallback branch. It applies nothing -- dropping a weapon, weapon
+/// hit-point loss, a movement penalty, hitting an ally or oneself are all structured outcomes a
+/// caller applies, the same seam #50/#96 use, because no encounter model lives in this layer.
+/// </para>
+/// </summary>
+public static class FumbleResolver
+{
+    /// <summary>
+    /// Selects which of the four fumble tables applies, from the existing combat context: the
+    /// fumbling combatant's <see cref="WeaponClass"/> and the <see cref="DefenseType"/> of the
+    /// fumbled roll. A natural (unarmed) weapon always uses the combined Natural table; a missile
+    /// weapon always uses the Missile Attack table (missile weapons have no parry table); a melee
+    /// weapon uses the Attack table for an attack and the Parry table for a parry.
+    /// </summary>
+    /// <param name="weaponClass">
+    /// The class of weapon the fumbling combatant was using (Ch 8, "Weapon Classes", p.196).
+    /// <see cref="WeaponClass.Brawl"/> is the natural/unarmed case; the firearm and thrown classes
+    /// are missile weapons; <see cref="WeaponClass.Club"/> and <see cref="WeaponClass.Dagger"/> are
+    /// melee weapons.
+    /// </param>
+    /// <param name="defense">
+    /// The defensive action the fumbled roll was, or <see cref="DefenseType.None"/> if the fumbled
+    /// roll was an attack. Only <see cref="DefenseType.Parry"/> has a fumble table; a fumbled
+    /// <see cref="DefenseType.Dodge"/> has none printed and is rejected.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// A missile weapon with a parry (missiles cannot parry), or any weapon with a dodge (no dodge
+    /// fumble table exists).
+    /// </exception>
+    public static FumbleTable SelectTable(WeaponClass weaponClass, DefenseType defense)
+    {
+        if (defense == DefenseType.Dodge)
+        {
+            throw new ArgumentException(
+                "No fumble table covers a dodge; Ch 6 prints attack/parry tables only (pp.148-149).",
+                nameof(defense));
+        }
+
+        if (weaponClass == WeaponClass.Brawl)
+        {
+            // The Natural table combines attack and parry, so the action does not matter.
+            return FumbleTable.Natural;
+        }
+
+        if (IsMissile(weaponClass))
+        {
+            if (defense == DefenseType.Parry)
+            {
+                throw new ArgumentException(
+                    "A missile weapon cannot parry; Ch 6 prints no missile parry fumble table (p.148).",
+                    nameof(defense));
+            }
+
+            return FumbleTable.MissileAttack;
+        }
+
+        // A melee weapon (Club, Dagger): the action selects attack vs. parry.
+        return defense == DefenseType.Parry ? FumbleTable.MeleeParry : FumbleTable.MeleeAttack;
+    }
+
+    /// <summary>
+    /// Resolves a fumble by selecting the table from <paramref name="weaponClass"/> and
+    /// <paramref name="defense"/> (see <see cref="SelectTable"/>) and rolling on it. A convenience
+    /// over <see cref="Resolve(FumbleTable, FumbleRuleset, IEntropySource, IFumbleAdjudicator)"/>.
+    /// </summary>
+    public static FumbleResolution Resolve(
+        WeaponClass weaponClass,
+        DefenseType defense,
+        FumbleRuleset ruleset,
+        IEntropySource entropy,
+        IFumbleAdjudicator adjudicator) =>
+        Resolve(SelectTable(weaponClass, defense), ruleset, entropy, adjudicator);
+
+    /// <summary>
+    /// Rolls D100 on the given <paramref name="table"/> and returns the structured consequence,
+    /// following the "blow it" (99) and "blow it badly" (00) reroll chain cumulatively and resolving
+    /// each hit-ally / weapon-hit-point row's branch. Each roll -- initial and reroll -- consumes one
+    /// D100 draw from <paramref name="entropy"/>; the "use result NN-NN" fallbacks consume none (they
+    /// reference an existing row, they do not reroll). The <paramref name="adjudicator"/> answers the
+    /// <see cref="FumbleDecisionId.AllyInRange"/> call for the hit-ally rows.
+    /// </summary>
+    public static FumbleResolution Resolve(
+        FumbleTable table,
+        FumbleRuleset ruleset,
+        IEntropySource entropy,
+        IFumbleAdjudicator adjudicator)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+        ArgumentNullException.ThrowIfNull(adjudicator);
+
+        var consequences = ruleset.ForTable(table);
+        var steps = new List<FumbleStep>();
+
+        // Iterative reroll accounting: start with one roll to make; a "blow it"/"blow it badly" row
+        // adds its reroll count to the outstanding total, so a reroll that lands on 99/00 again
+        // accumulates further rolls -- the book's "cumulative if rolled again."
+        var rollsRemaining = 1;
+        while (rollsRemaining > 0)
+        {
+            rollsRemaining--;
+
+            var roll = entropy.NextD100();
+            var row = consequences.ForRoll(roll);
+            steps.Add(new FumbleStep(roll, row, ResolveBranch(row, consequences, adjudicator)));
+
+            if (row.Kind == FumbleEffectKind.Reroll)
+            {
+                rollsRemaining += row.RerollCount
+                    ?? throw new InvalidOperationException("A reroll row is missing its reroll count.");
+            }
+        }
+
+        return new FumbleResolution(table, steps);
+    }
+
+    private static FumbleBranchSelection? ResolveBranch(
+        FumbleConsequenceRow row, FumbleConsequenceTable table, IFumbleAdjudicator adjudicator)
+    {
+        if (row.Fallback is not { } fallback)
+        {
+            return null;
+        }
+
+        var fallbackRow = table.ForRoll(fallback.MinimumRoll);
+        bool? primaryApplies = fallback.Condition switch
+        {
+            // "hit nearest ally ... or use result NN-NN if no ally nearby" -- the ally-in-range call.
+            FumbleFallbackCondition.NoAllyNearby => adjudicator.IsAllyInRange(),
+
+            // "do 1D6 damage to the weapon's hit points (or use 81-85 if the weapon has no hit
+            // points)" -- weapon hit points are not modeled here, so the caller decides; both
+            // branches are reported.
+            FumbleFallbackCondition.WeaponHasNoHitPoints => null,
+
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(row), fallback.Condition, "Unknown fumble fallback condition."),
+        };
+
+        return new FumbleBranchSelection(fallback.Condition, primaryApplies, fallbackRow);
+    }
+
+    private static bool IsMissile(WeaponClass weaponClass) => weaponClass switch
+    {
+        WeaponClass.Missile or WeaponClass.Pistol or WeaponClass.Revolver or WeaponClass.Rifle
+            or WeaponClass.Shotgun or WeaponClass.SubmachineGun => true,
+        WeaponClass.Brawl or WeaponClass.Club or WeaponClass.Dagger => false,
+        _ => throw new ArgumentOutOfRangeException(nameof(weaponClass), weaponClass, "Unknown weapon class."),
+    };
+}

--- a/src/Brp.Rules/Combat/FumbleRuleset.cs
+++ b/src/Brp.Rules/Combat/FumbleRuleset.cs
@@ -1,0 +1,35 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The four printed D100 fumble consequence tables of Ch 6: Combat (pp.148-149), keyed by
+/// <see cref="FumbleTable"/>. Immutable; the validating constructor requires all four tables to be
+/// present. Loaded from <c>Brp.Data/fumble-ruleset.json</c> by <c>NoirFumbleRuleset</c> (AGENTS.md
+/// invariant 7). See <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public sealed class FumbleRuleset
+{
+    private readonly Dictionary<FumbleTable, FumbleConsequenceTable> _tables;
+
+    /// <summary>Creates a ruleset from the four loaded tables.</summary>
+    public FumbleRuleset(IEnumerable<FumbleConsequenceTable> tables)
+    {
+        ArgumentNullException.ThrowIfNull(tables);
+        _tables = tables.ToDictionary(table => table.Table);
+
+        foreach (var expected in Enum.GetValues<FumbleTable>())
+        {
+            if (!_tables.ContainsKey(expected))
+            {
+                throw new ArgumentException($"The fumble ruleset is missing the '{expected}' table.", nameof(tables));
+            }
+        }
+
+        if (_tables.Count != Enum.GetValues<FumbleTable>().Length)
+        {
+            throw new ArgumentException("The fumble ruleset has a duplicate table.", nameof(tables));
+        }
+    }
+
+    /// <summary>Returns the consequence table for the given kind.</summary>
+    public FumbleConsequenceTable ForTable(FumbleTable table) => _tables[table];
+}

--- a/src/Brp.Rules/Combat/FumbleTable.cs
+++ b/src/Brp.Rules/Combat/FumbleTable.cs
@@ -1,0 +1,27 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Which of the four printed D100 fumble consequence tables applies, per Ch 6: Combat (pp.148-149).
+/// The book prints <strong>four</strong> tables -- not one -- selected by the fumbling combatant's
+/// weapon nature and action; this enum is their identity, the key the ruleset data
+/// (<see cref="FumbleRuleset"/>) files each table under. <see cref="FumbleResolver.SelectTable"/>
+/// maps the existing combat context (<see cref="Gear.WeaponClass"/> + <see cref="DefenseType"/>)
+/// onto one of these. See <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public enum FumbleTable
+{
+    /// <summary>Ch 6, "Melee Weapon Attack Fumbles" table (p.148): a fumbled melee attack.</summary>
+    MeleeAttack,
+
+    /// <summary>Ch 6, "Melee Weapon Parry Fumbles" table (p.148): a fumbled melee parry.</summary>
+    MeleeParry,
+
+    /// <summary>Ch 6, "Missile Weapon Attack Fumbles" table (p.148): a fumbled missile attack.</summary>
+    MissileAttack,
+
+    /// <summary>
+    /// Ch 6, "Natural Weapon Attack and Parry Fumbles" table (p.149): a fumbled unarmed/natural
+    /// attack <em>or</em> parry -- the book uses one combined table for both actions.
+    /// </summary>
+    Natural,
+}

--- a/tests/Brp.Core.Tests/Contests/FumbleAdjudicatorTests.cs
+++ b/tests/Brp.Core.Tests/Contests/FumbleAdjudicatorTests.cs
@@ -1,0 +1,47 @@
+using Brp.Core.Contests;
+
+namespace Brp.Core.Tests.Contests;
+
+/// <summary>
+/// Covers the named gamemaster-discretion port for the Ch 6 fumble tables (pp.148-149): the
+/// canonical decision id, the documented neutral default of <see cref="DefaultFumbleAdjudicator"/>,
+/// and that a deterministic stub can drive the port for replayable tests. See
+/// <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public class FumbleAdjudicatorTests
+{
+    [Theory]
+    [InlineData(FumbleDecisionId.AllyInRange, "fumble-ally-in-range")]
+    public void Every_decision_id_has_its_canonical_kebab_case_string(FumbleDecisionId id, string expected)
+    {
+        Assert.Equal(expected, FumbleDecisionIds.CanonicalId(id));
+    }
+
+    [Fact]
+    public void The_named_discretion_points_are_exactly_those_issue_97_calls_out()
+    {
+        Assert.Single(Enum.GetValues<FumbleDecisionId>());
+    }
+
+    [Fact]
+    public void The_default_adjudicator_assumes_no_ally_in_range()
+    {
+        Assert.False(new DefaultFumbleAdjudicator().IsAllyInRange());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void A_deterministic_stub_drives_the_port_with_a_scripted_answer(bool allyInRange)
+    {
+        IFumbleAdjudicator adjudicator = new ScriptedFumbleAdjudicator(allyInRange);
+
+        Assert.Equal(allyInRange, adjudicator.IsAllyInRange());
+    }
+
+    /// <summary>A deterministic test double returning a pre-scripted ruling for the port.</summary>
+    private sealed class ScriptedFumbleAdjudicator(bool allyInRange) : IFumbleAdjudicator
+    {
+        public bool IsAllyInRange() => allyInRange;
+    }
+}

--- a/tests/Brp.Data.Tests/NoirFumbleRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirFumbleRulesetTests.cs
@@ -1,0 +1,180 @@
+using Brp.Rules.Combat;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped fumble ruleset data loads and reproduces Ch 6: Combat's four D100 fumble
+/// tables -- "Melee Weapon Attack Fumbles", "Melee Weapon Parry Fumbles", "Missile Weapon Attack
+/// Fumbles" (p.148), and "Natural Weapon Attack and Parry Fumbles" (p.149) -- <strong>row by
+/// row</strong> rather than sampled, per AGENTS.md's "table-backed rule" convention. Each table has
+/// an exact-count fact so a dropped or added row fails loudly. See
+/// <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public class NoirFumbleRulesetTests
+{
+    private static readonly FumbleRuleset Ruleset = NoirFumbleRuleset.Load();
+
+    // Each row: table, minRoll, maxRoll, kind, amount (or null), magnitude (or null),
+    // hitGrade (or null), fallback condition (or null), fallback min (or -1), fallback max (or -1),
+    // rerollCount (or -1). Transcribed from the cited pages.
+
+    public static IEnumerable<object?[]> MeleeAttackRows()
+    {
+        // Ch 6, "Melee Weapon Attack Fumbles" table (p.148) -- 12 rows.
+        yield return Row(FumbleTable.MeleeAttack, 1, 15, FumbleEffectKind.LoseNextCombatRound);
+        yield return Row(FumbleTable.MeleeAttack, 16, 25, FumbleEffectKind.LoseMultipleCombatRounds, amount: "1D3");
+        yield return Row(FumbleTable.MeleeAttack, 26, 40, FumbleEffectKind.FallProne);
+        yield return Row(FumbleTable.MeleeAttack, 41, 50, FumbleEffectKind.DropWeapon);
+        yield return Row(FumbleTable.MeleeAttack, 51, 60, FumbleEffectKind.ThrowWeapon, amount: "1D10");
+        yield return Row(FumbleTable.MeleeAttack, 61, 65, FumbleEffectKind.LoseWeaponHitPoints, amount: "1D10");
+        yield return Row(FumbleTable.MeleeAttack, 66, 75, FumbleEffectKind.VisionObscured, amount: "1D3", magnitude: -30);
+        yield return Row(FumbleTable.MeleeAttack, 76, 85, FumbleEffectKind.HitNearestAlly, hitGrade: LandedGrade.Normal,
+            fallbackCondition: FumbleFallbackCondition.NoAllyNearby, fallbackMin: 41, fallbackMax: 50);
+        yield return Row(FumbleTable.MeleeAttack, 86, 90, FumbleEffectKind.HitNearestAlly, hitGrade: LandedGrade.Special,
+            fallbackCondition: FumbleFallbackCondition.NoAllyNearby, fallbackMin: 51, fallbackMax: 60);
+        yield return Row(FumbleTable.MeleeAttack, 91, 98, FumbleEffectKind.HitNearestAlly, hitGrade: LandedGrade.Critical,
+            fallbackCondition: FumbleFallbackCondition.NoAllyNearby, fallbackMin: 61, fallbackMax: 65);
+        yield return Row(FumbleTable.MeleeAttack, 99, 99, FumbleEffectKind.Reroll, rerollCount: 2);
+        yield return Row(FumbleTable.MeleeAttack, 100, 100, FumbleEffectKind.Reroll, rerollCount: 3);
+    }
+
+    public static IEnumerable<object?[]> MeleeParryRows()
+    {
+        // Ch 6, "Melee Weapon Parry Fumbles" table (p.148) -- 10 rows.
+        yield return Row(FumbleTable.MeleeParry, 1, 20, FumbleEffectKind.LoseNextCombatRound);
+        yield return Row(FumbleTable.MeleeParry, 21, 40, FumbleEffectKind.FallProne);
+        yield return Row(FumbleTable.MeleeParry, 41, 50, FumbleEffectKind.DropWeapon);
+        yield return Row(FumbleTable.MeleeParry, 51, 60, FumbleEffectKind.ThrowWeapon, amount: "1D10");
+        yield return Row(FumbleTable.MeleeParry, 61, 75, FumbleEffectKind.VisionObscured, amount: "1D3", magnitude: -30);
+        yield return Row(FumbleTable.MeleeParry, 76, 85, FumbleEffectKind.FoeAutomaticHit, hitGrade: LandedGrade.Normal);
+        yield return Row(FumbleTable.MeleeParry, 86, 90, FumbleEffectKind.FoeAutomaticHit, hitGrade: LandedGrade.Special);
+        yield return Row(FumbleTable.MeleeParry, 91, 93, FumbleEffectKind.FoeAutomaticHit, hitGrade: LandedGrade.Critical);
+        yield return Row(FumbleTable.MeleeParry, 94, 98, FumbleEffectKind.Reroll, rerollCount: 2);
+        yield return Row(FumbleTable.MeleeParry, 99, 100, FumbleEffectKind.Reroll, rerollCount: 3);
+    }
+
+    public static IEnumerable<object?[]> MissileAttackRows()
+    {
+        // Ch 6, "Missile Weapon Attack Fumbles" table (p.148) -- 12 rows.
+        yield return Row(FumbleTable.MissileAttack, 1, 15, FumbleEffectKind.LoseNextCombatRound);
+        yield return Row(FumbleTable.MissileAttack, 16, 25, FumbleEffectKind.LoseMultipleCombatRounds, amount: "1D3");
+        yield return Row(FumbleTable.MissileAttack, 26, 40, FumbleEffectKind.FallProne);
+        yield return Row(FumbleTable.MissileAttack, 41, 55, FumbleEffectKind.VisionObscured, amount: "1D3", magnitude: -30);
+        yield return Row(FumbleTable.MissileAttack, 56, 65, FumbleEffectKind.DropWeaponAndScatter, amount: "1D6-1");
+        yield return Row(FumbleTable.MissileAttack, 66, 80, FumbleEffectKind.LoseWeaponHitPoints, amount: "1D6",
+            fallbackCondition: FumbleFallbackCondition.WeaponHasNoHitPoints, fallbackMin: 81, fallbackMax: 85);
+        yield return Row(FumbleTable.MissileAttack, 81, 85, FumbleEffectKind.BreakWeapon);
+        yield return Row(FumbleTable.MissileAttack, 86, 90, FumbleEffectKind.HitNearestAlly, hitGrade: LandedGrade.Normal,
+            fallbackCondition: FumbleFallbackCondition.NoAllyNearby, fallbackMin: 56, fallbackMax: 65);
+        yield return Row(FumbleTable.MissileAttack, 91, 95, FumbleEffectKind.HitNearestAlly, hitGrade: LandedGrade.Special,
+            fallbackCondition: FumbleFallbackCondition.NoAllyNearby, fallbackMin: 66, fallbackMax: 80);
+        yield return Row(FumbleTable.MissileAttack, 96, 98, FumbleEffectKind.HitNearestAlly, hitGrade: LandedGrade.Critical,
+            fallbackCondition: FumbleFallbackCondition.NoAllyNearby, fallbackMin: 81, fallbackMax: 85);
+        yield return Row(FumbleTable.MissileAttack, 99, 99, FumbleEffectKind.Reroll, rerollCount: 2);
+        yield return Row(FumbleTable.MissileAttack, 100, 100, FumbleEffectKind.Reroll, rerollCount: 3);
+    }
+
+    public static IEnumerable<object?[]> NaturalRows()
+    {
+        // Ch 6, "Natural Weapon Attack and Parry Fumbles" table (p.149) -- 11 rows.
+        yield return Row(FumbleTable.Natural, 1, 25, FumbleEffectKind.LoseNextCombatRound);
+        yield return Row(FumbleTable.Natural, 26, 30, FumbleEffectKind.LoseMultipleCombatRounds, amount: "1D3");
+        yield return Row(FumbleTable.Natural, 31, 50, FumbleEffectKind.FallProne);
+        yield return Row(FumbleTable.Natural, 51, 60, FumbleEffectKind.FallProneAndTwistAnkle, amount: "1D10", magnitude: -1);
+        yield return Row(FumbleTable.Natural, 61, 75, FumbleEffectKind.VisionObscured, amount: "1D3", magnitude: -30);
+        yield return Row(FumbleTable.Natural, 76, 85, FumbleEffectKind.StrainSelf, magnitude: 1);
+        yield return Row(FumbleTable.Natural, 86, 90, FumbleEffectKind.HitNearestAlly, hitGrade: LandedGrade.Normal,
+            fallbackCondition: FumbleFallbackCondition.NoAllyNearby, fallbackMin: 76, fallbackMax: 85);
+        yield return Row(FumbleTable.Natural, 91, 94, FumbleEffectKind.HitNearestAlly, hitGrade: LandedGrade.Special,
+            fallbackCondition: FumbleFallbackCondition.NoAllyNearby, fallbackMin: 76, fallbackMax: 85);
+        yield return Row(FumbleTable.Natural, 95, 98, FumbleEffectKind.HitHardSurface, hitGrade: LandedGrade.Normal);
+        yield return Row(FumbleTable.Natural, 99, 99, FumbleEffectKind.Reroll, rerollCount: 2);
+        yield return Row(FumbleTable.Natural, 100, 100, FumbleEffectKind.Reroll, rerollCount: 3);
+    }
+
+    [Theory]
+    [MemberData(nameof(MeleeAttackRows))]
+    [MemberData(nameof(MeleeParryRows))]
+    [MemberData(nameof(MissileAttackRows))]
+    [MemberData(nameof(NaturalRows))]
+    public void Every_printed_fumble_row_matches_the_book(
+        FumbleTable table,
+        int minRoll,
+        int maxRoll,
+        FumbleEffectKind kind,
+        string? amount,
+        int? magnitude,
+        LandedGrade? hitGrade,
+        FumbleFallbackCondition? fallbackCondition,
+        int fallbackMin,
+        int fallbackMax,
+        int rerollCount)
+    {
+        var row = Ruleset.ForTable(table).Rows.Single(r => r.MinimumRoll == minRoll);
+
+        Assert.Equal(maxRoll, row.MaximumRoll);
+        Assert.Equal(kind, row.Kind);
+        Assert.Equal(amount, row.Amount?.Notation);
+        Assert.Equal(magnitude, row.Magnitude);
+        Assert.Equal(hitGrade, row.HitGrade);
+
+        if (fallbackCondition is null)
+        {
+            Assert.Null(row.Fallback);
+        }
+        else
+        {
+            Assert.NotNull(row.Fallback);
+            Assert.Equal(fallbackCondition, row.Fallback!.Condition);
+            Assert.Equal(fallbackMin, row.Fallback.MinimumRoll);
+            Assert.Equal(fallbackMax, row.Fallback.MaximumRoll);
+        }
+
+        Assert.Equal(rerollCount == -1 ? (int?)null : rerollCount, row.RerollCount);
+    }
+
+    [Theory]
+    [InlineData(FumbleTable.MeleeAttack, 12)]
+    [InlineData(FumbleTable.MeleeParry, 10)]
+    [InlineData(FumbleTable.MissileAttack, 12)]
+    [InlineData(FumbleTable.Natural, 11)]
+    public void Each_table_has_exactly_its_printed_number_of_rows(FumbleTable table, int expectedRows)
+    {
+        Assert.Equal(expectedRows, Ruleset.ForTable(table).Rows.Count);
+    }
+
+    [Theory]
+    [InlineData(FumbleTable.MeleeAttack)]
+    [InlineData(FumbleTable.MeleeParry)]
+    [InlineData(FumbleTable.MissileAttack)]
+    [InlineData(FumbleTable.Natural)]
+    public void Every_d100_result_maps_to_exactly_one_row(FumbleTable table)
+    {
+        var consequences = Ruleset.ForTable(table);
+
+        // The validating constructor already pins full 1-100 coverage; this walks every result to
+        // confirm the loaded data actually tiles the range with no throw.
+        for (var roll = 1; roll <= 100; roll++)
+        {
+            Assert.Single(consequences.Rows, r => r.Contains(roll));
+        }
+    }
+
+    private static object?[] Row(
+        FumbleTable table,
+        int minRoll,
+        int maxRoll,
+        FumbleEffectKind kind,
+        string? amount = null,
+        int? magnitude = null,
+        LandedGrade? hitGrade = null,
+        FumbleFallbackCondition? fallbackCondition = null,
+        int fallbackMin = -1,
+        int fallbackMax = -1,
+        int rerollCount = -1) =>
+        new object?[]
+        {
+            table, minRoll, maxRoll, kind, amount, magnitude, hitGrade,
+            fallbackCondition, fallbackMin, fallbackMax, rerollCount,
+        };
+}

--- a/tests/Brp.Rules.Tests/Combat/FumbleResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/FumbleResolverTests.cs
@@ -1,0 +1,201 @@
+using Brp.Core.Contests;
+using Brp.Data;
+using Brp.Rules.Combat;
+using Brp.Rules.Gear;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Ch 6: Combat, the four D100 fumble tables (pp.148-149). Covers table selection from the existing
+/// combat context (weapon class + defense), boundary rolls landing on the right row, the "blow it"
+/// (99) and "blow it badly" (00) cumulative reroll chain, and the hit-ally / weapon-hit-point
+/// fallback branch driven by a deterministic <see cref="IFumbleAdjudicator"/> stub. See
+/// <c>docs/decisions/0020-fumble-tables.md</c>.
+/// </summary>
+public class FumbleResolverTests
+{
+    private static readonly FumbleRuleset Ruleset = NoirFumbleRuleset.Load();
+
+    private sealed class StubAdjudicator(bool allyInRange) : IFumbleAdjudicator
+    {
+        public bool IsAllyInRange() => allyInRange;
+    }
+
+    [Theory]
+    // Ch 6 (pp.148-149): weapon class + defense select the table.
+    [InlineData(WeaponClass.Dagger, DefenseType.None, FumbleTable.MeleeAttack)]
+    [InlineData(WeaponClass.Club, DefenseType.None, FumbleTable.MeleeAttack)]
+    [InlineData(WeaponClass.Dagger, DefenseType.Parry, FumbleTable.MeleeParry)]
+    [InlineData(WeaponClass.Pistol, DefenseType.None, FumbleTable.MissileAttack)]
+    [InlineData(WeaponClass.Revolver, DefenseType.None, FumbleTable.MissileAttack)]
+    [InlineData(WeaponClass.Rifle, DefenseType.None, FumbleTable.MissileAttack)]
+    [InlineData(WeaponClass.Shotgun, DefenseType.None, FumbleTable.MissileAttack)]
+    [InlineData(WeaponClass.SubmachineGun, DefenseType.None, FumbleTable.MissileAttack)]
+    [InlineData(WeaponClass.Missile, DefenseType.None, FumbleTable.MissileAttack)]
+    [InlineData(WeaponClass.Brawl, DefenseType.None, FumbleTable.Natural)]
+    [InlineData(WeaponClass.Brawl, DefenseType.Parry, FumbleTable.Natural)]
+    public void Weapon_class_and_defense_select_the_table_pages_148_to_149(
+        WeaponClass weaponClass, DefenseType defense, FumbleTable expected)
+    {
+        Assert.Equal(expected, FumbleResolver.SelectTable(weaponClass, defense));
+    }
+
+    [Fact]
+    public void A_missile_weapon_cannot_parry_so_has_no_parry_table_page_148()
+    {
+        Assert.Throws<ArgumentException>(() => FumbleResolver.SelectTable(WeaponClass.Pistol, DefenseType.Parry));
+    }
+
+    [Fact]
+    public void No_fumble_table_covers_a_dodge_pages_148_to_149()
+    {
+        Assert.Throws<ArgumentException>(() => FumbleResolver.SelectTable(WeaponClass.Dagger, DefenseType.Dodge));
+    }
+
+    [Theory]
+    // Boundary rolls at each band edge of the Melee Weapon Attack table (Ch 6, p.148).
+    [InlineData(1, FumbleEffectKind.LoseNextCombatRound)]
+    [InlineData(15, FumbleEffectKind.LoseNextCombatRound)]
+    [InlineData(16, FumbleEffectKind.LoseMultipleCombatRounds)]
+    [InlineData(40, FumbleEffectKind.FallProne)]
+    [InlineData(41, FumbleEffectKind.DropWeapon)]
+    [InlineData(60, FumbleEffectKind.ThrowWeapon)]
+    [InlineData(65, FumbleEffectKind.LoseWeaponHitPoints)]
+    [InlineData(75, FumbleEffectKind.VisionObscured)]
+    public void A_boundary_roll_maps_to_the_right_melee_attack_row_page_148(int roll, FumbleEffectKind expected)
+    {
+        var resolution = FumbleResolver.Resolve(
+            FumbleTable.MeleeAttack, Ruleset, new FixedEntropySource(roll), new DefaultFumbleAdjudicator());
+
+        Assert.Equal(FumbleTable.MeleeAttack, resolution.Table);
+        var step = Assert.Single(resolution.Steps);
+        Assert.Equal(roll, step.Roll);
+        Assert.Equal(expected, step.Row.Kind);
+    }
+
+    [Fact]
+    public void A_percentile_00_reads_as_100_and_lands_on_the_blow_it_badly_row_page_148()
+    {
+        var resolution = FumbleResolver.Resolve(
+            FumbleTable.MeleeAttack, Ruleset, new FixedEntropySource(100, 26, 26, 26), new DefaultFumbleAdjudicator());
+
+        // 00 -> "blow it badly": roll three more times (all 26 -> Fall prone).
+        Assert.Equal(4, resolution.Steps.Count);
+        Assert.Equal(FumbleEffectKind.Reroll, resolution.Steps[0].Row.Kind);
+        Assert.Equal(3, resolution.Steps[0].Row.RerollCount);
+        Assert.All(resolution.Steps.Skip(1), s => Assert.Equal(FumbleEffectKind.FallProne, s.Row.Kind));
+    }
+
+    [Fact]
+    public void Blow_it_rolls_twice_more_on_the_same_table_page_148()
+    {
+        // 99 -> "blow it": two more rolls (26 Fall prone, 41 Drop weapon).
+        var resolution = FumbleResolver.Resolve(
+            FumbleTable.MeleeAttack, Ruleset, new FixedEntropySource(99, 26, 41), new DefaultFumbleAdjudicator());
+
+        Assert.Equal(3, resolution.Steps.Count);
+        Assert.Equal(FumbleEffectKind.Reroll, resolution.Steps[0].Row.Kind);
+        Assert.Equal(2, resolution.Steps[0].Row.RerollCount);
+        Assert.Equal(FumbleEffectKind.FallProne, resolution.Steps[1].Row.Kind);
+        Assert.Equal(FumbleEffectKind.DropWeapon, resolution.Steps[2].Row.Kind);
+    }
+
+    [Fact]
+    public void The_reroll_chain_is_cumulative_when_a_reroll_lands_on_99_again_page_148()
+    {
+        // 99 (blow it, +2) -> 99 again (blow it, +2 more) -> then three ordinary rolls.
+        // Rolls consumed: 99, 99, 26, 26, 26 = 5 steps; two rolls still owed after the first 99 are
+        // one-more-plus-the-second-99's-two = the second 99 adds to the outstanding count cumulatively.
+        var resolution = FumbleResolver.Resolve(
+            FumbleTable.MeleeAttack, Ruleset, new FixedEntropySource(99, 99, 26, 26, 26), new DefaultFumbleAdjudicator());
+
+        Assert.Equal(5, resolution.Steps.Count);
+        Assert.Equal(FumbleEffectKind.Reroll, resolution.Steps[0].Row.Kind);
+        Assert.Equal(FumbleEffectKind.Reroll, resolution.Steps[1].Row.Kind);
+        Assert.Equal(3, resolution.Steps.Count(s => s.Row.Kind == FumbleEffectKind.FallProne));
+    }
+
+    [Fact]
+    public void With_an_ally_in_range_the_hit_ally_primary_applies_page_148()
+    {
+        // Roll 76 -> "Hit nearest ally for normal damage, or use result 41-50".
+        var resolution = FumbleResolver.Resolve(
+            FumbleTable.MeleeAttack, Ruleset, new FixedEntropySource(76), new StubAdjudicator(allyInRange: true));
+
+        var step = Assert.Single(resolution.Steps);
+        Assert.Equal(FumbleEffectKind.HitNearestAlly, step.Row.Kind);
+        Assert.Equal(LandedGrade.Normal, step.Row.HitGrade);
+
+        Assert.NotNull(step.Branch);
+        Assert.Equal(FumbleFallbackCondition.NoAllyNearby, step.Branch!.Condition);
+        Assert.True(step.Branch.PrimaryApplies);
+        // The fallback (41-50, Drop weapon) is still named for transparency.
+        Assert.Equal(FumbleEffectKind.DropWeapon, step.Branch.FallbackRow.Kind);
+    }
+
+    [Fact]
+    public void With_no_ally_in_range_the_printed_fallback_result_applies_page_148()
+    {
+        // Roll 76 -> no ally -> use result 41-50 (Drop weapon).
+        var resolution = FumbleResolver.Resolve(
+            FumbleTable.MeleeAttack, Ruleset, new FixedEntropySource(76), new StubAdjudicator(allyInRange: false));
+
+        var step = Assert.Single(resolution.Steps);
+        Assert.NotNull(step.Branch);
+        Assert.False(step.Branch!.PrimaryApplies);
+        Assert.Equal(41, step.Branch.FallbackRow.MinimumRoll);
+        Assert.Equal(50, step.Branch.FallbackRow.MaximumRoll);
+        Assert.Equal(FumbleEffectKind.DropWeapon, step.Branch.FallbackRow.Kind);
+    }
+
+    [Fact]
+    public void Resolving_the_ally_fallback_consumes_no_extra_entropy_page_148()
+    {
+        // Only the single D100 for the row itself is drawn; "use result 41-50" is a lookup, not a reroll.
+        var entropy = new FixedEntropySource(76);
+
+        FumbleResolver.Resolve(FumbleTable.MeleeAttack, Ruleset, entropy, new StubAdjudicator(allyInRange: false));
+
+        Assert.Equal(1, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void The_weapon_hit_point_fallback_is_left_to_the_caller_not_an_adjudicator_page_148()
+    {
+        // Missile roll 66 -> "Do 1D6 damage to weapon's hit points (or use 81-85 if no hit points)".
+        var resolution = FumbleResolver.Resolve(
+            FumbleTable.MissileAttack, Ruleset, new FixedEntropySource(66), new DefaultFumbleAdjudicator());
+
+        var step = Assert.Single(resolution.Steps);
+        Assert.Equal(FumbleEffectKind.LoseWeaponHitPoints, step.Row.Kind);
+        Assert.NotNull(step.Branch);
+        Assert.Equal(FumbleFallbackCondition.WeaponHasNoHitPoints, step.Branch!.Condition);
+        // Null: this layer does not model weapon hit points, so the caller decides between branches.
+        Assert.Null(step.Branch.PrimaryApplies);
+        Assert.Equal(FumbleEffectKind.BreakWeapon, step.Branch.FallbackRow.Kind);
+    }
+
+    [Fact]
+    public void The_convenience_overload_selects_the_table_from_the_combat_context_page_148()
+    {
+        // A brawler (natural weapon) fumbling: roll 95 -> "Hit hard surface; normal damage to self".
+        var resolution = FumbleResolver.Resolve(
+            WeaponClass.Brawl, DefenseType.None, Ruleset, new FixedEntropySource(95), new DefaultFumbleAdjudicator());
+
+        Assert.Equal(FumbleTable.Natural, resolution.Table);
+        Assert.Equal(FumbleEffectKind.HitHardSurface, Assert.Single(resolution.Steps).Row.Kind);
+    }
+
+    [Fact]
+    public void The_same_seed_produces_the_identical_step_chain_invariant_5()
+    {
+        var first = FumbleResolver.Resolve(
+            FumbleTable.MissileAttack, Ruleset, new FixedEntropySource(99, 96, 66), new StubAdjudicator(true));
+        var second = FumbleResolver.Resolve(
+            FumbleTable.MissileAttack, Ruleset, new FixedEntropySource(99, 96, 66), new StubAdjudicator(true));
+
+        Assert.Equal(
+            first.Steps.Select(s => (s.Roll, s.Row.Kind)),
+            second.Steps.Select(s => (s.Roll, s.Row.Kind)));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #97

## Exact behavioral claim

When a combat roll fumbles, the engine resolves the consequence by rolling D100 on the correct
one of the **four printed fumble tables** (melee attack / melee parry / missile attack / natural),
selected from the existing combat context, and returns the named outcome — handling the 99/00
"roll again" rows cumulatively and the "hit ally or fall back" branches as structured outcomes for
a caller. This supplies the consequence table that the kernel (#10), attack/defense (#49), and spot
rules (#50) all reference but nothing resolved.

## Scope

Adds the four tables as data (`fumble-ruleset.json` + `NoirFumbleRuleset`), a `FumbleResolver`
(+ supporting records) in `Brp.Rules.Combat`, and the `IFumbleAdjudicator` port (`Brp.Core.Contests`)
for the one discretion point (ally-in-range). Reuses `SuccessLevel.Fumble` (kernel untouched) and the
existing `WeaponClass`/`DefenseType`/`LandedGrade` for table selection. No damage/effects applied —
all structured outcomes (the #50/#96 caller seam). ADR 0020 + tests.

## Rules conformance

Source: **Chapter 6: Combat, pp.148-149** of `BasicRoleplaying-ORC-Content-Document.pdf`. Verified
adversarially by `rules-conformance`, which confirmed **all 45 rows across the four tables exact**,
each table's D100 ranges tiling 1-100 with no gap/overlap, the 99/00 cumulative re-roll chains, and
the ally/fallback range references — all correct. The only defect it found was a page off-by-one
(the tables sit on pp.148-149, not pp.147-148); that citation was corrected everywhere and re-checked.
The two house readings (missile "no weapon HP" fallback as caller-decided; `DefenseType.None`→attack)
were judged sound.

| Table | Rows | Page |
|---|---|---|
| Melee Weapon Attack Fumbles | 12 | p.148 |
| Melee Weapon Parry Fumbles | 10 | p.148 |
| Missile Weapon Attack Fumbles | 12 | p.148 |
| Natural Weapon Attack and Parry Fumbles | 11 | p.149 |

All rows live in `fumble-ruleset.json`; the loader validates at load that rows tile [1,100] and every
fallback references a real row.

## Tests and evidence

- `dotnet build NoiRPG.slnx` → 0 warnings (warnings-as-errors), 0 errors.
- `dotnet test NoiRPG.slnx` → **2168 passed, 0 failed** (Core 1538, Rules 294, Data 285, Cli 51) — ~57 new. Re-run independently after the citation fix.
- `dotnet format NoiRPG.slnx --verify-no-changes` → exit 0.

## Decisions and tradeoffs

Table selection reuses the existing combat types rather than a parallel enum; 99/00 re-rolls accumulate
via injected entropy (same seed → identical chain); ally/self effects are returned, never applied
(no encounter model in this layer). The page citation was corrected to pp.148-149 after review; the
source extract's original pages were wrong (the book is authoritative, per invariant 1).

## Known limitations

Effects that reference other subsystems (drop/throw weapon, −MOV, weapon-HP loss, hit ally/self) are
structured outcomes for a clock/encounter-aware caller, not applied here — the same deferral as #50/#96.

## Agent provenance

Implemented by a build agent as `engine-dev` (Claude, via Claude Code) from a cited Ch 6 extract.
Verified by adversarial `rules-conformance` (FAILED first on a page off-by-one, remediated, re-checked
clean; 45/45 rows exact) and `scope-warden` (kernel untouched, data-driven, discretion via the port —
PASS). Orchestrated at the repository owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
