### PR TITLE
Correct ROADMAP/AGENTS to reflect the completeness audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,17 +92,19 @@ pipeline (`Modifiers/`), resistance and opposed rolls (`Contests/`), data-define
 characteristics with live-recomputing derived values (`Abilities/`), and the skill system
 (`Skills/`). `Brp.Rules` (Layers 3–4) adds characters — point-buy creation and tick-on-use
 experience — and combat: range bands, the combat round, the attack/defense matrix, gear,
-damage/wounds, and situational spot rules (`Combat/`). `Brp.Data` supplies the ruleset JSON.
-The solution has 2,013 tests, including printed tables reproduced cell by cell.
+damage/wounds, spot rules, injury, and fumble tables (`Combat/`). `Brp.Data` supplies the
+ruleset JSON. The solution has ~2,168 tests, including printed tables reproduced cell by cell.
 
 `tools/Brp.Cli` is the `brp` command line over that kernel — one command, `roll`, which
 resolves a check and prints its whole derivation. It has its own `AGENTS.md`.
 
-**What's left** — see [`ROADMAP.md`](ROADMAP.md) for the ordered plan. Layer 4 is nearly
-complete: injury/environmental spot rules (#96) and the fumble tables (#97) remain. Layer 5 —
-the noir game layer (cases, clue-routing, interrogation) — has not started (epic #98).
-`engine-implementation-plan.md` §3 has the layer map — the *structure* there is sound even
-though its formulas are not.
+**What's left — the engine is NOT complete.** A 2026-08-31 completeness audit found Layers 0–1
+and skill *data* correct, but a real backlog of in-scope, book-derivable gaps — several marked ON
+by the scope filter/ADRs yet never built. See [`ROADMAP.md`](ROADMAP.md) for the ordered backlog;
+the high-priority ones: skill category bonus not applied in the engine (#110), Major Wounds effect
+(#111), hit locations (#112), healing/recovery (#109). Layer 5 — the noir game (cases, clue-routing,
+interrogation, #98) — has not started and is design-led. `engine-implementation-plan.md` §3 has the
+layer map — the *structure* there is sound even though its formulas are not.
 
 ## Commands
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,50 +29,66 @@ NoiRPG is an **engine** (`Brp.*`, a faithful Basic Roleplaying rules engine) wit
 
 ---
 
-## You are here (2026-08-31)
+## You are here
 
-**Engine — Layers 0–3 complete, Layer 4 nearly complete.**
+**Engine — Layers 0–3 complete; Layer 4 scaffold complete but with an objective completeness backlog.**
 
 | Layer | What | Status |
 |---|---|---|
 | 0 | dice / entropy / resolution kernel / modifier pipeline | ✅ done |
 | 1 | abilities: characteristics-as-data, rolls, recomputing derived values | ✅ done |
-| 2 | skills: definitions, specialties, registry | ✅ done |
+| 2 | skills: definitions, specialties, registry (category-bonus *application* is a gap — #110) | ✅ data done |
 | 3 | characters: aggregate, point-buy, tick-on-use experience | ✅ done |
-| 4 | combat/gear/spot rules: range bands (#21), combat round (#47), attack/defense matrix (#49), gear, damage (#52), **situational spot rules (#50)** | 🚧 nearly done — see next |
-| 5 | the noir game: cases, clue-routing, interrogation | ⬜ not started |
+| 4 | combat: range bands (#21), combat round (#47), attack/defense matrix (#49), gear, damage (#52), spot rules (#50), injury (#96), fumble tables (#97) | 🚧 scaffold done; **completeness backlog open** — see below |
+| 5 | the noir game: cases, clue-routing, interrogation | ⬜ not started (design-led) |
+
+**A 2026-08-31 engine-completeness audit** (six parallel domain auditors vs. the book + `orc-scope-filter.md`)
+found Layers 0–1 and skill *data* complete and correct, but a real backlog of in-scope, book-derivable
+gaps — several of them mechanics the scope filter/ADRs marked **ON** that were never built. So the engine
+is **not** complete; "Layer 4 nearly done" was wrong. The backlog is objective (no playtesting) and tracked
+below.
 
 **Game — Phase 0/1 partially done on paper** (interrogation design, a paper case, the case
-schema, advancement sim), **Phase 2+ (game code) not started.**
+schema, advancement sim), **Phase 2+ (game code) not started, and design-led (needs a human, not agents).**
 
 ---
 
 ## What to build next (ordered)
 
-### 1. Finish Layer 4 (engine — small, well-specified, `ready` now)
-- **[#96] Injury/environmental spot rules** — falling, poison + antidotes, disease ladder. The
-  sibling of #50 (damage/drain, not roll modifiers). Builds on damage #52. `ready`.
-- **[#97] Fumble tables** — the printed fumble-results table as data + resolver; #10/#49/#50 all
-  reference it. `ready`.
+### 1. Complete the engine (objective, book-derivable — no playtesting; the audit's backlog)
 
-Either can be picked up cold by the **engine team** (engine-dev implements; rules-extractor,
-rules-conformance, scope-warden verify) — the same workflow that shipped #50.
+All of these are ideal team work (engine-dev implements; rules-extractor / rules-conformance /
+scope-warden verify — the workflow that shipped #50/#96/#97).
 
-### 2. Start Layer 5 — the game (the priority; `needs-design`)
+**🔴 High** — the four that stand between here and a whole injure→heal→advance engine:
+- **[#110] Skill category bonus** applied in the engine (ADR 0006 mandates it; today it lives only in a Python tool, so player-built characters silently lack it).
+- **[#111] Major Wounds effect** + a damage amount on `Wound` (only the *threshold* exists).
+- **[#112] Hit locations** — formally decided ON (#4), only string scaffolding exists.
+- **[#109] Healing / recovery** — First Aid, natural healing (flat 1D3/week), characteristic restoration.
+
+**🟡 Medium:**
+- **[#113]** special-damage *effects* (crushing stun, impaling lodged) + Fighting Defensively.
+- **[#114]** complimentary/augment skills (+1/5).
+- **[#115]** advancement: Research (self-study) + the default-+3 gain option.
+
+**🟢 Low-Med:**
+- **[#116]** Ch 8 world cluster — equipment quality, gear↔skill, wealth, item HP, vehicles, drugs.
+
+### 2. Then Layer 5 — the game (design-led; the owner drives, agents support)
 - **[#98] Epic: the noir game layer (`Noir.Rules` + `Noir.Scenario`)** — case schema→code, the
   Three Doors clue-routing engine, narrative-state junction budget, and the **interrogation
   minigame**.
 
 > **Read this before choosing.** `development-plan.md` is blunt: *"if interrogations are fun, the
-> game works; if not, nothing else rescues it."* The engine is the well-understood part and it is
-> nearly done; the game's three original systems (clue routing, narrative state, interrogation)
-> are the real risk and the actual product. **#98 is the highest-value frontier.** Its first
-> sub-issue is to confirm the Phase-1 paper gate (interrogation is fun on paper) before committing
-> to heavy code — the assets to judge that already exist in the repo.
+> game works; if not, nothing else rescues it."* The engine is the well-understood, objective part;
+> the game's three original systems (clue routing, narrative state, interrogation) are the real risk
+> and the actual product — and they are **design work that needs a human, not agents** (the #98
+> entry point #101 is a paper playtest only a person can judge). Its sub-issues are decomposed under
+> #98 (#101–#105).
 
-**Recommended sequence:** clear #96 and #97 to close out the engine (fast, low-risk, keeps the
-combat surface complete), then commit the team to **#98**, decomposing it into `blocked_by`
-sub-issues as `development-plan.md` Phase 1→2 describes.
+**Recommended sequence:** finish the engine backlog above (the team, in priority order — start with
+the 🔴 items), which is objective and closable cold; the Layer-5 game (#98) advances when the owner
+runs the Phase-1 playtest and drives the design.
 
 ---
 


### PR DESCRIPTION
## Linked Issue

Closes #118

## Exact behavioral claim

`ROADMAP.md` and `AGENTS.md` no longer overclaim engine completeness. They stated "Layer 4 nearly
complete" with only #96/#97 outstanding (both now merged); a completeness audit proved that wrong.
Both now show Layer 4's scaffold done with an objective completeness backlog, and point at the
prioritized gap issues — so an agent or the owner reading them gets the true state.

## Scope

Edits `ROADMAP.md` ("You are here" table + note, "What to build next" backlog, the Layer-5 blurb) and
`AGENTS.md` ("State of the code"). No code.

## Rules conformance

N/A — documentation only.

## Tests and evidence

- The backlog listed matches the filed issues #109–#116 (verified against `gh issue list`).
- Test count updated to ~2,168 (the current `dotnet test` total after #96/#97 merged).

## Decisions and tradeoffs

Kept the roadmap as an index that points at the live issues rather than restating each gap in full, so
it won't drift from the tracker. Marked the game track explicitly design-led / human-driven, per the
owner's boundary that agents don't do playtest-dependent design.

## Known limitations

The "You are here" snapshot is hand-maintained; it must be updated as backlog issues close.

## Agent provenance

Authored by Claude (Opus 4.8) via Claude Code, at the repository owner's direction, after a six-agent
completeness audit.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
