### PR TITLE
Add Major Wounds effect + wound damage amount

### DIFF
--- a/docs/decisions/0021-major-wounds.md
+++ b/docs/decisions/0021-major-wounds.md
@@ -1,0 +1,176 @@
+# 0021. Major Wounds: the wound damage amount, the shock/Luck/table effect, cumulative minors, and the fatal-wound rescue window
+
+## Status
+
+Accepted — 2026-08-31. Resolves #111 (Layer 4, the Major Wounds effect). Builds on the damage/HP
+path (ADR 0017) and the Layer 1 derived-characteristic recompute (ADR 0008), and follows the
+named-adjudication-port precedent of ADR 0018 (#50) and ADR 0019 (#96).
+
+## Context
+
+Ch 2 gave the major-wound *threshold* (`AbilitySet.MajorWoundLevel`, half of total hit points,
+rounded up — ADR 0008). Ch 6: Combat, "Damage & Healing" (pp.154-156) gives the *effect*, which was
+unbuilt. `Wound` stored only a description, so no mechanic could classify a wound by its size. This
+record covers the whole Ch 6 wound-classification surface: the wound damage amount, minor wounds,
+major wounds (shock, the immediate Luck roll, and the Major Wounds Table), and fatal wounds (the
+rescue window).
+
+Only Ch 6, "Damage & Healing" (pp.154-156) and the Ch 2 hit-point rules were consulted. Every value
+below was verified against the printed book text with `pdftotext -f/-l`, not the issue or
+`engine-implementation-plan.md` (AGENTS.md invariant 2). The printed page numbers were re-verified:
+Damage & Healing opens on p.154, Minor/Major Wounds and the first table rows are on p.155, and the
+table's remainder plus Fatal Wounds are on p.156.
+
+## Decision
+
+### The wound damage amount — sourced (prerequisite)
+
+`Wound` gains a `DamageAmount` (the hit points the wound dealt) alongside its description. Every site
+that creates a `Wound` — the three `DamageResolver` apply paths (weapon `DamageRoll`, the #96
+plain-int non-weapon overload, and knockout attacks) — now records the amount. The `Wound` is built
+inside `DamageResolver`'s private `Apply`, where the applied damage is known, so the amount and the
+hit-point subtraction can never diverge. This is the figure the major-wound trigger and First Aid's
+per-wound cap (#109) compare against — not the character's remaining hit points, but the size of the
+single blow (Ch 6, "Minor/Major Wounds", p.155).
+
+### The major-wound trigger — sourced
+
+A single wound is a major wound when its damage is **at least half the character's total hit points**
+(Ch 6, p.155: "equal to or more than half the character's total hit points"). `MajorWoundResolver`
+reuses the already-tested Layer 1 `AbilitySet.MajorWoundLevel` (Ch 2, p.14, rounded up) rather than
+re-deriving the fraction. `IsMajorWound(woundDamage, target)` is the guard; `Resolve` throws if
+called below the threshold.
+
+### Shock — sourced, structured outcome (no roll)
+
+On a major wound the character goes into shock (Ch 6, p.155): they "can fight on only for combat
+rounds equal to their current remaining hit points," then fall unconscious. A character at **2 or
+fewer hit points** after the wound "collapses immediately… and is unconscious for an hour." Shock is
+returned as a `MajorWoundShock` structured outcome (`FightingRounds` = remaining hit points, or
+`CollapsesImmediately`/`UnconsciousForAnHour` at ≤2 HP) for whichever piece runs a combat round to
+apply — this resolver holds no encounter model, the same caller seam as #50/#96/#97. The collapse
+threshold reuses `DamageRuleset.UnconsciousHitPointLevel` (2, Ch 2, p.13); the collapse duration
+(one hour) is data. Shock is read from remaining hit points **before** any Luck-roll characteristic
+drain, so a CON drain's later hit-point clamp cannot retroactively change the shock rounds.
+
+### Permanence — the immediate Luck roll — sourced
+
+On a major wound the character attempts a **Luck roll immediately** (Ch 6, p.155). Luck is POW's
+characteristic roll (the ability ruleset names POW's roll "Luck," Ch 2), so this is the standard
+POW×5 — a citation, not a house choice. **Success** → the wound "will heal cleanly and does not
+inflict any permanent loss of characteristic points": no table roll, no drain, `AbleToFight` true
+(shock still applies). **Failure** → the injury is permanent: roll the Major Wounds Table and
+subtract the indicated points. Lost points may later be regained (out of scope: #109); the drain is
+applied through `AbilitySet.Set` (via the #96 `InjuryDrain` helper, floored at the ruleset minimum)
+so hit points, damage modifier, and major-wound level recompute live (ADR 0008), never baked.
+
+### The Major Wounds Table — sourced, reproduced row-by-row
+
+The 1D100 table (Ch 6, pp.155-156) is data in `Brp.Data/major-wound-ruleset.json`, loaded into a
+banded `MajorWoundTable`/`MajorWoundRow` lookup mirroring `IllnessSeverityTable`/`DamageModifierBand`,
+and reproduced **row by row** in tests (`NoirMajorWoundRulesetTests`, `[Theory][MemberData]` + an
+exact-count `[Fact]` = 15 rows + a whole-1..100-coverage `[Fact]`). Each row carries only the
+mechanical result — the characteristic loss(es), whether MOV is reduced by that loss, whether the
+row's limb is unspecified, and the still-able-to-fight flag; the book's illustrative example causes
+are not modeled (the printed grid is normative). A printed **00 is represented as 100**, matching
+`IEntropySource.NextD100`.
+
+| 1D100 | Characteristic loss | MOV reduced by loss | Still fight? |
+|---|---|---|---|
+| 01–10 | 1D3 DEX | yes | yes |
+| 11–20 | 1D3 CHA | no | yes |
+| 21–30 | 1D3 STR | no | yes (weapon, not shield) |
+| 31–40 | 1D3 CON | yes | yes |
+| 41–50 | 1D3 INT | no | yes |
+| 51–60 | 1D6 DEX | yes | **no** |
+| 61–70 | 1D6 CHA | no | yes |
+| 71–80 | 1D6 STR | no | yes |
+| 81–90 | 1D6 CON | yes | **no** |
+| 91–92 | 1D6 CHA | no | yes |
+| 93–94 | 1D6 DEX | no | yes |
+| 95–96 | 1D6 DEX | no | yes (limb-side ruling) |
+| 97–98 | 1D6 DEX | no | **no** |
+| 99 | 1D3 each CHA, DEX, CON | no | **no** |
+| 00 | 1D4 each from four characteristics (GM choice) | no | **no** |
+
+- **MOV reduction is a structured outcome — sourced effect, house representation.** The rows that
+  say "reduce MOV by the same amount" (01-10, 31-40, 51-60, 81-90) reduce MOV by the rolled
+  characteristic loss. MOV is a flat value the engine does not derive from characteristics
+  (`AbilitySet.Movement`, Ch 2, p.15), so there is nothing to recompute; the reduction is reported as
+  `MajorWoundOutcome.MovementReduction` for the caller to apply. The rows the printed table does not
+  annotate with a MOV clause (including 99, whose printed text omits it) report no reduction — the
+  table beats the prose.
+
+### Cumulative minor wounds — sourced
+
+Several minor wounds the same day whose **total hit-point loss reaches the major-wound level** force a
+**Luck roll or fall unconscious** (Ch 6, p.155). This is explicitly **not** a major wound: the Major
+Wounds Table is **not** rolled ("do not roll on the Major Wounds Table for multiple minor wounds").
+Separately, minor wounds reducing the character to **1 or 2 hit points** knock them out for up to an
+hour. `ResolveCumulativeMinorWounds` takes the caller-tracked same-day total and reports both
+(`ReachedMajorWoundEquivalent`/`FallsUnconscious` and `KnockedOutForAnHour`), consuming a d100 only
+when the Luck roll is triggered.
+
+### Fatal-wound rescue window — sourced, reuses the death-timing seam
+
+A fatal wound is 0 or negative hit points (Ch 6, p.156): the character is knocked prone and cannot
+act. Death results **unless** medical attention brings hit points to 1 or more **in the round of the
+fatal wound or the round immediately after**. `DamageResolver.ResolvesToDeath` already models the
+death hit-point test (ADR 0017); `MajorWoundResolver.SurvivesFatalWound` **adds the window**
+(`FatalWoundRescueWindowRounds` = 1, the extra round after the wound round) and reuses
+`ResolvesToDeath` for the hit-point test rather than duplicating the threshold. Applying the aid
+itself, and holding the round clock, are caller seams (First Aid is #109).
+
+### Gamemaster-discretion points become named adjudication ports — following ADR 0018/0019
+
+Two calls the table hands to the gamemaster become first-class ports on a new
+`IMajorWoundAdjudicator` (in `Brp.Core.Contests`, mirroring `IInjuryAdjudicator`), with a
+`MajorWoundDecisionId` enum, canonical kebab-case ids (`MajorWoundDecisionIds.CanonicalId`), and a
+`DefaultMajorWoundAdjudicator`. A separate triad from #96's `IInjuryAdjudicator` (Ch 7) keeps this
+Ch 6 rule self-contained, exactly as #50 and #96 are separate triads. Return types are `Brp.Core`
+values (no `Brp.Rules` dependency; AGENTS.md invariant 6).
+
+| Decision id | What the book leaves open | Timing | Default | Source |
+|---|---|---|---|---|
+| `major-wound-limb-side` | Which side an unspecified limb wound (the 95-96 "left or right arm" row) falls on | narrative | left | **sourced** — Ch 6 p.155 |
+| `major-wound-characteristics` | Which four characteristics the 00 row's loss strikes | pre-drain | STR, CON, DEX, INT (fixed order) | **sourced** — Ch 6 p.156 |
+
+- **Limb side is narrative only — sourced port, house default.** The characteristic loss is identical
+  whichever side is chosen, so this decides flavor, not mechanics. The book's suggested resolution is
+  a 1D6 (1-3 left, 4-6 right); the neutral default returns left without rolling, and an adjudicator
+  wanting the book's randomization rolls it. The decision *port* is sourced to the passage that leaves
+  the call open; the *default answers* are a house choice of the most neutral reading (documented on
+  `DefaultMajorWoundAdjudicator`). Tests drive every port with a deterministic stub.
+
+### Incompatibility with hit locations — recorded for #112
+
+The book states plainly (Ch 6, p.156, "Damage and Hit Locations") that the optional hit-location
+system "is incompatible with Major Wounds and the two systems should not be used together," and the
+Major Wounds text repeats it ("major wounds are incompatible with hit locations without considerable
+gamemaster interpretation," p.155). This resolver applies loss to the single hit-point pool, as the
+book does when hit locations are not used. **#112 must reconcile the two rather than layering hit
+locations on top of Major Wounds** — recorded here so that issue inherits the constraint.
+
+## Out of scope (per `orc-scope-filter.md` and the issue)
+
+Not implemented here: hit locations (#112); First Aid / natural healing / Medicine, including
+regaining lost characteristic points and applying the in-window fatal-wound aid (#109);
+special-damage effects (#113); and the turn-economy application of shock / "unable to fight" /
+unconsciousness to a running encounter (a caller seam — the resolver returns structured outcomes and
+simulates no round). MOV is reported as a reduction amount, not mutated (the engine has no mutable
+MOV).
+
+## Consequences
+
+- `Brp.Rules.Characters.Wound` gains `DamageAmount`; the three `DamageResolver` apply paths record
+  it (built inside the private `Apply`).
+- `Brp.Rules.Combat` gains `MajorWoundResolver` (with `MajorWoundOutcome`, `MajorWoundShock`,
+  `MajorWoundCharacteristicResult`, `CumulativeMinorWoundOutcome`), the `MajorWoundRuleset` /
+  `MajorWoundTable` / `MajorWoundRow` / `MajorWoundLoss` / `MajorWoundGamemasterChoice` data model.
+  `Brp.Data` gains `major-wound-ruleset.json` and `NoirMajorWoundRuleset`. `Brp.Core.Contests` gains
+  `IMajorWoundAdjudicator`, `MajorWoundDecisionId`/`MajorWoundDecisionIds`,
+  `DefaultMajorWoundAdjudicator`, and the `BodySide` enum.
+- The shock turn-economy, the MOV reduction, the First-Aid application of the fatal-wound rescue and
+  characteristic-point regain, and the hit-location reconciliation all need caller/round/time state
+  this resolver does not hold. As in ADR 0018/0019, the resolver computes the harm and names the open
+  calls; whichever piece orchestrates a running encounter wires the ports and the timing.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -43,3 +43,4 @@ supersedes it — the original is not edited or deleted.
 | [0018](0018-spot-rules.md) | Situational combat spot rules: five modifier producers and named adjudication ports | Accepted |
 | [0019](0019-injury-spot-rules.md) | Injury/effect spot rules: falling, poison, and disease through the damage and characteristic-drain paths | Accepted |
 | [0020](0020-fumble-tables.md) | Combat fumble tables: the four D100 consequence tables, a context-selecting resolver, and the ally/reroll seams | Accepted |
+| [0021](0021-major-wounds.md) | Major Wounds: the wound damage amount, the shock/Luck/table effect, cumulative minors, and the fatal-wound rescue window | Accepted |

--- a/src/Brp.Core/Contests/IMajorWoundAdjudicator.cs
+++ b/src/Brp.Core/Contests/IMajorWoundAdjudicator.cs
@@ -1,0 +1,135 @@
+using Brp.Core.Abilities;
+
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// The named gamemaster-adjudication points the Ch 6: Combat, "Major Wounds" (pp.155-156) rule
+/// leaves open. The Major Wounds sibling of <see cref="IInjuryAdjudicator"/> (the Ch 7 injury spot
+/// rules, #96) and <see cref="ISpotRuleAdjudicator"/> (the situational-modifier spot rules, #50):
+/// each member is a call the Major Wounds Table hands to the gamemaster -- which side a limb wound
+/// falls on when the roll "does not specify," and which characteristics the 00 row's "gamemaster's
+/// discretion" removes -- rather than resolving mechanically. Naming them as first-class ids keeps
+/// <c>MajorWoundResolver</c> from silently hardcoding these calls. The canonical kebab-case id for
+/// each is given in its summary and returned by <see cref="MajorWoundDecisionIds.CanonicalId"/>.
+/// See <c>docs/decisions/0021-major-wounds.md</c>.
+/// </summary>
+public enum MajorWoundDecisionId
+{
+    /// <summary>
+    /// Canonical id <c>major-wound-limb-side</c>. Ch 6, "Major Wounds" (p.155): "When a limb is not
+    /// specified, roll 1D6: a result of 1-3 is left, 4-6 is right." Which side an unspecified limb
+    /// wound (the "left or right arm" of the 95-96 row) falls on is a gamemaster call. Purely
+    /// narrative: the characteristic loss is identical whichever side is chosen, so this decides only
+    /// flavor, not mechanics. The book's suggested resolution method is a 1D6 (1-3 left, 4-6 right) --
+    /// an adjudicator wanting that randomization rolls it; the neutral default does not.
+    /// </summary>
+    LimbSide,
+
+    /// <summary>
+    /// Canonical id <c>major-wound-characteristics</c>. Ch 6, Major Wounds Table 00 row (p.156):
+    /// "Remove 1D4 points each from four characteristics (gamemaster's discretion)." Which four
+    /// characteristics the worst result strikes is a gamemaster call; the dice (1D4 each) and the
+    /// count (four) are fixed by the table. A pre-drain ruling: it selects the characteristics the
+    /// row's loss is applied to via <see cref="AbilitySet.Set"/> so derived values recompute.
+    /// </summary>
+    Characteristics,
+}
+
+/// <summary>Canonical kebab-case ids for the <see cref="MajorWoundDecisionId"/> ports.</summary>
+public static class MajorWoundDecisionIds
+{
+    /// <summary>
+    /// The canonical kebab-case id for <paramref name="decisionId"/> -- the stable string a GM tool,
+    /// authored policy, or log keys on (e.g. <c>major-wound-limb-side</c>), matching the ids named in
+    /// Issue #111 and ADR 0021.
+    /// </summary>
+    public static string CanonicalId(MajorWoundDecisionId decisionId) => decisionId switch
+    {
+        MajorWoundDecisionId.LimbSide => "major-wound-limb-side",
+        MajorWoundDecisionId.Characteristics => "major-wound-characteristics",
+        _ => throw new ArgumentOutOfRangeException(nameof(decisionId), decisionId, "Unknown major wound decision id."),
+    };
+}
+
+/// <summary>
+/// Which side an unspecified limb wound falls on, for the <see cref="MajorWoundDecisionId.LimbSide"/>
+/// ruling (Ch 6, p.155). Narrative only -- the characteristic loss does not depend on the side.
+/// </summary>
+public enum BodySide
+{
+    /// <summary>The left side -- the book's 1D6 result of 1-3 (p.155).</summary>
+    Left,
+
+    /// <summary>The right side -- the book's 1D6 result of 4-6 (p.155).</summary>
+    Right,
+}
+
+/// <summary>
+/// A gamemaster-discretion port for Ch 6: Combat, "Major Wounds" (pp.155-156), modeled -- like
+/// <see cref="IInjuryAdjudicator"/> and <see cref="ISpotRuleAdjudicator"/> -- as a first-class
+/// interface rather than a set of silent hardcoded choices. Each method answers one
+/// <see cref="MajorWoundDecisionId"/> the table leaves open. A GM tool can prompt a human; an
+/// unattended simulation can supply an authored policy; tests supply a deterministic stub. The
+/// return types are ordinary <c>Brp.Core</c> values so this port stays within <c>Brp.Core</c> and
+/// does not invert the layer dependency (AGENTS.md invariant 6). See
+/// <c>docs/decisions/0021-major-wounds.md</c>.
+/// </summary>
+public interface IMajorWoundAdjudicator
+{
+    /// <summary>
+    /// Decides which side an unspecified limb wound falls on
+    /// (<see cref="MajorWoundDecisionId.LimbSide"/>). Narrative only.
+    /// </summary>
+    BodySide DecideLimbSide();
+
+    /// <summary>
+    /// Decides which characteristics the 00 row's "gamemaster's discretion" loss strikes
+    /// (<see cref="MajorWoundDecisionId.Characteristics"/>). Pre-drain.
+    /// </summary>
+    /// <param name="count">
+    /// How many distinct characteristics the row removes points from (four, per the 00 row). The
+    /// returned list must contain exactly this many distinct characteristics.
+    /// </param>
+    IReadOnlyList<CharacteristicId> DecideCharacteristics(int count);
+}
+
+/// <summary>
+/// The documented default policy for every <see cref="MajorWoundDecisionId"/>: the most
+/// minimal-assumption answer to a call the table leaves open, mirroring
+/// <see cref="DefaultInjuryAdjudicator"/>. A table with a house rule or a human gamemaster should
+/// supply its own <see cref="IMajorWoundAdjudicator"/> instead.
+/// </summary>
+public sealed class DefaultMajorWoundAdjudicator : IMajorWoundAdjudicator
+{
+    // The 00 row strikes four distinct characteristics; the neutral default draws from the physical
+    // and mental characteristics a living being always has, in a fixed order, so a defaulted result
+    // is deterministic and never repeats a characteristic. A table wanting a different or random
+    // selection supplies its own adjudicator.
+    private static readonly IReadOnlyList<CharacteristicId> DefaultCharacteristicOrder =
+    [
+        new("STR"), new("CON"), new("DEX"), new("INT"), new("POW"), new("CHA"), new("SIZ"),
+    ];
+
+    /// <summary>
+    /// Defaults to <see cref="BodySide.Left"/> -- the low half of the book's 1D6 (1-3), a neutral
+    /// fixed answer that adds no randomness the caller did not ask for.
+    /// </summary>
+    public BodySide DecideLimbSide() => BodySide.Left;
+
+    /// <summary>
+    /// Defaults to the first <paramref name="count"/> characteristics of a fixed order (STR, CON,
+    /// DEX, INT, POW, CHA, SIZ) -- distinct and deterministic, adding no setting-specific choice the
+    /// book left to the gamemaster.
+    /// </summary>
+    public IReadOnlyList<CharacteristicId> DecideCharacteristics(int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
+        if (count > DefaultCharacteristicOrder.Count)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(count), count, "The default adjudicator knows fewer distinct characteristics than requested.");
+        }
+
+        return DefaultCharacteristicOrder.Take(count).ToList();
+    }
+}

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -25,6 +25,7 @@
     <EmbeddedResource Include="damage-ruleset.json" />
     <EmbeddedResource Include="spot-rule-ruleset.json" />
     <EmbeddedResource Include="injury-ruleset.json" />
+    <EmbeddedResource Include="major-wound-ruleset.json" />
     <EmbeddedResource Include="fumble-ruleset.json" />
   </ItemGroup>
 

--- a/src/Brp.Data/NoirMajorWoundRuleset.cs
+++ b/src/Brp.Data/NoirMajorWoundRuleset.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using Brp.Core.Abilities;
+using Brp.Core.Dice;
+using Brp.Rules.Combat;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's Major Wounds values from embedded JSON. Sourced: Ch 6: Combat, "Major Wounds" and
+/// "Fatal Wounds" (pp.155-156) -- the Major Wounds Table, the shock collapse duration, and the
+/// fatal-wound rescue window. Recorded in <c>docs/decisions/0021-major-wounds.md</c>.
+/// </summary>
+public static class NoirMajorWoundRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable major wound ruleset from the shipped data.</summary>
+    public static MajorWoundRuleset Load()
+    {
+        var assembly = typeof(NoirMajorWoundRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.major-wound-ruleset.json")
+            ?? throw new InvalidOperationException("The major wound ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<MajorWoundRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The major wound ruleset data is empty.");
+
+        var rows = data.MajorWoundTable.Select(BuildRow);
+        return new MajorWoundRuleset(
+            table: new MajorWoundTable(rows),
+            fatalWoundRescueWindowRounds: data.FatalWoundRescueWindowRounds,
+            collapseUnconsciousHours: data.CollapseUnconsciousHours);
+    }
+
+    private static MajorWoundRow BuildRow(MajorWoundRowData row)
+    {
+        var losses = row.Losses.Select(loss => new MajorWoundLoss(
+            new CharacteristicId(loss.Characteristic), DiceExpression.Parse(loss.DiceFormula))).ToList();
+
+        var choice = row.GamemasterChoice is null
+            ? null
+            : new MajorWoundGamemasterChoice(row.GamemasterChoice.Count, DiceExpression.Parse(row.GamemasterChoice.DiceFormula));
+
+        return new MajorWoundRow(
+            row.Minimum, row.Maximum, losses, choice, row.ReducesMovement, row.RequiresLimbSide, row.AbleToFight);
+    }
+
+    private sealed class MajorWoundRulesetData
+    {
+        public required int FatalWoundRescueWindowRounds { get; init; }
+
+        public required int CollapseUnconsciousHours { get; init; }
+
+        public required IReadOnlyList<MajorWoundRowData> MajorWoundTable { get; init; }
+    }
+
+    private sealed class MajorWoundRowData
+    {
+        public required int Minimum { get; init; }
+
+        public required int Maximum { get; init; }
+
+        public required IReadOnlyList<MajorWoundLossData> Losses { get; init; }
+
+        public MajorWoundGamemasterChoiceData? GamemasterChoice { get; init; }
+
+        public required bool ReducesMovement { get; init; }
+
+        public required bool RequiresLimbSide { get; init; }
+
+        public required bool AbleToFight { get; init; }
+    }
+
+    private sealed class MajorWoundLossData
+    {
+        public required string Characteristic { get; init; }
+
+        public required string DiceFormula { get; init; }
+    }
+
+    private sealed class MajorWoundGamemasterChoiceData
+    {
+        public required int Count { get; init; }
+
+        public required string DiceFormula { get; init; }
+    }
+}

--- a/src/Brp.Data/major-wound-ruleset.json
+++ b/src/Brp.Data/major-wound-ruleset.json
@@ -1,0 +1,28 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 6: Combat",
+    "notes": "Major Wounds and Fatal Wounds (pp.155-156): the immediate shock, the Luck roll deciding permanence, the Major Wounds Table (1D100 -> characteristic loss / MOV / fight flag), the cumulative-minor-wound Luck-or-unconscious rule, and the fatal-wound rescue window. The book notes (p.156) that Major Wounds are incompatible with the optional hit location system (#112). See docs/decisions/0021-major-wounds.md."
+  },
+  "fatalWoundRescueWindowRounds": 1,
+  "collapseUnconsciousHours": 1,
+  "fatalWoundSource": "Ch 6, Fatal Wounds (p.156): survives if medical attention 'in the round they received the fatal wound or the round immediately after' brings hit points to 1 or more (window offset 1). Collapse: Ch 6, Major Wounds (p.155): '2 or fewer hit points after suffering a major wound collapses immediately... unconscious for an hour.'",
+  "majorWoundTableSource": "Ch 6, Major Wounds Table (pp.155-156), transcribed row by row. Each row's mechanical result (dice loss, MOV effect, still-able-to-fight flag) is data; the illustrative example causes are not modeled. A printed 00 is represented as 100.",
+  "majorWoundTable": [
+    { "minimum": 1, "maximum": 10, "losses": [{ "characteristic": "DEX", "diceFormula": "1D3" }], "reducesMovement": true, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 11, "maximum": 20, "losses": [{ "characteristic": "CHA", "diceFormula": "1D3" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 21, "maximum": 30, "losses": [{ "characteristic": "STR", "diceFormula": "1D3" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 31, "maximum": 40, "losses": [{ "characteristic": "CON", "diceFormula": "1D3" }], "reducesMovement": true, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 41, "maximum": 50, "losses": [{ "characteristic": "INT", "diceFormula": "1D3" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 51, "maximum": 60, "losses": [{ "characteristic": "DEX", "diceFormula": "1D6" }], "reducesMovement": true, "requiresLimbSide": false, "ableToFight": false },
+    { "minimum": 61, "maximum": 70, "losses": [{ "characteristic": "CHA", "diceFormula": "1D6" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 71, "maximum": 80, "losses": [{ "characteristic": "STR", "diceFormula": "1D6" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 81, "maximum": 90, "losses": [{ "characteristic": "CON", "diceFormula": "1D6" }], "reducesMovement": true, "requiresLimbSide": false, "ableToFight": false },
+    { "minimum": 91, "maximum": 92, "losses": [{ "characteristic": "CHA", "diceFormula": "1D6" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 93, "maximum": 94, "losses": [{ "characteristic": "DEX", "diceFormula": "1D6" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": true },
+    { "minimum": 95, "maximum": 96, "losses": [{ "characteristic": "DEX", "diceFormula": "1D6" }], "reducesMovement": false, "requiresLimbSide": true, "ableToFight": true },
+    { "minimum": 97, "maximum": 98, "losses": [{ "characteristic": "DEX", "diceFormula": "1D6" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": false },
+    { "minimum": 99, "maximum": 99, "losses": [{ "characteristic": "CHA", "diceFormula": "1D3" }, { "characteristic": "DEX", "diceFormula": "1D3" }, { "characteristic": "CON", "diceFormula": "1D3" }], "reducesMovement": false, "requiresLimbSide": false, "ableToFight": false },
+    { "minimum": 100, "maximum": 100, "losses": [], "gamemasterChoice": { "count": 4, "diceFormula": "1D4" }, "reducesMovement": false, "requiresLimbSide": false, "ableToFight": false }
+  ]
+}

--- a/src/Brp.Rules/Characters/Wound.cs
+++ b/src/Brp.Rules/Characters/Wound.cs
@@ -1,10 +1,18 @@
 namespace Brp.Rules.Characters;
 
 /// <summary>
-/// A single entry in a character's wound list. Structure only: this issue (#40) builds the
-/// container a <see cref="Character"/> carries, not the mechanics that populate or resolve it
-/// (First Aid per wound, Major Wounds, hit locations) -- those are Layer 4 (#21).
-/// Deliberately minimal so nothing here presumes a mechanic that has not been decided yet.
+/// A single entry in a character's wound list: a free-text note of what happened plus the hit
+/// points that wound dealt. The damage amount, added in #111, is the prerequisite for the two
+/// mechanics that classify a wound by its size: the Major Wounds trigger (Ch 6: Combat, "Major
+/// Wounds", p.155 -- a single wound of half the character's total hit points or more) and First
+/// Aid's per-wound healing cap (#109). <see cref="WoundTrack"/> lists wounds individually, so a
+/// caller can compare any one wound, or a same-day sum of them, against
+/// <see cref="Core.Abilities.AbilitySet.MajorWoundLevel"/>.
 /// </summary>
 /// <param name="Description">A free-text note of what happened, for the game layer to render.</param>
-public sealed record Wound(string Description);
+/// <param name="DamageAmount">
+/// The hit points this wound dealt (non-negative). The figure the Major Wounds trigger and the
+/// First Aid cap compare against -- not the character's remaining hit points, but the size of this
+/// single blow.
+/// </param>
+public sealed record Wound(string Description, int DamageAmount);

--- a/src/Brp.Rules/Combat/DamageResolver.cs
+++ b/src/Brp.Rules/Combat/DamageResolver.cs
@@ -215,7 +215,7 @@ public static class DamageResolver
             return new DamageApplicationResult(0, target.CurrentHitPoints, ClassifyHitPoints(target.CurrentHitPoints, ruleset), Wound: null);
         }
 
-        return Apply(target, wounds, damage.DamageDealt, ruleset, new Wound(woundDescription));
+        return Apply(target, wounds, damage.DamageDealt, ruleset, woundDescription);
     }
 
     /// <summary>
@@ -249,7 +249,7 @@ public static class DamageResolver
         ArgumentOutOfRangeException.ThrowIfNegative(hitPointDamage);
         ArgumentException.ThrowIfNullOrWhiteSpace(woundDescription);
 
-        return Apply(target, wounds, hitPointDamage, ruleset, new Wound(woundDescription));
+        return Apply(target, wounds, hitPointDamage, ruleset, woundDescription);
     }
 
     /// <summary>
@@ -343,7 +343,7 @@ public static class DamageResolver
             return new DamageApplicationResult(0, target.CurrentHitPoints, ClassifyHitPoints(target.CurrentHitPoints, ruleset), Wound: null);
         }
 
-        return Apply(target, wounds, knockout.DamageDealt, ruleset, new Wound(woundDescription));
+        return Apply(target, wounds, knockout.DamageDealt, ruleset, woundDescription);
     }
 
     /// <summary>
@@ -365,8 +365,12 @@ public static class DamageResolver
     }
 
     private static DamageApplicationResult Apply(
-        AbilitySet target, WoundTrack wounds, int damageDealt, DamageRuleset ruleset, Wound wound)
+        AbilitySet target, WoundTrack wounds, int damageDealt, DamageRuleset ruleset, string woundDescription)
     {
+        // The wound records the hit points this blow dealt (#111) -- the figure the Major Wounds
+        // trigger (Ch 6, p.155) and the First Aid cap (#109) compare against -- so it is built here,
+        // where the applied damage is known, rather than by the caller.
+        var wound = new Wound(woundDescription, damageDealt);
         var resultingHitPoints = target.CurrentHitPoints - damageDealt;
         target.SetCurrentHitPoints(resultingHitPoints);
         wounds.Add(wound);

--- a/src/Brp.Rules/Combat/MajorWoundResolver.cs
+++ b/src/Brp.Rules/Combat/MajorWoundResolver.cs
@@ -1,0 +1,322 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+using Brp.Core.Randomness;
+using Brp.Core.Resolution;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Resolves Ch 6: Combat, "Major Wounds" and "Fatal Wounds" (pp.155-156): the shock a major wound
+/// imposes, the immediate Luck roll that decides whether the injury is permanent, the Major Wounds
+/// Table drain on a failed Luck roll, the cumulative-minor-wound Luck-or-unconscious rule, and the
+/// fatal-wound rescue window. A major wound is a single wound of at least half the character's total
+/// hit points -- reusing the already-tested Layer 1 figure
+/// <see cref="AbilitySet.MajorWoundLevel"/> (Ch 2, p.14) rather than re-deriving the fraction.
+/// Characteristic loss is applied through <see cref="AbilitySet.Set"/> (via <see cref="InjuryDrain"/>)
+/// so derived values (hit points, damage modifier, major-wound level) recompute live (Ch 2, p.13;
+/// ADR 0008), the same path as the #96 injury spot rules. See <c>docs/decisions/0021-major-wounds.md</c>.
+/// <para>
+/// <strong>Structured outcomes, not a simulated round.</strong> "Shock" (fight on for rounds equal
+/// to remaining hit points, then unconscious), the collapse-for-an-hour at 2 or fewer hit points,
+/// the still-able-to-fight flag, and the MOV reduction are returned as data for whichever piece runs
+/// a combat round to apply -- this resolver holds no encounter model, the same caller seam as
+/// #50/#96/#97. The book's own caveat that Major Wounds are "incompatible with hit locations" (p.156)
+/// is recorded in ADR 0021 for #112 to reconcile; this resolver applies loss to the single hit-point
+/// pool, as the book does when hit locations are not used.
+/// </para>
+/// </summary>
+public static class MajorWoundResolver
+{
+    private static readonly CharacteristicId Power = new("POW");
+
+    /// <summary>
+    /// Whether a single wound of <paramref name="woundDamage"/> hit points is a major wound for
+    /// <paramref name="target"/> -- Ch 6, "Major Wounds" (p.155): "equal to or more than half the
+    /// character's total hit points." Reuses <see cref="AbilitySet.MajorWoundLevel"/> (Ch 2, p.14).
+    /// </summary>
+    public static bool IsMajorWound(int woundDamage, AbilitySet target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentOutOfRangeException.ThrowIfNegative(woundDamage);
+        return woundDamage >= target.MajorWoundLevel;
+    }
+
+    /// <summary>
+    /// Resolves a single major wound for <paramref name="target"/>, whose hit points already reflect
+    /// the wound (the caller applies the damage first, e.g. through
+    /// <see cref="DamageResolver.ApplyDamage(AbilitySet, Characters.WoundTrack, int, DamageRuleset, string)"/>).
+    /// Computes shock from the current remaining hit points, then attempts a Luck roll (POW×5): on a
+    /// success the wound heals cleanly with no permanent loss; on a failure it rolls the Major Wounds
+    /// Table and applies the indicated characteristic drain, recomputing derived values.
+    /// <para>
+    /// Consumes entropy in a fixed order: the Luck roll (one d100); then, only on a failed Luck roll,
+    /// the Major Wounds Table roll (one d100) and the row's loss dice in order. Shock consumes none.
+    /// </para>
+    /// </summary>
+    /// <param name="target">The wounded character (hit points already reduced by the wound).</param>
+    /// <param name="woundDamage">The hit points that single wound dealt.</param>
+    /// <param name="damageRuleset">Supplies the shock collapse (unconscious) threshold (Ch 2, p.13).</param>
+    /// <param name="majorWoundRuleset">The Major Wounds Table and its values.</param>
+    /// <param name="adjudicator">Resolves the table's gamemaster-discretion points (limb side, the 00 row's four characteristics).</param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    public static MajorWoundOutcome Resolve(
+        AbilitySet target,
+        int woundDamage,
+        DamageRuleset damageRuleset,
+        MajorWoundRuleset majorWoundRuleset,
+        IMajorWoundAdjudicator adjudicator,
+        IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(damageRuleset);
+        ArgumentNullException.ThrowIfNull(majorWoundRuleset);
+        ArgumentNullException.ThrowIfNull(adjudicator);
+        ArgumentNullException.ThrowIfNull(entropy);
+        if (!IsMajorWound(woundDamage, target))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(woundDamage),
+                woundDamage,
+                $"A wound of {woundDamage} is not a major wound (major wound level {target.MajorWoundLevel}); " +
+                "check IsMajorWound before calling Resolve.");
+        }
+
+        // Shock is immediate and read from remaining hit points before any Luck-roll characteristic
+        // drain (which could clamp hit points): Ch 6, p.155.
+        var shock = ResolveShock(target, damageRuleset);
+
+        // The immediate Luck roll (POW's "Luck" characteristic roll, POW×5): Ch 6, p.155.
+        var luckRoll = RollLuck(target, entropy);
+        if (luckRoll.Succeeded)
+        {
+            // "the major wound will heal cleanly and does not inflict any permanent loss": no table
+            // roll, no drain. Shock still applies. Able to fight (no lasting restriction).
+            return new MajorWoundOutcome(
+                shock, luckRoll, PermanentInjury: false, TableRoll: null, Row: null,
+                CharacteristicLosses: [], MovementReduction: 0, AbleToFight: true, LimbSide: null);
+        }
+
+        // Failed Luck roll: the injury is permanent. Roll the Major Wounds Table and apply it.
+        var tableRoll = entropy.NextD100();
+        var row = majorWoundRuleset.Table.ForRoll(tableRoll);
+        var (losses, movementReduction) = ApplyRow(target, row, adjudicator, entropy);
+        var limbSide = row.RequiresLimbSide ? adjudicator.DecideLimbSide() : (BodySide?)null;
+
+        return new MajorWoundOutcome(
+            shock, luckRoll, PermanentInjury: true, tableRoll, row,
+            losses, movementReduction, row.AbleToFight, limbSide);
+    }
+
+    /// <summary>
+    /// Resolves the cumulative-minor-wound rule (Ch 6, "Minor Wounds", p.155). Two independent
+    /// checks a caller tracking a character's same-day wounds can make:
+    /// <list type="bullet">
+    /// <item><description>
+    /// If <paramref name="totalMinorHitPointsLostToday"/> reaches the major-wound level, the character
+    /// "must make a successful Luck roll or they will fall unconscious." This is <em>not</em> a major
+    /// wound: the Major Wounds Table is never rolled ("do not roll on the Major Wounds Table for
+    /// multiple minor wounds").
+    /// </description></item>
+    /// <item><description>
+    /// If the character's current hit points are 1 or 2, "this knocks them out for up to an hour" --
+    /// read from <paramref name="target"/>'s current hit points, no roll.
+    /// </description></item>
+    /// </list>
+    /// Consumes one d100 only when the Luck roll is triggered.
+    /// </summary>
+    /// <param name="target">The character (current hit points read for the knockout check).</param>
+    /// <param name="totalMinorHitPointsLostToday">The running sum of the day's minor-wound hit-point losses.</param>
+    /// <param name="damageRuleset">Supplies the 1-or-2-hit-point knockout threshold (Ch 2, p.13).</param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    public static CumulativeMinorWoundOutcome ResolveCumulativeMinorWounds(
+        AbilitySet target,
+        int totalMinorHitPointsLostToday,
+        DamageRuleset damageRuleset,
+        IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(damageRuleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+        ArgumentOutOfRangeException.ThrowIfNegative(totalMinorHitPointsLostToday);
+
+        // "reduce them to 1 or 2 hit points" -> knocked out up to an hour. Above the dead level, at or
+        // below the unconscious level (2).
+        var knockedOut = target.CurrentHitPoints > damageRuleset.DeadHitPointLevel
+            && target.CurrentHitPoints <= damageRuleset.UnconsciousHitPointLevel;
+
+        var reachedEquivalent = totalMinorHitPointsLostToday >= target.MajorWoundLevel;
+        if (!reachedEquivalent)
+        {
+            return new CumulativeMinorWoundOutcome(
+                ReachedMajorWoundEquivalent: false, LuckRoll: null, FallsUnconscious: false, knockedOut);
+        }
+
+        var luckRoll = RollLuck(target, entropy);
+        return new CumulativeMinorWoundOutcome(
+            ReachedMajorWoundEquivalent: true, luckRoll, FallsUnconscious: !luckRoll.Succeeded, knockedOut);
+    }
+
+    /// <summary>
+    /// Whether a fatally wounded character survives, per Ch 6, "Fatal Wounds" (p.156): a fatal wound
+    /// (0 or negative hit points) "may be averted with immediate successful medical assistance" if aid
+    /// in "the round they received the fatal wound or the round immediately after" brings hit points to
+    /// 1 or more. Reuses <see cref="DamageResolver.ResolvesToDeath"/> for the hit-point test rather
+    /// than duplicating the death threshold; this method adds the <em>window</em> the death timing
+    /// leaves open (<see cref="MajorWoundRuleset.FatalWoundRescueWindowRounds"/>).
+    /// </summary>
+    /// <param name="hitPointsAfterAid">The character's hit points after the in-window medical aid.</param>
+    /// <param name="roundsSinceFatalWound">
+    /// Rounds elapsed since the fatal wound: 0 is the wound round, 1 the round immediately after.
+    /// </param>
+    /// <param name="majorWoundRuleset">Supplies the rescue-window length.</param>
+    /// <param name="damageRuleset">Supplies the dead hit-point level (Ch 2, p.13; Ch 6, p.156).</param>
+    public static bool SurvivesFatalWound(
+        int hitPointsAfterAid,
+        int roundsSinceFatalWound,
+        MajorWoundRuleset majorWoundRuleset,
+        DamageRuleset damageRuleset)
+    {
+        ArgumentNullException.ThrowIfNull(majorWoundRuleset);
+        ArgumentNullException.ThrowIfNull(damageRuleset);
+        ArgumentOutOfRangeException.ThrowIfNegative(roundsSinceFatalWound);
+
+        // In the window and restored above the dead level -> survives. Otherwise death resolves.
+        return roundsSinceFatalWound <= majorWoundRuleset.FatalWoundRescueWindowRounds
+            && !DamageResolver.ResolvesToDeath(hitPointsAfterAid, damageRuleset);
+    }
+
+    private static MajorWoundShock ResolveShock(AbilitySet target, DamageRuleset damageRuleset)
+    {
+        var remaining = target.CurrentHitPoints;
+
+        // "A character possessing 2 or fewer hit points after suffering a major wound collapses
+        // immediately... and is unconscious for an hour." (Ch 6, p.155.) The unconscious threshold is
+        // the same 2-or-less the hit-point rules use (Ch 2, p.13).
+        if (remaining <= damageRuleset.UnconsciousHitPointLevel)
+        {
+            return new MajorWoundShock(FightingRounds: 0, CollapsesImmediately: true, UnconsciousForAnHour: true);
+        }
+
+        // "your character can fight on only for combat rounds equal to their current remaining hit
+        // points" -> then unconscious. (Ch 6, p.155.)
+        return new MajorWoundShock(FightingRounds: remaining, CollapsesImmediately: false, UnconsciousForAnHour: false);
+    }
+
+    private static RollOutcome RollLuck(AbilitySet target, IEntropySource entropy)
+    {
+        // POW's characteristic roll is named "Luck" in the ability ruleset (Ch 2); the immediate roll
+        // a major wound calls for is the standard POW×5. (Ch 6, p.155.)
+        var luck = target.Ruleset.StandardCharacteristicRoll(Power);
+        return AbilityResolver.Resolve(target, luck, [], entropy)
+            ?? throw new InvalidOperationException("The major wound Luck roll was unexpectedly gated.");
+    }
+
+    private static (IReadOnlyList<MajorWoundCharacteristicResult> Losses, int MovementReduction) ApplyRow(
+        AbilitySet target, MajorWoundRow row, IMajorWoundAdjudicator adjudicator, IEntropySource entropy)
+    {
+        var results = new List<MajorWoundCharacteristicResult>();
+        var firstLossPoints = 0;
+
+        // Fixed losses (one for most rows, three for the 99 row), rolled and applied in row order.
+        foreach (var loss in row.Losses)
+        {
+            var points = loss.Dice.Roll(entropy).Total;
+            if (results.Count == 0)
+            {
+                firstLossPoints = points;
+            }
+
+            var resulting = InjuryDrain.Apply(target, loss.Characteristic, points);
+            results.Add(new MajorWoundCharacteristicResult(loss.Characteristic, points, resulting));
+        }
+
+        // The 00 row: 1D4 each from four gamemaster-chosen characteristics.
+        if (row.GamemasterChoice is { } choice)
+        {
+            var chosen = adjudicator.DecideCharacteristics(choice.Count);
+            if (chosen.Count != choice.Count)
+            {
+                throw new InvalidOperationException(
+                    $"The adjudicator returned {chosen.Count} characteristics for a row requiring {choice.Count}.");
+            }
+
+            foreach (var characteristic in chosen)
+            {
+                var points = choice.Dice.Roll(entropy).Total;
+                var resulting = InjuryDrain.Apply(target, characteristic, points);
+                results.Add(new MajorWoundCharacteristicResult(characteristic, points, resulting));
+            }
+        }
+
+        // MOV is reduced "by the same amount" as the (single) characteristic loss on the rows that say
+        // so; every ReducesMovement row has exactly one fixed loss. Reported as a structured outcome:
+        // MOV is a flat value the engine does not derive from characteristics (AbilitySet.Movement).
+        var movementReduction = row.ReducesMovement ? firstLossPoints : 0;
+        return (results, movementReduction);
+    }
+}
+
+/// <summary>
+/// The immediate shock a major wound imposes (Ch 6, "Major Wounds", p.155). A structured outcome for
+/// whichever piece runs a combat round -- this resolver simulates no round.
+/// </summary>
+/// <param name="FightingRounds">
+/// Combat rounds the character can fight on before falling unconscious -- equal to their remaining
+/// hit points, or 0 when they collapse immediately.
+/// </param>
+/// <param name="CollapsesImmediately">Whether the character collapses at once (2 or fewer hit points).</param>
+/// <param name="UnconsciousForAnHour">Whether the collapse renders them unconscious for an hour.</param>
+public sealed record MajorWoundShock(int FightingRounds, bool CollapsesImmediately, bool UnconsciousForAnHour);
+
+/// <summary>One applied characteristic loss from the Major Wounds Table (Ch 6, pp.155-156).</summary>
+/// <param name="Characteristic">The characteristic lowered.</param>
+/// <param name="PointsLost">The points rolled and removed.</param>
+/// <param name="ResultingValue">The characteristic's value after the drain (floored at its minimum).</param>
+public sealed record MajorWoundCharacteristicResult(CharacteristicId Characteristic, int PointsLost, int ResultingValue);
+
+/// <summary>
+/// The result of resolving a single major wound (Ch 6, "Major Wounds", pp.155-156): the shock, the
+/// Luck roll, and -- only when the Luck roll fails -- the permanent Major Wounds Table result.
+/// </summary>
+/// <param name="Shock">The immediate shock effect (always present).</param>
+/// <param name="LuckRoll">The immediate Luck (POW×5) roll.</param>
+/// <param name="PermanentInjury">Whether the Luck roll failed, making the injury permanent.</param>
+/// <param name="TableRoll">The 1D100 Major Wounds Table result, or <see langword="null"/> on a successful Luck roll.</param>
+/// <param name="Row">The table row rolled, or <see langword="null"/> on a successful Luck roll.</param>
+/// <param name="CharacteristicLosses">The characteristic drains applied (empty on a successful Luck roll).</param>
+/// <param name="MovementReduction">
+/// MOV points to reduce (0 unless the row reduces MOV by the characteristic loss). A structured
+/// outcome the caller applies -- MOV is a flat value the engine does not derive.
+/// </param>
+/// <param name="AbleToFight">
+/// Whether the character can still fight after any permanent injury (always <see langword="true"/> on
+/// a successful Luck roll). Independent of shock, which may still cut the fight short.
+/// </param>
+/// <param name="LimbSide">
+/// The gamemaster-ruled side for a row whose limb is unspecified (the 95-96 row), or
+/// <see langword="null"/> otherwise. Narrative only.
+/// </param>
+public sealed record MajorWoundOutcome(
+    MajorWoundShock Shock,
+    RollOutcome LuckRoll,
+    bool PermanentInjury,
+    int? TableRoll,
+    MajorWoundRow? Row,
+    IReadOnlyList<MajorWoundCharacteristicResult> CharacteristicLosses,
+    int MovementReduction,
+    bool AbleToFight,
+    BodySide? LimbSide);
+
+/// <summary>
+/// The result of the cumulative-minor-wound rule (Ch 6, "Minor Wounds", p.155). Never a major wound:
+/// the Major Wounds Table is not rolled.
+/// </summary>
+/// <param name="ReachedMajorWoundEquivalent">Whether the day's minor wounds summed to the major-wound level.</param>
+/// <param name="LuckRoll">The Luck roll made when the equivalent is reached, or <see langword="null"/> otherwise.</param>
+/// <param name="FallsUnconscious">Whether the character falls unconscious (the equivalent was reached and the Luck roll failed).</param>
+/// <param name="KnockedOutForAnHour">Whether the character is knocked out for up to an hour (reduced to 1 or 2 hit points).</param>
+public sealed record CumulativeMinorWoundOutcome(
+    bool ReachedMajorWoundEquivalent,
+    RollOutcome? LuckRoll,
+    bool FallsUnconscious,
+    bool KnockedOutForAnHour);

--- a/src/Brp.Rules/Combat/MajorWoundRow.cs
+++ b/src/Brp.Rules/Combat/MajorWoundRow.cs
@@ -1,0 +1,64 @@
+using Brp.Core.Abilities;
+using Brp.Core.Dice;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// One fixed characteristic loss on a <see cref="MajorWoundRow"/> (Ch 6: Combat, "Major Wounds
+/// Table", pp.155-156): a characteristic and the dice removed from it on a failed Luck roll.
+/// </summary>
+/// <param name="Characteristic">The characteristic the row lowers.</param>
+/// <param name="Dice">The points removed (e.g. 1D3, 1D6), rolled when the loss is applied.</param>
+public sealed record MajorWoundLoss(CharacteristicId Characteristic, DiceExpression Dice);
+
+/// <summary>
+/// The gamemaster-chosen loss on the 00 row of the Major Wounds Table (Ch 6, p.156: "Remove 1D4
+/// points each from four characteristics (gamemaster's discretion)"). The count and dice are fixed
+/// by the table; which characteristics are struck is a
+/// <see cref="Core.Contests.MajorWoundDecisionId.Characteristics"/> ruling.
+/// </summary>
+/// <param name="Count">How many distinct characteristics are struck (four, per the 00 row).</param>
+/// <param name="Dice">The points removed from each chosen characteristic (1D4).</param>
+public sealed record MajorWoundGamemasterChoice(int Count, DiceExpression Dice);
+
+/// <summary>
+/// One row of Ch 6: Combat, "Major Wounds Table" (pp.155-156), banded by the 1D100 result. Carries
+/// the row's mechanical effect only -- the characteristic loss(es), whether MOV is reduced by that
+/// loss, whether the row's limb is unspecified (needing a side ruling), and the still-able-to-fight
+/// flag. The book's illustrative flavor text (multiple example causes per row) is not modeled: the
+/// dice, MOV effect, and fight flag are what the printed grid makes normative. Mirrors
+/// <see cref="IllnessSeverityBand"/> / <see cref="Core.Abilities.DamageModifierBand"/>.
+/// </summary>
+/// <param name="Minimum">The lowest 1D100 result this row covers (a printed 00 is 100).</param>
+/// <param name="Maximum">The highest 1D100 result this row covers.</param>
+/// <param name="Losses">
+/// The fixed characteristic losses this row applies (one for most rows, three for the 99 row, none
+/// for the 00 row, which uses <paramref name="GamemasterChoice"/> instead).
+/// </param>
+/// <param name="GamemasterChoice">
+/// The gamemaster-chosen loss for the 00 row, or <see langword="null"/> for every other row.
+/// </param>
+/// <param name="ReducesMovement">
+/// Whether the row reduces MOV "by the same amount" as the characteristic loss (Ch 6, pp.155-156:
+/// the DEX-loss rows 01-10 and 51-60, and the CON-loss rows 31-40 and 81-90). MOV is a flat value
+/// the engine does not derive from characteristics (<see cref="AbilitySet.Movement"/>), so the
+/// reduction is reported as a structured outcome for the caller to apply, not baked here.
+/// </param>
+/// <param name="RequiresLimbSide">
+/// Whether the row's wound is to an unspecified limb needing a
+/// <see cref="Core.Contests.MajorWoundDecisionId.LimbSide"/> ruling (the "left or right arm" 95-96
+/// row). Narrative only -- the loss does not depend on the side.
+/// </param>
+/// <param name="AbleToFight">Whether the character can still fight after this permanent injury.</param>
+public sealed record MajorWoundRow(
+    int Minimum,
+    int Maximum,
+    IReadOnlyList<MajorWoundLoss> Losses,
+    MajorWoundGamemasterChoice? GamemasterChoice,
+    bool ReducesMovement,
+    bool RequiresLimbSide,
+    bool AbleToFight)
+{
+    /// <summary>Whether this row covers the given 1D100 result.</summary>
+    public bool Contains(int roll) => roll >= Minimum && roll <= Maximum;
+}

--- a/src/Brp.Rules/Combat/MajorWoundRuleset.cs
+++ b/src/Brp.Rules/Combat/MajorWoundRuleset.cs
@@ -1,0 +1,49 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The data-defined values for Ch 6: Combat, "Major Wounds" and "Fatal Wounds" (pp.155-156) that
+/// <see cref="MajorWoundResolver"/> reads (AGENTS.md invariant 7: rules values are data, not
+/// constants). Loaded from <c>major-wound-ruleset.json</c> by
+/// <c>Brp.Data.NoirMajorWoundRuleset.Load()</c>. See <c>docs/decisions/0021-major-wounds.md</c>.
+/// <para>
+/// Deliberately does <em>not</em> carry the major-wound <em>threshold</em> (half of total hit
+/// points): that figure already exists, tested, at Layer 1 as
+/// <see cref="Core.Abilities.AbilitySet.MajorWoundLevel"/> (Ch 2, p.14, rounded up), which the
+/// resolver reuses directly. Nor does it carry the shock collapse threshold or the death threshold:
+/// those are the unconscious/dead hit-point levels on <see cref="DamageRuleset"/> (Ch 2, p.13),
+/// reused so a single source defines each.
+/// </para>
+/// </summary>
+public sealed class MajorWoundRuleset
+{
+    /// <summary>Creates a major wound ruleset from data-defined values.</summary>
+    public MajorWoundRuleset(MajorWoundTable table, int fatalWoundRescueWindowRounds, int collapseUnconsciousHours)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentOutOfRangeException.ThrowIfNegative(fatalWoundRescueWindowRounds);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(collapseUnconsciousHours);
+
+        Table = table;
+        FatalWoundRescueWindowRounds = fatalWoundRescueWindowRounds;
+        CollapseUnconsciousHours = collapseUnconsciousHours;
+    }
+
+    /// <summary>Ch 6, "Major Wounds Table" (pp.155-156): the 1D100 characteristic-loss table.</summary>
+    public MajorWoundTable Table { get; }
+
+    /// <summary>
+    /// Ch 6, "Fatal Wounds" (p.156): a fatally wounded character survives if medical attention brings
+    /// their hit points to 1 or more "in the round they received the fatal wound or the round
+    /// immediately after." This is the extra-round offset after the wound round (1 = the round
+    /// immediately after), so the rescue window is rounds 0 through this value inclusive. See
+    /// <see cref="MajorWoundResolver.SurvivesFatalWound"/>.
+    /// </summary>
+    public int FatalWoundRescueWindowRounds { get; }
+
+    /// <summary>
+    /// Ch 6, "Major Wounds" (p.155): a character at 2 or fewer hit points after a major wound
+    /// "collapses immediately from shock and loss of blood and is unconscious for an hour." The
+    /// duration of that collapse, in hours.
+    /// </summary>
+    public int CollapseUnconsciousHours { get; }
+}

--- a/src/Brp.Rules/Combat/MajorWoundTable.cs
+++ b/src/Brp.Rules/Combat/MajorWoundTable.cs
@@ -1,0 +1,38 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Data-backed lookup for Ch 6: Combat, "Major Wounds Table" (pp.155-156). The fifteen printed rows
+/// (01-10 through 00) are represented as ruleset bands, cross-indexed by a 1D100 result (a printed
+/// 00 read as 100, per <see cref="Core.Randomness.IEntropySource.NextD100"/>). Mirrors
+/// <see cref="IllnessSeverityTable"/> / <see cref="Core.Abilities.DamageModifierTable"/>.
+/// </summary>
+public sealed class MajorWoundTable
+{
+    private readonly List<MajorWoundRow> _rows;
+
+    /// <summary>Creates a table from ordered ruleset rows.</summary>
+    public MajorWoundTable(IEnumerable<MajorWoundRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        _rows = rows.ToList();
+        if (_rows.Count == 0)
+        {
+            throw new ArgumentException("Major wound table must contain at least one row.", nameof(rows));
+        }
+    }
+
+    /// <summary>Every printed row, in load order.</summary>
+    public IReadOnlyList<MajorWoundRow> Rows => _rows;
+
+    /// <summary>Returns the row that covers the given 1D100 result (a printed 00 read as 100).</summary>
+    public MajorWoundRow ForRoll(int d100)
+    {
+        if (d100 is < 1 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(d100), d100, "A 1D100 result is in [1, 100].");
+        }
+
+        return _rows.SingleOrDefault(row => row.Contains(d100))
+            ?? throw new ArgumentOutOfRangeException(nameof(d100), d100, "No major wound row covers this result.");
+    }
+}

--- a/tests/Brp.Core.Tests/Contests/MajorWoundAdjudicatorTests.cs
+++ b/tests/Brp.Core.Tests/Contests/MajorWoundAdjudicatorTests.cs
@@ -1,0 +1,75 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+
+namespace Brp.Core.Tests.Contests;
+
+/// <summary>
+/// Covers the named gamemaster-discretion ports for Ch 6: Combat, "Major Wounds" (pp.155-156): the
+/// canonical decision ids, the documented neutral defaults of
+/// <see cref="DefaultMajorWoundAdjudicator"/>, and that a deterministic stub can drive every port for
+/// replayable tests. See <c>docs/decisions/0021-major-wounds.md</c>.
+/// </summary>
+public class MajorWoundAdjudicatorTests
+{
+    [Theory]
+    [InlineData(MajorWoundDecisionId.LimbSide, "major-wound-limb-side")]
+    [InlineData(MajorWoundDecisionId.Characteristics, "major-wound-characteristics")]
+    public void Every_decision_id_has_its_canonical_kebab_case_string(MajorWoundDecisionId id, string expected)
+    {
+        Assert.Equal(expected, MajorWoundDecisionIds.CanonicalId(id));
+    }
+
+    [Fact]
+    public void The_named_discretion_points_are_exactly_those_issue_111_calls_out()
+    {
+        Assert.Equal(2, Enum.GetValues<MajorWoundDecisionId>().Length);
+    }
+
+    [Fact]
+    public void The_default_adjudicator_returns_the_documented_minimal_assumption_answers()
+    {
+        var adjudicator = new DefaultMajorWoundAdjudicator();
+
+        // Ch 6, p.155: the book's 1D6 low half (1-3) is left; the neutral default is left, without rolling.
+        Assert.Equal(BodySide.Left, adjudicator.DecideLimbSide());
+
+        // The 00 row's four distinct characteristics, deterministic and non-repeating.
+        var chosen = adjudicator.DecideCharacteristics(4);
+        Assert.Equal(4, chosen.Count);
+        Assert.Equal(4, chosen.Distinct().Count());
+        Assert.Equal(
+            new[] { new CharacteristicId("STR"), new CharacteristicId("CON"), new CharacteristicId("DEX"), new CharacteristicId("INT") },
+            chosen);
+    }
+
+    [Fact]
+    public void The_default_adjudicator_rejects_a_non_positive_or_oversized_characteristic_count()
+    {
+        var adjudicator = new DefaultMajorWoundAdjudicator();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => adjudicator.DecideCharacteristics(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => adjudicator.DecideCharacteristics(99));
+    }
+
+    [Fact]
+    public void A_deterministic_stub_drives_every_port_with_scripted_answers()
+    {
+        IMajorWoundAdjudicator adjudicator = new ScriptedMajorWoundAdjudicator(
+            limbSide: BodySide.Right,
+            characteristics: [new CharacteristicId("POW"), new CharacteristicId("CHA"), new CharacteristicId("SIZ"), new CharacteristicId("STR")]);
+
+        Assert.Equal(BodySide.Right, adjudicator.DecideLimbSide());
+        Assert.Equal(
+            new[] { new CharacteristicId("POW"), new CharacteristicId("CHA"), new CharacteristicId("SIZ"), new CharacteristicId("STR") },
+            adjudicator.DecideCharacteristics(4));
+    }
+
+    /// <summary>A deterministic test double returning pre-scripted rulings for each port.</summary>
+    private sealed class ScriptedMajorWoundAdjudicator(BodySide limbSide, IReadOnlyList<CharacteristicId> characteristics)
+        : IMajorWoundAdjudicator
+    {
+        public BodySide DecideLimbSide() => limbSide;
+
+        public IReadOnlyList<CharacteristicId> DecideCharacteristics(int count) => characteristics;
+    }
+}

--- a/tests/Brp.Data.Tests/NoirMajorWoundRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirMajorWoundRulesetTests.cs
@@ -1,0 +1,111 @@
+using Brp.Core.Abilities;
+using Brp.Rules.Combat;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped major wound data loads and reproduces every row of Ch 6: Combat, "Major
+/// Wounds Table" (pp.155-156) -- row by row rather than sampled, per AGENTS.md's "table-backed
+/// rule" convention -- and carries the Fatal Wounds / collapse values. See
+/// <c>docs/decisions/0021-major-wounds.md</c>.
+/// </summary>
+public class NoirMajorWoundRulesetTests
+{
+    private static readonly MajorWoundRuleset Ruleset = NoirMajorWoundRuleset.Load();
+
+    // (minimum, maximum, "CHR:dice;CHR:dice" fixed losses, gmChoiceCount, gmChoiceDice,
+    //  reducesMovement, requiresLimbSide, ableToFight) -- one case per printed row, Ch 6 pp.155-156.
+    public static IEnumerable<object?[]> PrintedRows()
+    {
+        yield return new object?[] { 1, 10, "DEX:1D3", 0, null, true, false, true };
+        yield return new object?[] { 11, 20, "CHA:1D3", 0, null, false, false, true };
+        yield return new object?[] { 21, 30, "STR:1D3", 0, null, false, false, true };
+        yield return new object?[] { 31, 40, "CON:1D3", 0, null, true, false, true };
+        yield return new object?[] { 41, 50, "INT:1D3", 0, null, false, false, true };
+        yield return new object?[] { 51, 60, "DEX:1D6", 0, null, true, false, false };
+        yield return new object?[] { 61, 70, "CHA:1D6", 0, null, false, false, true };
+        yield return new object?[] { 71, 80, "STR:1D6", 0, null, false, false, true };
+        yield return new object?[] { 81, 90, "CON:1D6", 0, null, true, false, false };
+        yield return new object?[] { 91, 92, "CHA:1D6", 0, null, false, false, true };
+        yield return new object?[] { 93, 94, "DEX:1D6", 0, null, false, false, true };
+        yield return new object?[] { 95, 96, "DEX:1D6", 0, null, false, true, true };
+        yield return new object?[] { 97, 98, "DEX:1D6", 0, null, false, false, false };
+        yield return new object?[] { 99, 99, "CHA:1D3;DEX:1D3;CON:1D3", 0, null, false, false, false };
+        yield return new object?[] { 100, 100, "", 4, "1D4", false, false, false };
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintedRows))]
+    public void Every_printed_table_row_matches_the_book(
+        int minimum,
+        int maximum,
+        string fixedLosses,
+        int gamemasterChoiceCount,
+        string? gamemasterChoiceDice,
+        bool reducesMovement,
+        bool requiresLimbSide,
+        bool ableToFight)
+    {
+        // A row is looked up by its own range so a mis-ordered or mis-ranged transcription surfaces here.
+        var row = Ruleset.Table.ForRoll(minimum);
+        Assert.Same(row, Ruleset.Table.ForRoll(maximum));
+
+        Assert.Equal(minimum, row.Minimum);
+        Assert.Equal(maximum, row.Maximum);
+        Assert.Equal(reducesMovement, row.ReducesMovement);
+        Assert.Equal(requiresLimbSide, row.RequiresLimbSide);
+        Assert.Equal(ableToFight, row.AbleToFight);
+
+        var expectedLosses = fixedLosses.Length == 0
+            ? []
+            : fixedLosses.Split(';').Select(pair =>
+            {
+                var parts = pair.Split(':');
+                return (Characteristic: parts[0], Dice: parts[1]);
+            }).ToArray();
+
+        Assert.Equal(expectedLosses.Length, row.Losses.Count);
+        for (var i = 0; i < expectedLosses.Length; i++)
+        {
+            Assert.Equal(new CharacteristicId(expectedLosses[i].Characteristic), row.Losses[i].Characteristic);
+            Assert.Equal(expectedLosses[i].Dice, row.Losses[i].Dice.Notation);
+        }
+
+        if (gamemasterChoiceCount == 0)
+        {
+            Assert.Null(row.GamemasterChoice);
+        }
+        else
+        {
+            Assert.NotNull(row.GamemasterChoice);
+            Assert.Equal(gamemasterChoiceCount, row.GamemasterChoice!.Count);
+            Assert.Equal(gamemasterChoiceDice, row.GamemasterChoice.Dice.Notation);
+        }
+    }
+
+    [Fact]
+    public void The_shipped_table_has_exactly_the_fifteen_printed_rows()
+    {
+        Assert.Equal(15, Ruleset.Table.Rows.Count);
+    }
+
+    [Fact]
+    public void The_table_covers_every_1D100_result_exactly_once()
+    {
+        // No gaps and no overlaps across the whole 1-100 range (a printed 00 read as 100).
+        for (var roll = 1; roll <= 100; roll++)
+        {
+            Assert.Single(Ruleset.Table.Rows, row => row.Contains(roll));
+        }
+    }
+
+    [Fact]
+    public void The_fatal_wound_and_collapse_values_match_the_book()
+    {
+        // Ch 6, Fatal Wounds (p.156): the wound round or the round immediately after -> window offset 1.
+        Assert.Equal(1, Ruleset.FatalWoundRescueWindowRounds);
+
+        // Ch 6, Major Wounds (p.155): collapse "unconscious for an hour".
+        Assert.Equal(1, Ruleset.CollapseUnconsciousHours);
+    }
+}

--- a/tests/Brp.Rules.Tests/Characters/CharacterTests.cs
+++ b/tests/Brp.Rules.Tests/Characters/CharacterTests.cs
@@ -70,7 +70,7 @@ public class CharacterTests
         Assert.Empty(character.Wounds.Wounds);
         Assert.Empty(character.Equipment.Items);
 
-        character.Wounds.Add(new Wound("grazed by a bullet"));
+        character.Wounds.Add(new Wound("grazed by a bullet", DamageAmount: 1));
         character.Equipment.Add(new EquipmentItem("revolver"));
 
         Assert.Single(character.Wounds.Wounds);

--- a/tests/Brp.Rules.Tests/Combat/DamageResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/DamageResolverTests.cs
@@ -271,6 +271,8 @@ public class DamageResolverTests
         Assert.Equal(target.CurrentHitPoints, result.ResultingHitPoints);
         Assert.Single(wounds.Wounds);
         Assert.Equal("Struck by a test weapon.", wounds.Wounds[0].Description);
+        // #111: the wound records the hit points it dealt (the Major Wounds trigger / First Aid cap figure).
+        Assert.Equal(4, wounds.Wounds[0].DamageAmount);
         Assert.Same(wounds.Wounds[0], result.Wound);
     }
 

--- a/tests/Brp.Rules.Tests/Combat/MajorWoundResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/MajorWoundResolverTests.cs
@@ -1,0 +1,305 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+using Brp.Data;
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Ch 6: Combat, "Major Wounds" and "Fatal Wounds" (pp.155-156). The major-wound trigger at the
+/// half-hit-point threshold, the shock effect (fight on for rounds equal to remaining hit points;
+/// collapse for an hour at 2 or fewer), the immediate Luck roll (success = clean heal, failure =
+/// permanent drain routed through the characteristic-recompute path), the cumulative-minor-wound
+/// Luck-or-unconscious rule, and the fatal-wound rescue window. See
+/// <c>docs/decisions/0021-major-wounds.md</c>.
+/// </summary>
+public class MajorWoundResolverTests
+{
+    private static readonly MajorWoundRuleset MajorWounds = NoirMajorWoundRuleset.Load();
+    private static readonly DamageRuleset Damage = NoirDamageRuleset.Load();
+
+    private static AbilitySet MakeTarget(int con = 12, int siz = 12, int pow = 12)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 12);
+        values[new CharacteristicId("CON")] = con;
+        values[new CharacteristicId("SIZ")] = siz;
+        values[new CharacteristicId("POW")] = pow;
+        return new AbilitySet(ruleset, values);
+    }
+
+    private sealed class StubAdjudicator(BodySide limbSide, IReadOnlyList<CharacteristicId> characteristics)
+        : IMajorWoundAdjudicator
+    {
+        public BodySide DecideLimbSide() => limbSide;
+
+        public IReadOnlyList<CharacteristicId> DecideCharacteristics(int count) => characteristics;
+    }
+
+    private static StubAdjudicator Adjudicator(
+        BodySide limbSide = BodySide.Left, IReadOnlyList<CharacteristicId>? characteristics = null) =>
+        new(limbSide, characteristics ?? []);
+
+    [Fact]
+    public void A_wound_of_half_total_hit_points_or_more_is_a_major_wound_page_155()
+    {
+        // CON 12 + SIZ 12 => 12 max HP, major wound level = 6 (half, rounded up).
+        var target = MakeTarget();
+        Assert.Equal(6, target.MajorWoundLevel);
+
+        Assert.True(MajorWoundResolver.IsMajorWound(6, target));
+        Assert.True(MajorWoundResolver.IsMajorWound(7, target));
+        Assert.False(MajorWoundResolver.IsMajorWound(5, target));
+    }
+
+    [Fact]
+    public void Resolve_rejects_a_wound_below_the_major_wound_threshold_page_155()
+    {
+        var target = MakeTarget();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => MajorWoundResolver.Resolve(
+            target, woundDamage: 5, Damage, MajorWounds, Adjudicator(), new FixedEntropySource(10)));
+    }
+
+    [Fact]
+    public void Shock_lets_the_character_fight_on_for_rounds_equal_to_remaining_hit_points_page_155()
+    {
+        // 8 hit points remaining after a major wound => fights on for 8 rounds, then unconscious.
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(8);
+
+        // POW 12 => Luck 60; roll 10 succeeds (no permanent loss), so only the Luck roll is drawn.
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds, Adjudicator(), new FixedEntropySource(10));
+
+        Assert.Equal(8, outcome.Shock.FightingRounds);
+        Assert.False(outcome.Shock.CollapsesImmediately);
+        Assert.False(outcome.Shock.UnconsciousForAnHour);
+    }
+
+    [Fact]
+    public void Two_or_fewer_hit_points_after_a_major_wound_collapses_for_an_hour_page_155()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(2);
+
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds, Adjudicator(), new FixedEntropySource(10));
+
+        Assert.True(outcome.Shock.CollapsesImmediately);
+        Assert.True(outcome.Shock.UnconsciousForAnHour);
+        Assert.Equal(0, outcome.Shock.FightingRounds);
+    }
+
+    [Fact]
+    public void A_successful_luck_roll_heals_cleanly_with_no_permanent_loss_page_155()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(6);
+        var conBefore = target.ValueOf(new CharacteristicId("CON"));
+
+        // POW 12 => Luck 60; roll 10 succeeds. No table roll, no drain.
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds, Adjudicator(), new FixedEntropySource(10));
+
+        Assert.True(outcome.LuckRoll.Succeeded);
+        Assert.False(outcome.PermanentInjury);
+        Assert.Null(outcome.TableRoll);
+        Assert.Null(outcome.Row);
+        Assert.Empty(outcome.CharacteristicLosses);
+        Assert.True(outcome.AbleToFight);
+        Assert.Equal(0, outcome.MovementReduction);
+        Assert.Equal(conBefore, target.ValueOf(new CharacteristicId("CON")));
+    }
+
+    [Fact]
+    public void A_failed_luck_roll_applies_the_table_drain_and_recomputes_derived_values_page_155()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(6);
+        Assert.Equal(12, target.MaximumHitPoints);
+
+        // POW 12 => Luck 60; roll 90 fails. Table roll 35 => 31-40 row (lose 1D3 CON, reduce MOV by
+        // the same). Loss die 3 => CON 12 -> 9. Entropy order: Luck, table, loss die.
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds, Adjudicator(), new FixedEntropySource(90, 35, 3));
+
+        Assert.False(outcome.LuckRoll.Succeeded);
+        Assert.True(outcome.PermanentInjury);
+        Assert.Equal(35, outcome.TableRoll);
+        Assert.Single(outcome.CharacteristicLosses);
+
+        var loss = outcome.CharacteristicLosses[0];
+        Assert.Equal(new CharacteristicId("CON"), loss.Characteristic);
+        Assert.Equal(3, loss.PointsLost);
+        Assert.Equal(9, loss.ResultingValue);
+        Assert.Equal(9, target.ValueOf(new CharacteristicId("CON")));
+
+        // Live recompute: CON 9 + SIZ 12 => 11 max HP (was 12) -- not baked.
+        Assert.Equal(11, target.MaximumHitPoints);
+
+        // 31-40 reduces MOV by the CON loss (3).
+        Assert.Equal(3, outcome.MovementReduction);
+        Assert.True(outcome.AbleToFight);
+    }
+
+    [Fact]
+    public void A_no_fight_row_reports_the_character_cannot_fight_page_156()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(6);
+
+        // Luck 60 fails on 90; table roll 55 => 51-60 row (lose 1D6 DEX, unable to fight). Loss die 4.
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds, Adjudicator(), new FixedEntropySource(90, 55, 4));
+
+        Assert.False(outcome.AbleToFight);
+        Assert.Equal(new CharacteristicId("DEX"), outcome.CharacteristicLosses[0].Characteristic);
+        Assert.Equal(4, outcome.MovementReduction);
+    }
+
+    [Fact]
+    public void A_limb_row_reports_the_gamemaster_ruled_side_page_155()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(6);
+
+        // Table roll 95 => 95-96 row ("left or right arm"), needs a limb-side ruling. Loss die 4.
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds,
+            Adjudicator(limbSide: BodySide.Right), new FixedEntropySource(90, 95, 4));
+
+        Assert.Equal(BodySide.Right, outcome.LimbSide);
+    }
+
+    [Fact]
+    public void A_non_limb_row_reports_no_side_page_155()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(6);
+
+        // Table roll 35 (31-40) is not a limb row.
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds,
+            Adjudicator(limbSide: BodySide.Right), new FixedEntropySource(90, 35, 3));
+
+        Assert.Null(outcome.LimbSide);
+    }
+
+    [Fact]
+    public void The_99_row_drains_three_characteristics_page_156()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(6);
+
+        // Table roll 99 => lose 1D3 each from CHA, DEX, CON. Loss dice 2, 2, 2 in row order.
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds, Adjudicator(), new FixedEntropySource(90, 99, 2, 2, 2));
+
+        Assert.Equal(3, outcome.CharacteristicLosses.Count);
+        Assert.Equal(
+            new[] { new CharacteristicId("CHA"), new CharacteristicId("DEX"), new CharacteristicId("CON") },
+            outcome.CharacteristicLosses.Select(l => l.Characteristic));
+        Assert.False(outcome.AbleToFight);
+    }
+
+    [Fact]
+    public void The_00_row_removes_1D4_each_from_four_gamemaster_chosen_characteristics_page_156()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(6);
+        var chosen = new[]
+        {
+            new CharacteristicId("STR"), new CharacteristicId("CON"),
+            new CharacteristicId("DEX"), new CharacteristicId("INT"),
+        };
+
+        // Table roll 100 (printed 00) => remove 1D4 each from four GM-chosen characteristics.
+        // Entropy: Luck 90, table 100, then four 1D4 loss dice (2 each).
+        var outcome = MajorWoundResolver.Resolve(
+            target, woundDamage: 6, Damage, MajorWounds,
+            Adjudicator(characteristics: chosen), new FixedEntropySource(90, 100, 2, 2, 2, 2));
+
+        Assert.Equal(4, outcome.CharacteristicLosses.Count);
+        Assert.Equal(chosen, outcome.CharacteristicLosses.Select(l => l.Characteristic));
+        Assert.All(outcome.CharacteristicLosses, l => Assert.Equal(2, l.PointsLost));
+        Assert.Equal(10, target.ValueOf(new CharacteristicId("STR")));
+        Assert.False(outcome.AbleToFight);
+    }
+
+    [Fact]
+    public void Cumulative_minor_wounds_reaching_a_major_equivalent_force_a_luck_roll_page_155()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(6);
+
+        // Total minor loss 6 == major wound level; Luck 60 fails on 90 => falls unconscious.
+        var failed = MajorWoundResolver.ResolveCumulativeMinorWounds(
+            target, totalMinorHitPointsLostToday: 6, Damage, new FixedEntropySource(90));
+
+        Assert.True(failed.ReachedMajorWoundEquivalent);
+        Assert.NotNull(failed.LuckRoll);
+        Assert.True(failed.FallsUnconscious);
+
+        // A successful Luck roll stays conscious. (Do NOT roll on the Major Wounds Table for this.)
+        var target2 = MakeTarget();
+        target2.SetCurrentHitPoints(6);
+        var passed = MajorWoundResolver.ResolveCumulativeMinorWounds(
+            target2, totalMinorHitPointsLostToday: 6, Damage, new FixedEntropySource(10));
+
+        Assert.True(passed.ReachedMajorWoundEquivalent);
+        Assert.False(passed.FallsUnconscious);
+    }
+
+    [Fact]
+    public void Cumulative_minor_wounds_below_the_equivalent_roll_nothing_page_155()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(7);
+
+        // Total 5 < major wound level 6, and 7 HP is above the knockout band. No entropy consumed.
+        var entropy = new FixedEntropySource();
+        var outcome = MajorWoundResolver.ResolveCumulativeMinorWounds(
+            target, totalMinorHitPointsLostToday: 5, Damage, entropy);
+
+        Assert.False(outcome.ReachedMajorWoundEquivalent);
+        Assert.Null(outcome.LuckRoll);
+        Assert.False(outcome.FallsUnconscious);
+        Assert.False(outcome.KnockedOutForAnHour);
+        Assert.Equal(0, entropy.DrawCount);
+    }
+
+    [Fact]
+    public void Minor_wounds_reducing_the_character_to_one_or_two_hit_points_knock_them_out_page_155()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(2);
+
+        // 5 lost is below the major-wound equivalent (no Luck roll), but 2 HP => knocked out an hour.
+        var outcome = MajorWoundResolver.ResolveCumulativeMinorWounds(
+            target, totalMinorHitPointsLostToday: 5, Damage, new FixedEntropySource());
+
+        Assert.False(outcome.ReachedMajorWoundEquivalent);
+        Assert.True(outcome.KnockedOutForAnHour);
+    }
+
+    [Fact]
+    public void A_fatally_wounded_character_survives_only_with_in_window_aid_that_restores_hit_points_page_156()
+    {
+        // In the wound round (0), aid to 1 HP => survives.
+        Assert.True(MajorWoundResolver.SurvivesFatalWound(
+            hitPointsAfterAid: 1, roundsSinceFatalWound: 0, MajorWounds, Damage));
+
+        // The round immediately after (1) is still in the window.
+        Assert.True(MajorWoundResolver.SurvivesFatalWound(
+            hitPointsAfterAid: 3, roundsSinceFatalWound: 1, MajorWounds, Damage));
+
+        // Two rounds later is too late, even at healthy hit points.
+        Assert.False(MajorWoundResolver.SurvivesFatalWound(
+            hitPointsAfterAid: 6, roundsSinceFatalWound: 2, MajorWounds, Damage));
+
+        // In the window but not brought above 0 => death still resolves.
+        Assert.False(MajorWoundResolver.SurvivesFatalWound(
+            hitPointsAfterAid: 0, roundsSinceFatalWound: 0, MajorWounds, Damage));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #111

## Exact behavioral claim

A wound that deals ≥ half a character's total hit points now resolves as a **major wound**: the engine
reports the shock outcome (fight on only for rounds = remaining HP; collapse for an hour at ≤2 HP), rolls
an immediate **Luck roll** for permanence, and on failure rolls the printed **1D100 Major Wound Table**
(15 rows) and applies the characteristic drain through `AbilitySet.Set` (live recompute). Also adds the
cumulative-minor-wounds rule, the fatal-wound rescue window, and — the prerequisite — a **damage amount on
`Wound`** (which First Aid #109 also needs). Only the major-wound *threshold* existed before.

## Scope

New: `MajorWoundResolver` + ruleset/table/row (`Brp.Rules.Combat`), `major-wound-ruleset.json` +
`NoirMajorWoundRuleset`, the `IMajorWoundAdjudicator` port (`Brp.Core.Contests`), ADR 0021. `Wound` gains
`DamageAmount`, threaded through the single `DamageResolver` creation site (so it can't diverge from HP
subtracted). Turn-economy effects are structured outcomes (caller seam — no encounter model), consistent
with #50/#96/#97.

## Rules conformance

Source: **Ch 6 "Major Wounds"/"Fatal Wounds", pp.155-156** of `BasicRoleplaying-ORC-Content-Document.pdf`.
Verified adversarially by `rules-conformance` (pages re-checked against the PDF — correct, no off-by-one):
all **15 Major Wound Table rows exact** (range + die/characteristic + MOV flag + able-to-fight flag),
tiling 1-100 with an exact-count `[Fact]`; trigger = wound ≥ `MajorWoundLevel` (⌈HP/2⌉); shock read
before drain; Luck = POW×5; failure drains via `AbilitySet.Set` with live recompute (CON 12→9 → max HP
12→11); cumulative-minor and fatal-window per the text. No defects, no misattributed citations. All row
data lives in `major-wound-ruleset.json`.

## Tests and evidence

- `dotnet build NoiRPG.slnx` → 0 warnings, 0 errors.
- `dotnet test NoiRPG.slnx` → **2207 passed, 0 failed** (~39 new). Re-run independently.
- `dotnet format NoiRPG.slnx --verify-no-changes` → clean.

## Decisions and tradeoffs

Row 99 records no MOV reduction (its printed text omits the MOV clause — table beats prose). Limb-side and
the 00-row's four-characteristics choice are `IMajorWoundAdjudicator` decision ids (narrative discretion),
on a new triad consistent with #50/#96. Entropy order is fixed (Luck → table → loss dice) for replayability.

## Known limitations

Applying "unable to fight"/unconsciousness/MOV reduction to a running encounter is a caller seam (the engine
has no encounter model or mutable MOV). ADR 0021 records the book's "Major Wounds incompatible with hit
locations" caveat for #112 to reconcile.

## Agent provenance

Implemented by a build agent as `engine-dev` (Claude, via Claude Code) from a cited Ch 6 extract. Verified
by adversarial `rules-conformance` (15/15 rows, pages re-verified — PASS) and `scope-warden` (no
hit-locations/healing bled in, drain via recompute, one concern — PASS). Orchestrated at the owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
