### PR TITLE
Apply the skill category bonus in the engine (ADR 0006)

### DIFF
--- a/docs/decisions/0022-skill-category-bonus-application.md
+++ b/docs/decisions/0022-skill-category-bonus-application.md
@@ -1,0 +1,116 @@
+# 0022. Skill category bonus: applied in the engine as base + category bonus, by subtraction for authored ratings
+
+## Status
+
+Accepted — 2026-08-31. Resolves #110. Applies the policy decided in ADR 0006 (which chose *full*
+skill category bonuses, applied by subtraction), and follows the live-recompute precedent of ADR
+0008 (derived characteristics) and the ruleset-as-data invariant of ADR 0002.
+
+## Context
+
+ADR 0006 decided *which* characteristic-to-skill system NoiRPG uses and settled the arithmetic, but
+that decision lived only in `tools/skill_bonus.py` (a Python audit tool). The C# engine never
+applied it: `CharacterBuilder.Build` set every skill to `printed base + professional + personal
+points` with no category-bonus term, so **player-built characters silently lacked their category
+bonuses**. No test caught the gap, because the only characters carrying category bonuses were the
+authored background packages in `case_validator.py`, whose ratings are *already final-effective*
+(base derived by subtraction) — so nothing was ever added on top of them to be wrong.
+
+This record covers making the ADR 0006 policy real in the engine: a data-driven bonus policy, its
+application to a character's effective rating, its live recompute on characteristic change, and the
+rule that keeps it from being double-applied to authored ratings.
+
+Only Ch 2: Characters, "Skill Category Bonuses (Option)" — the "Skill Category Modifiers" and
+"Skill Bonus Table" — was consulted. The printed page numbers were re-verified against the PDF with
+`pdftotext -f/-l`: "Skill Category Bonuses (Option)", the Skill Category Modifiers table, and the
+Skill Bonus Table (values 1–20) are on **p.18**; the table's value-21 row, its `+1%/point` /
+`+1%/2 points` continuation, and "Simpler Skill Bonuses" are on **p.19**. The prep note's "pp.18–19"
+holds. The chapter's own worked example is reproduced end to end in test.
+
+## Decision
+
+### The formula — sourced (Ch 2, "Skill Category Bonuses (Option)", pp.18–19)
+
+For a characteristic measured from a neutral value of 10:
+
+- **Primary** characteristic: +1% for every point over 10, −1% for every point under 10.
+- **Secondary** characteristic: +1% for every **2** points over 10, −1% for every 2 points under
+  10, **magnitude rounded down** (−3 points → −1, not −2).
+- **Negative** characteristic: an **inverted primary** — subtracted rather than added (+1% per point
+  *under* 10, −1% per point over).
+
+The category bonus is the sum across a category's primary, secondaries, and negatives. It can be
+negative. This is the "full" option; ADR 0006 rejected the "simpler" (½ primary, always positive)
+and "neither" (bonus always 0) options.
+
+### The category → characteristic table — sourced (the printed "Skill Category Modifiers", p.18)
+
+| Category | Primary | Secondary | Negative |
+|---|---|---|---|
+| Combat | DEX | INT, STR | — |
+| Communication | INT | POW, CHA | — |
+| Manipulation | DEX | INT, STR | — |
+| Mental | INT | POW, EDU | — |
+| Perception | INT | POW, CON | — |
+| Physical | DEX | STR, CON | SIZ |
+
+Mental's second secondary is **EDU** per ADR 0006 (the book prints the slot; NoiRPG fills it with
+the optional Education characteristic). The book's worked example leaves EDU "not used", which is
+equivalent to EDU at the neutral value 10 (a zero contribution).
+
+### Where it lives — data + a Core policy
+
+- **Data** (`src/Brp.Data/skill-category-bonus-ruleset.json`): the neutral value (10), the two
+  divisors (1 for primary/negative, 2 for secondary), and the category→characteristic map. Nothing
+  is a hardcoded C# constant (AGENTS.md invariant 7). `NoirSkillCategoryBonusRuleset.Load()` builds
+  it.
+- **Policy** (`Brp.Core.Skills.SkillCategoryBonusRuleset`): `BonusFor(SkillCategory, AbilitySet)`
+  computes the bonus. It is data-configured, so ADR 0006's "neither" option is expressible (an
+  all-neutral or empty map yields a zero bonus); "simpler" would be a different policy shape and is
+  not built, matching ADR 0006's choice. No game-engine dependency (invariant 6).
+
+### How it is applied — effective rating = base + category bonus, recomputed live
+
+`CharacterSkill.CurrentRating` remains the character's **base** rating (printed base + points spent,
+moved only by advancement). The effective rating is computed on read:
+
+```
+effective rating = CurrentRating + BonusFor(Definition.Category, abilities)
+```
+
+exposed as `CharacterSkill.EffectiveRating(abilities, bonuses)` and
+`Character.EffectiveRating(skillId, bonuses)`. Because the bonus is read live from the mutable
+`AbilitySet`, the effective rating **recomputes whenever a characteristic changes** — the same
+"changes immediately" treatment ADR 0008 gives hit points (Ch 2 p.13). `CharacterBuilder` therefore
+does **not** bake the bonus into `CurrentRating`; baking it would freeze it against later drain.
+
+### No double-apply to authored ratings — by subtraction (ADR 0006)
+
+Authored content (background packages) treats its numbers as **final effective ratings** and stores
+the base by subtraction: `base = effective − category bonus`. The seam is
+`CharacterSkill.FromEffectiveRating(definition, effectiveRating, abilities, bonuses)`. Reading
+`EffectiveRating` back then reproduces the authored number exactly — the bonus is never added a
+second time. This preserves the audited door coverage ADR 0006 protected: adding the engine bonus
+does not shift a single authored rating.
+
+## Consequences
+
+- Player-built characters now get their category bonuses; the #110 gap is closed. The base rating,
+  the number advancement moves, is unchanged — advancement still rolls against `CurrentRating`
+  (base), not the effective rating; whether improvement should roll against the effective rating is
+  a separate question left to a future issue, not decided here.
+- The effective rating is now *exposed* but not yet *consumed* by a roll pipeline: `SkillRoll.Resolve`
+  still takes its effective chance from the caller (the pre-existing state), so a future glue layer
+  can feed it `Character.EffectiveRating`. Nothing in this issue changes the CLI.
+- A bonus can be negative and, for a low-base skill, can push an effective rating below 0. The value
+  is returned unclamped, matching `tools/skill_bonus.py`; a sub-zero chance simply always fails at
+  resolution.
+
+## Verification
+
+`Brp.Data.Tests.NoirSkillCategoryBonusRulesetTests` reproduces both printed tables in full — the
+Skill Category Modifiers map (all six rows) and the Skill Bonus Table (values 1–21 × primary /
+secondary / negative columns) — plus the chapter's worked example, matching `tools/skill_bonus.py`.
+`Brp.Core.Tests` covers the policy's validation and round-down rule. `Brp.Rules.Tests` covers a
+player-built character's effective rating, recompute on drain, and the authored no-double-apply
+seam.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -44,3 +44,4 @@ supersedes it — the original is not edited or deleted.
 | [0019](0019-injury-spot-rules.md) | Injury/effect spot rules: falling, poison, and disease through the damage and characteristic-drain paths | Accepted |
 | [0020](0020-fumble-tables.md) | Combat fumble tables: the four D100 consequence tables, a context-selecting resolver, and the ally/reroll seams | Accepted |
 | [0021](0021-major-wounds.md) | Major Wounds: the wound damage amount, the shock/Luck/table effect, cumulative minors, and the fatal-wound rescue window | Accepted |
+| [0022](0022-skill-category-bonus-application.md) | Skill category bonus applied in the engine as base + category bonus, live-recomputed, by subtraction for authored ratings | Accepted |

--- a/src/Brp.Core/Skills/SkillCategoryBonusRuleset.cs
+++ b/src/Brp.Core/Skills/SkillCategoryBonusRuleset.cs
@@ -1,0 +1,131 @@
+using Brp.Core.Abilities;
+
+namespace Brp.Core.Skills;
+
+/// <summary>
+/// The ruleset-configurable skill-category-bonus policy mandated by
+/// <c>docs/decisions/0006-skill-bonus-system.md</c> and applied to the engine by
+/// <c>docs/decisions/0022-skill-category-bonus-application.md</c>. It computes a category bonus
+/// for any <see cref="SkillCategory"/> from an <see cref="AbilitySet"/>, per Ch 2: Characters,
+/// "Skill Category Bonuses (Option)" -- the "Skill Category Modifiers" and "Skill Bonus Table"
+/// (pp.18-19):
+/// <list type="bullet">
+///   <item>Primary characteristic: +/-1% for every point away from the neutral value.</item>
+///   <item>Secondary characteristic: +/-1% for every 2 points away, magnitude rounded down.</item>
+///   <item>Negative characteristic: an inverted primary -- the primary rule, subtracted.</item>
+/// </list>
+/// Every value (the neutral pivot, the two divisors, and the category-to-characteristic map) is
+/// supplied as data by <c>Brp.Data.NoirSkillCategoryBonusRuleset.Load()</c> (AGENTS.md invariant
+/// 7); nothing here is a hardcoded book number. This is the "full" option; ADR 0006's "neither"
+/// option is expressible by configuring every category with no secondaries and no negatives
+/// (leaving the bonus at the primary's deviation) or, more directly, a zero map.
+/// <para>
+/// This computes the <em>bonus</em> only. Applying it to a character -- effective rating = base
+/// rating + category bonus, recomputed whenever a characteristic changes, and <em>not</em>
+/// double-applied to authored final-effective ratings -- lives in
+/// <c>Brp.Rules.Characters.CharacterSkill</c> (see ADR 0022).
+/// </para>
+/// </summary>
+public sealed class SkillCategoryBonusRuleset
+{
+    private readonly Dictionary<SkillCategory, SkillCategoryModifierSpec> _specs;
+
+    /// <summary>Creates a bonus policy from data-defined values.</summary>
+    /// <param name="neutralCharacteristicValue">The value a characteristic contributes nothing at (10 in the book).</param>
+    /// <param name="primaryPointsPerModifier">Points of deviation per +/-1% for a primary or negative characteristic (1 in the book).</param>
+    /// <param name="secondaryPointsPerModifier">Points of deviation per +/-1% for a secondary characteristic (2 in the book).</param>
+    /// <param name="categories">One <see cref="SkillCategoryModifierSpec"/> per skill category; all six are required.</param>
+    public SkillCategoryBonusRuleset(
+        int neutralCharacteristicValue,
+        int primaryPointsPerModifier,
+        int secondaryPointsPerModifier,
+        IEnumerable<SkillCategoryModifierSpec> categories)
+    {
+        ArgumentNullException.ThrowIfNull(categories);
+        if (primaryPointsPerModifier <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(primaryPointsPerModifier), primaryPointsPerModifier, "Points per modifier must be positive.");
+        }
+
+        if (secondaryPointsPerModifier <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(secondaryPointsPerModifier), secondaryPointsPerModifier, "Points per modifier must be positive.");
+        }
+
+        NeutralCharacteristicValue = neutralCharacteristicValue;
+        PrimaryPointsPerModifier = primaryPointsPerModifier;
+        SecondaryPointsPerModifier = secondaryPointsPerModifier;
+
+        _specs = new Dictionary<SkillCategory, SkillCategoryModifierSpec>();
+        foreach (var spec in categories)
+        {
+            ArgumentNullException.ThrowIfNull(spec);
+            if (!_specs.TryAdd(spec.Category, spec))
+            {
+                throw new ArgumentException($"Duplicate configuration for skill category '{spec.Category}'.", nameof(categories));
+            }
+        }
+
+        foreach (var category in Enum.GetValues<SkillCategory>())
+        {
+            if (!_specs.ContainsKey(category))
+            {
+                throw new ArgumentException($"Skill category '{category}' has no bonus configuration.", nameof(categories));
+            }
+        }
+    }
+
+    /// <summary>The characteristic value that contributes a zero bonus (Ch 2 p.18: 10).</summary>
+    public int NeutralCharacteristicValue { get; }
+
+    /// <summary>Points of deviation from neutral per +/-1% for a primary/negative characteristic.</summary>
+    public int PrimaryPointsPerModifier { get; }
+
+    /// <summary>Points of deviation from neutral per +/-1% for a secondary characteristic.</summary>
+    public int SecondaryPointsPerModifier { get; }
+
+    /// <summary>The category-to-characteristic map, keyed by category.</summary>
+    public IReadOnlyDictionary<SkillCategory, SkillCategoryModifierSpec> Categories => _specs;
+
+    /// <summary>
+    /// Computes the skill category bonus for <paramref name="category"/> from a character's
+    /// characteristics. May be negative; the book's example gives Communication -3% for a
+    /// low-INT character (Ch 2 p.18). The result is a live read -- calling it again after a
+    /// characteristic changes yields the new bonus, which is what makes an effective rating
+    /// "recompute whenever a characteristic changes" (ADR 0006).
+    /// </summary>
+    public int BonusFor(SkillCategory category, AbilitySet abilities)
+    {
+        ArgumentNullException.ThrowIfNull(abilities);
+        if (!_specs.TryGetValue(category, out var spec))
+        {
+            throw new KeyNotFoundException($"No bonus configuration for skill category '{category}'.");
+        }
+
+        var bonus = Contribution(spec.Primary, abilities, PrimaryPointsPerModifier);
+        foreach (var secondary in spec.Secondary)
+        {
+            bonus += Contribution(secondary, abilities, SecondaryPointsPerModifier);
+        }
+
+        foreach (var negative in spec.Negative)
+        {
+            bonus -= Contribution(negative, abilities, PrimaryPointsPerModifier);
+        }
+
+        return bonus;
+    }
+
+    private int Contribution(CharacteristicId characteristic, AbilitySet abilities, int pointsPerModifier) =>
+        SignedQuotient(abilities.ValueOf(characteristic) - NeutralCharacteristicValue, pointsPerModifier);
+
+    /// <summary>
+    /// Deviation divided by the points-per-modifier, with the magnitude rounded down (toward
+    /// zero) and the sign preserved -- the book's "+1% for every 2 points ... round down" and
+    /// the reference <c>tools/skill_bonus.py</c>'s <c>signed_half</c>. Integer division alone
+    /// would round -3/2 toward zero to -1, which is correct here; splitting sign and magnitude
+    /// makes the rounding rule explicit and divisor-agnostic.
+    /// </summary>
+    private static int SignedQuotient(int deviation, int pointsPerModifier) =>
+        Math.Sign(deviation) * (Math.Abs(deviation) / pointsPerModifier);
+}

--- a/src/Brp.Core/Skills/SkillCategoryModifierSpec.cs
+++ b/src/Brp.Core/Skills/SkillCategoryModifierSpec.cs
@@ -1,0 +1,28 @@
+using Brp.Core.Abilities;
+
+namespace Brp.Core.Skills;
+
+/// <summary>
+/// One row of the book's "Skill Category Modifiers" table (Ch 2: Characters, "Skill Category
+/// Bonuses (Option)", p.18): the characteristics a single <see cref="SkillCategory"/> draws its
+/// category bonus from. A category has exactly one primary characteristic, zero or more
+/// secondary characteristics, and zero or more negative characteristics.
+/// </summary>
+/// <param name="Category">The skill category this row configures.</param>
+/// <param name="Primary">
+/// The primary characteristic: +/-1% per point away from the neutral value (see
+/// <see cref="SkillCategoryBonusRuleset.NeutralCharacteristicValue"/>).
+/// </param>
+/// <param name="Secondary">
+/// The secondary characteristics: +/-1% per 2 points away from neutral, magnitude rounded down.
+/// The printed table gives a category one or two secondaries; the shape allows any count.
+/// </param>
+/// <param name="Negative">
+/// The negative characteristics: an inverted primary, subtracted rather than added (+1% per
+/// point <em>under</em> neutral, -1% per point over). Only Physical has one (SIZ) in the book.
+/// </param>
+public sealed record SkillCategoryModifierSpec(
+    SkillCategory Category,
+    CharacteristicId Primary,
+    IReadOnlyList<CharacteristicId> Secondary,
+    IReadOnlyList<CharacteristicId> Negative);

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <EmbeddedResource Include="ability-ruleset.json" />
     <EmbeddedResource Include="skill-ruleset.json" />
+    <EmbeddedResource Include="skill-category-bonus-ruleset.json" />
     <EmbeddedResource Include="character-creation-ruleset.json" />
     <EmbeddedResource Include="background-packages.json" />
     <EmbeddedResource Include="experience-ruleset.json" />

--- a/src/Brp.Data/NoirSkillCategoryBonusRuleset.cs
+++ b/src/Brp.Data/NoirSkillCategoryBonusRuleset.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using Brp.Core.Abilities;
+using Brp.Core.Skills;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's skill-category-bonus policy from embedded JSON. The source is Ch 2: Characters,
+/// "Skill Category Bonuses (Option)" -- the "Skill Category Modifiers" and "Skill Bonus Table"
+/// (pp.18-19); the neutral pivot, the per-point/per-2-point divisors, and the
+/// category-to-characteristic map are all data. Recorded in
+/// <c>docs/decisions/0006-skill-bonus-system.md</c> (the decision) and
+/// <c>docs/decisions/0022-skill-category-bonus-application.md</c> (its engine application),
+/// and book-verified against <c>tools/skill_bonus.py</c>.
+/// </summary>
+public static class NoirSkillCategoryBonusRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable skill-category-bonus policy from the shipped data.</summary>
+    public static SkillCategoryBonusRuleset Load()
+    {
+        var assembly = typeof(NoirSkillCategoryBonusRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.skill-category-bonus-ruleset.json")
+            ?? throw new InvalidOperationException("The skill category bonus ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<SkillCategoryBonusData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The skill category bonus ruleset data is empty.");
+
+        var categories = data.Categories.Select(c => new SkillCategoryModifierSpec(
+            Enum.Parse<SkillCategory>(c.Category, ignoreCase: true),
+            new CharacteristicId(c.Primary),
+            c.Secondary.Select(id => new CharacteristicId(id)).ToList(),
+            c.Negative.Select(id => new CharacteristicId(id)).ToList()));
+
+        return new SkillCategoryBonusRuleset(
+            data.NeutralCharacteristicValue,
+            data.PrimaryPointsPerModifier,
+            data.SecondaryPointsPerModifier,
+            categories);
+    }
+
+    private sealed class SkillCategoryBonusData
+    {
+        public required int NeutralCharacteristicValue { get; init; }
+
+        public required int PrimaryPointsPerModifier { get; init; }
+
+        public required int SecondaryPointsPerModifier { get; init; }
+
+        public required List<CategoryData> Categories { get; init; }
+    }
+
+    private sealed class CategoryData
+    {
+        public required string Category { get; init; }
+
+        public required string Primary { get; init; }
+
+        public required List<string> Secondary { get; init; }
+
+        public required List<string> Negative { get; init; }
+    }
+}

--- a/src/Brp.Data/skill-category-bonus-ruleset.json
+++ b/src/Brp.Data/skill-category-bonus-ruleset.json
@@ -1,0 +1,20 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 2: Characters",
+    "section": "Skill Category Bonuses (Option) -- 'Skill Category Modifiers' and 'Skill Bonus Table'",
+    "pages": "18-19",
+    "notes": "Primary: +/-1% per point from 10. Secondary: +/-1% per 2 points from 10, magnitude rounded down. Negative: inverted primary (subtracted). The category-to-characteristic map is the printed 'Skill Category Modifiers' table (p.18); Mental's second secondary is EDU per docs/decisions/0006-skill-bonus-system.md. Applied to the engine by docs/decisions/0022-skill-category-bonus-application.md; book-verified against tools/skill_bonus.py."
+  },
+  "neutralCharacteristicValue": 10,
+  "primaryPointsPerModifier": 1,
+  "secondaryPointsPerModifier": 2,
+  "categories": [
+    { "category": "Combat", "primary": "DEX", "secondary": ["INT", "STR"], "negative": [] },
+    { "category": "Communication", "primary": "INT", "secondary": ["POW", "CHA"], "negative": [] },
+    { "category": "Manipulation", "primary": "DEX", "secondary": ["INT", "STR"], "negative": [] },
+    { "category": "Mental", "primary": "INT", "secondary": ["POW", "EDU"], "negative": [] },
+    { "category": "Perception", "primary": "INT", "secondary": ["POW", "CON"], "negative": [] },
+    { "category": "Physical", "primary": "DEX", "secondary": ["STR", "CON"], "negative": ["SIZ"] }
+  ]
+}

--- a/src/Brp.Rules/Characters/Character.cs
+++ b/src/Brp.Rules/Characters/Character.cs
@@ -73,6 +73,20 @@ public sealed class Character
         ? skill
         : throw new KeyNotFoundException($"Character '{Name}' has no skill '{id}'.");
 
+    /// <summary>
+    /// The live effective rating of one skill: its base rating plus its category bonus (Ch 2:
+    /// Characters, "Skill Category Bonuses (Option)", pp.18-19), read against this character's
+    /// current <see cref="Abilities"/>. ADR 0006 mandates effective = base + category bonus and
+    /// ADR 0022 applies it; because the bonus is read live, this recomputes when a characteristic
+    /// changes, exactly like <see cref="MaximumHitPoints"/>.
+    /// </summary>
+    public int EffectiveRating(SkillId id, SkillCategoryBonusRuleset bonuses) =>
+        Skill(id).EffectiveRating(Abilities, bonuses);
+
+    /// <summary>This character's category bonus for one skill, read live against <see cref="Abilities"/>.</summary>
+    public int CategoryBonus(SkillId id, SkillCategoryBonusRuleset bonuses) =>
+        Skill(id).CategoryBonus(Abilities, bonuses);
+
     /// <summary>Whether this character has a given skill at all -- the "has / does not have" question (#6).</summary>
     public bool HasSkill(SkillId id) => Skills.ContainsKey(id);
 }

--- a/src/Brp.Rules/Characters/CharacterSkill.cs
+++ b/src/Brp.Rules/Characters/CharacterSkill.cs
@@ -23,6 +23,25 @@ public sealed class CharacterSkill
         CurrentRating = currentRating;
     }
 
+    /// <summary>
+    /// Builds a skill from an <em>authored, already-final effective rating</em>, storing its base
+    /// rating by subtraction: base = effective - category bonus (ADR 0006, "applied by
+    /// subtraction"). Reading <see cref="EffectiveRating"/> against the same abilities then
+    /// reproduces <paramref name="effectiveRating"/> exactly -- the category bonus is not added a
+    /// second time. This is the seam Layer 5 authored packages use so that adding the engine's
+    /// category bonus does not perturb ratings that were authored as final (ADR 0022). Contrast
+    /// with the ordinary constructor, whose argument is a <em>base</em> rating the bonus is added
+    /// to.
+    /// </summary>
+    public static CharacterSkill FromEffectiveRating(
+        SkillDefinition definition, int effectiveRating, AbilitySet abilities, SkillCategoryBonusRuleset bonuses)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(bonuses);
+        var baseRating = effectiveRating - bonuses.BonusFor(definition.Category, abilities);
+        return new CharacterSkill(definition, baseRating);
+    }
+
     /// <summary>The Layer 2 skill this instance resolves against.</summary>
     public SkillDefinition Definition { get; }
 
@@ -43,6 +62,33 @@ public sealed class CharacterSkill
 
     /// <summary>This skill's printed base chance, evaluated against a character's abilities.</summary>
     public Percent PrintedBaseChance(AbilitySet abilities) => Definition.BaseChanceFor(abilities);
+
+    /// <summary>
+    /// This skill's category bonus (Ch 2: Characters, "Skill Category Bonuses (Option)",
+    /// pp.18-19), read live from <paramref name="abilities"/> through
+    /// <paramref name="bonuses"/> using this skill's <see cref="SkillDefinition.Category"/>.
+    /// Recomputes on every call, so a characteristic change is reflected immediately.
+    /// </summary>
+    public int CategoryBonus(AbilitySet abilities, SkillCategoryBonusRuleset bonuses)
+    {
+        ArgumentNullException.ThrowIfNull(bonuses);
+        return bonuses.BonusFor(Definition.Category, abilities);
+    }
+
+    /// <summary>
+    /// This skill's effective rating = <see cref="CurrentRating"/> (the base rating) + its
+    /// category bonus. This is the number a skill roll resolves against; ADR 0006 mandates
+    /// effective = base + category bonus, and ADR 0022 applies it here. Because the bonus is a
+    /// live read of <paramref name="abilities"/>, the effective rating "recomputes whenever a
+    /// characteristic changes" (ADR 0006) rather than being baked in at creation.
+    /// <para>
+    /// The category bonus is <em>not</em> applied on top of an already-final authored rating:
+    /// an authored skill built through <see cref="FromEffectiveRating"/> stored its base by
+    /// subtraction, so base + bonus reproduces the authored number exactly (no double-apply).
+    /// </para>
+    /// </summary>
+    public int EffectiveRating(AbilitySet abilities, SkillCategoryBonusRuleset bonuses) =>
+        CurrentRating + CategoryBonus(abilities, bonuses);
 
     /// <summary>Sets the current rating directly. Creation-time only; advancement uses <see cref="Improve"/>.</summary>
     internal void SetRating(int rating) => CurrentRating = rating;

--- a/src/Brp.Rules/Creation/CharacterBuilder.cs
+++ b/src/Brp.Rules/Creation/CharacterBuilder.cs
@@ -82,6 +82,10 @@ public sealed class CharacterBuilder
                     nameof(request));
             }
 
+            // `total` is the character's BASE rating (printed base chance + points spent), which
+            // is what CharacterSkill stores. The skill category bonus (Ch 2 pp.18-19) is NOT baked
+            // in here: it is added live by CharacterSkill/Character.EffectiveRating so it recomputes
+            // when a characteristic changes (ADR 0006 / ADR 0022). Baking it in would freeze it.
             skills[id] = new CharacterSkill(definition, total);
         }
 

--- a/tests/Brp.Core.Tests/Skills/SkillCategoryBonusRulesetTests.cs
+++ b/tests/Brp.Core.Tests/Skills/SkillCategoryBonusRulesetTests.cs
@@ -1,0 +1,117 @@
+using Brp.Core.Abilities;
+using Brp.Core.Skills;
+
+namespace Brp.Core.Tests.Skills;
+
+/// <summary>
+/// Unit tests for the <see cref="SkillCategoryBonusRuleset"/> policy itself (Ch 2: Characters,
+/// "Skill Category Bonuses (Option)", pp.18-19): validation, the "round the magnitude down"
+/// rule, negative bonuses, and the live-recompute property that lets an effective rating track a
+/// characteristic change (ADR 0006). Built from hand-made specs to show the policy needs no data
+/// project. The shipped data's reproduction of the two printed tables lives in
+/// <c>Brp.Data.Tests.NoirSkillCategoryBonusRulesetTests</c>.
+/// </summary>
+public class SkillCategoryBonusRulesetTests
+{
+    private static SkillCategoryModifierSpec Spec(
+        SkillCategory category, string primary, string secondary = "", string negative = "") =>
+        new(category,
+            new CharacteristicId(primary),
+            Ids(secondary),
+            Ids(negative));
+
+    private static List<CharacteristicId> Ids(string commaSeparated) => commaSeparated
+        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .Select(id => new CharacteristicId(id))
+        .ToList();
+
+    private static IEnumerable<SkillCategoryModifierSpec> AllSix()
+    {
+        yield return Spec(SkillCategory.Combat, "DEX", "INT,STR");
+        yield return Spec(SkillCategory.Communication, "INT", "POW,CHA");
+        yield return Spec(SkillCategory.Manipulation, "DEX", "INT,STR");
+        yield return Spec(SkillCategory.Mental, "INT", "POW,EDU");
+        yield return Spec(SkillCategory.Perception, "INT", "POW,CON");
+        yield return Spec(SkillCategory.Physical, "DEX", "STR,CON", "SIZ");
+    }
+
+    private static SkillCategoryBonusRuleset Full() => new(10, 1, 2, AllSix());
+
+    private static AbilitySet Abilities(params (string Id, int Value)[] overrides)
+    {
+        var ids = new[] { "STR", "CON", "SIZ", "INT", "POW", "DEX", "CHA", "EDU" };
+        var characteristics = ids.Select(id => new CharacteristicDefinition(
+            new CharacteristicId(id), id, Minimum: 1, Maximum: null, RollName: null));
+        var table = new DamageModifierTable(new[] { new DamageModifierBand(-1000, null, null) });
+        var ruleset = new AbilityRuleset(
+            characteristics, table, 10, 1, 10, 5, 2, 2, 2);
+        var values = ids.ToDictionary(id => new CharacteristicId(id), _ => 10);
+        foreach (var (id, value) in overrides)
+        {
+            values[new CharacteristicId(id)] = value;
+        }
+
+        return new AbilitySet(ruleset, values);
+    }
+
+    [Fact]
+    public void A_category_missing_from_the_map_is_rejected_at_construction()
+    {
+        var withoutPhysical = AllSix().Where(s => s.Category != SkillCategory.Physical);
+
+        Assert.Throws<ArgumentException>(() => new SkillCategoryBonusRuleset(10, 1, 2, withoutPhysical));
+    }
+
+    [Fact]
+    public void A_duplicate_category_is_rejected_at_construction()
+    {
+        var withDuplicate = AllSix().Append(Spec(SkillCategory.Combat, "DEX"));
+
+        Assert.Throws<ArgumentException>(() => new SkillCategoryBonusRuleset(10, 1, 2, withDuplicate));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Non_positive_points_per_modifier_are_rejected(int badDivisor)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SkillCategoryBonusRuleset(10, badDivisor, 2, AllSix()));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SkillCategoryBonusRuleset(10, 1, badDivisor, AllSix()));
+    }
+
+    [Fact]
+    public void Secondary_magnitude_rounds_down_toward_zero_for_odd_deviations_in_both_directions()
+    {
+        // Mental secondary = POW. POW 7 is -3 from neutral -> -1 (magnitude 1, not 1.5 up to 2);
+        // POW 13 is +3 -> +1. INT/EDU held neutral so only the secondary contributes.
+        Assert.Equal(-1, Full().BonusFor(SkillCategory.Mental, Abilities(("POW", 7))));
+        Assert.Equal(1, Full().BonusFor(SkillCategory.Mental, Abilities(("POW", 13))));
+    }
+
+    [Fact]
+    public void A_negative_characteristic_subtracts_an_inverted_primary()
+    {
+        // Physical negative = SIZ. High SIZ hurts, low SIZ helps (Ch 2 p.18).
+        Assert.Equal(-5, Full().BonusFor(SkillCategory.Physical, Abilities(("SIZ", 15))));
+        Assert.Equal(5, Full().BonusFor(SkillCategory.Physical, Abilities(("SIZ", 5))));
+    }
+
+    [Fact]
+    public void The_bonus_is_a_live_read_that_moves_when_a_characteristic_changes()
+    {
+        var policy = Full();
+        var abilities = Abilities(("DEX", 15)); // Combat primary DEX 15 -> +5
+        Assert.Equal(5, policy.BonusFor(SkillCategory.Combat, abilities));
+
+        abilities.Set(new CharacteristicId("DEX"), 8); // drained to 8 -> -2
+
+        Assert.Equal(-2, policy.BonusFor(SkillCategory.Combat, abilities));
+    }
+
+    [Fact]
+    public void An_unknown_category_lookup_throws()
+    {
+        // Every enum value is configured, so this can only happen for an out-of-range cast.
+        Assert.Throws<KeyNotFoundException>(() => Full().BonusFor((SkillCategory)999, Abilities()));
+    }
+}

--- a/tests/Brp.Data.Tests/NoirSkillCategoryBonusRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirSkillCategoryBonusRulesetTests.cs
@@ -1,0 +1,142 @@
+using Brp.Core.Abilities;
+using Brp.Core.Skills;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped skill-category-bonus data loads and reproduces Ch 2: Characters,
+/// "Skill Category Bonuses (Option)" -- the "Skill Category Modifiers" table and the "Skill
+/// Bonus Table" (pp.18-19). Both printed tables are reproduced in full (cell by cell) rather
+/// than sampled, per AGENTS.md's table-backed-rule convention, and the chapter's worked example
+/// is reproduced end to end. Book-verified against <c>tools/skill_bonus.py</c>. See
+/// <c>docs/decisions/0006-skill-bonus-system.md</c> and
+/// <c>docs/decisions/0022-skill-category-bonus-application.md</c>.
+/// </summary>
+public class NoirSkillCategoryBonusRulesetTests
+{
+    private static readonly SkillCategoryBonusRuleset Bonuses = NoirSkillCategoryBonusRuleset.Load();
+
+    [Fact]
+    public void Formula_parameters_match_chapter_2_page_18()
+    {
+        // "Primary ... +/-1% for every point ... Secondary ... +/-1% for every 2 points ...
+        // round down." The neutral value the deviations are measured from is 10.
+        Assert.Equal(10, Bonuses.NeutralCharacteristicValue);
+        Assert.Equal(1, Bonuses.PrimaryPointsPerModifier);
+        Assert.Equal(2, Bonuses.SecondaryPointsPerModifier);
+    }
+
+    // The printed "Skill Category Modifiers" table (Ch 2 p.18), reproduced row by row. Secondary
+    // and negative lists are pipe-joined in declaration order; "" is an empty list.
+    [Theory]
+    [InlineData(SkillCategory.Combat, "DEX", "INT|STR", "")]
+    [InlineData(SkillCategory.Communication, "INT", "POW|CHA", "")]
+    [InlineData(SkillCategory.Manipulation, "DEX", "INT|STR", "")]
+    [InlineData(SkillCategory.Mental, "INT", "POW|EDU", "")]
+    [InlineData(SkillCategory.Perception, "INT", "POW|CON", "")]
+    [InlineData(SkillCategory.Physical, "DEX", "STR|CON", "SIZ")]
+    public void Skill_category_modifiers_table_maps_every_category_to_its_characteristics(
+        SkillCategory category, string primary, string secondary, string negative)
+    {
+        var spec = Bonuses.Categories[category];
+
+        Assert.Equal(primary, spec.Primary.Value);
+        Assert.Equal(secondary, string.Join('|', spec.Secondary.Select(c => c.Value)));
+        Assert.Equal(negative, string.Join('|', spec.Negative.Select(c => c.Value)));
+    }
+
+    // The printed "Skill Bonus Table" (Ch 2 pp.18-19): for a characteristic at each value 1-21,
+    // the bonus contributed as a Primary, a Secondary, and a Negative characteristic. Values are
+    // the book's printed cells, exercised through a live AbilitySet:
+    //   Primary   via Combat's DEX (its INT/STR secondaries held neutral),
+    //   Secondary via Mental's EDU (INT/POW held neutral) -- the same path skill_bonus.py pins,
+    //   Negative  via Physical's SIZ (DEX/STR/CON held neutral).
+    [Theory]
+    [InlineData(1, -9, -4, 9)]
+    [InlineData(2, -8, -4, 8)]
+    [InlineData(3, -7, -3, 7)]
+    [InlineData(4, -6, -3, 6)]
+    [InlineData(5, -5, -2, 5)]
+    [InlineData(6, -4, -2, 4)]
+    [InlineData(7, -3, -1, 3)]
+    [InlineData(8, -2, -1, 2)]
+    [InlineData(9, -1, 0, 1)]
+    [InlineData(10, 0, 0, 0)]
+    [InlineData(11, 1, 0, -1)]
+    [InlineData(12, 2, 1, -2)]
+    [InlineData(13, 3, 1, -3)]
+    [InlineData(14, 4, 2, -4)]
+    [InlineData(15, 5, 2, -5)]
+    [InlineData(16, 6, 3, -6)]
+    [InlineData(17, 7, 3, -7)]
+    [InlineData(18, 8, 4, -8)]
+    [InlineData(19, 9, 4, -9)]
+    [InlineData(20, 10, 5, -10)]
+    [InlineData(21, 11, 5, -11)]
+    public void Skill_bonus_table_reproduces_each_value_as_primary_secondary_and_negative(
+        int value, int primary, int secondary, int negative)
+    {
+        Assert.Equal(primary, Bonuses.BonusFor(SkillCategory.Combat, Neutral(("DEX", value))));
+        Assert.Equal(secondary, Bonuses.BonusFor(SkillCategory.Mental, Neutral(("EDU", value))));
+        Assert.Equal(negative, Bonuses.BonusFor(SkillCategory.Physical, Neutral(("SIZ", value))));
+    }
+
+    // The worked example on Ch 2 p.18: STR 14, CON 13, INT 8, SIZ 12, POW 10, DEX 12, CHA 8.
+    // The book leaves EDU "not used in this campaign"; EDU 10 is its neutral equivalent here, so
+    // Mental still comes out -2. All seven printed values are within NoiRPG's characteristic
+    // bounds, so this runs against the real ability ruleset.
+    [Theory]
+    [InlineData(SkillCategory.Combat, 3)]         // +2 DEX, +2 STR, -1 INT
+    [InlineData(SkillCategory.Communication, -3)] // -2 INT, 0 POW, -1 CHA
+    [InlineData(SkillCategory.Manipulation, 3)]   // +2 DEX, -1 INT, +2 STR
+    [InlineData(SkillCategory.Mental, -2)]        // -2 INT, 0 POW, 0 EDU
+    [InlineData(SkillCategory.Perception, -1)]    // -2 INT, 0 POW, +1 CON
+    [InlineData(SkillCategory.Physical, 3)]       // +2 DEX, +2 STR, +1 CON, -2 SIZ
+    public void Worked_example_from_chapter_2_page_18_reproduces_every_category_bonus(
+        SkillCategory category, int expected)
+    {
+        var abilities = RealAbilities(
+            ("STR", 14), ("CON", 13), ("INT", 8), ("SIZ", 12),
+            ("POW", 10), ("DEX", 12), ("CHA", 8), ("EDU", 10));
+
+        Assert.Equal(expected, Bonuses.BonusFor(category, abilities));
+    }
+
+    private static AbilitySet RealAbilities(params (string Id, int Value)[] overrides)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 10);
+        foreach (var (id, value) in overrides)
+        {
+            values[new CharacteristicId(id)] = value;
+        }
+
+        return new AbilitySet(ruleset, values);
+    }
+
+    // A permissive ability ruleset (every characteristic 1..infinity) so the full printed Skill
+    // Bonus Table can be reproduced, including the value 1-2 rows that NoiRPG's real minimums put
+    // out of reach. Only the characteristic bounds differ from the shipped data; the bonus math
+    // under test is the shipped policy.
+    private static AbilitySet Neutral(params (string Id, int Value)[] overrides)
+    {
+        var ids = new[] { "STR", "CON", "SIZ", "INT", "POW", "DEX", "CHA", "EDU" };
+        var characteristics = ids.Select(id => new CharacteristicDefinition(
+            new CharacteristicId(id), id, Minimum: 1, Maximum: null, RollName: null));
+        var table = new DamageModifierTable(new[] { new DamageModifierBand(-1000, null, null) });
+        var ruleset = new AbilityRuleset(
+            characteristics, table, startingMovement: 10,
+            minimumCharacteristicRollMultiplier: 1,
+            maximumCharacteristicRollMultiplier: 10,
+            standardCharacteristicRollMultiplier: 5,
+            hitPointDivisor: 2, majorWoundDivisor: 2, experienceBonusDivisor: 2);
+
+        var values = ids.ToDictionary(id => new CharacteristicId(id), _ => 10);
+        foreach (var (id, value) in overrides)
+        {
+            values[new CharacteristicId(id)] = value;
+        }
+
+        return new AbilitySet(ruleset, values);
+    }
+}

--- a/tests/Brp.Rules.Tests/Characters/SkillCategoryBonusApplicationTests.cs
+++ b/tests/Brp.Rules.Tests/Characters/SkillCategoryBonusApplicationTests.cs
@@ -1,0 +1,104 @@
+using Brp.Core.Abilities;
+using Brp.Core.Skills;
+using Brp.Data;
+using Brp.Rules.Characters;
+using Brp.Rules.Creation;
+
+namespace Brp.Rules.Tests.Characters;
+
+/// <summary>
+/// Confirms the ADR 0006 policy is actually applied to a character in the engine (ADR 0022):
+/// a player-built character's effective skill rating is base + category bonus, it recomputes
+/// when a characteristic changes, and it is NOT double-applied to an authored, already-final
+/// effective rating (which stores its base by subtraction). Before #110 the C# builder set every
+/// skill to base + points with no bonus term, so player-built characters silently lacked their
+/// category bonuses; these tests are the regression guard.
+/// </summary>
+public class SkillCategoryBonusApplicationTests
+{
+    private static readonly CharacterCreationRuleset CreationRuleset = NoirCharacterCreationRuleset.Load();
+    private static readonly AbilityRuleset AbilityRuleset = NoirAbilityRuleset.Load();
+    private static readonly SkillRegistry SkillRegistry = NoirSkillRuleset.Load();
+    private static readonly SkillCategoryBonusRuleset Bonuses = NoirSkillCategoryBonusRuleset.Load();
+
+    private static readonly SkillId Brawl = new("Brawl"); // Combat: primary DEX, secondary INT+STR.
+
+    private static Dictionary<CharacteristicId, int> Deltas(params (string Id, int Delta)[] overrides)
+    {
+        var deltas = CreationRuleset.CharacteristicCosts.Keys.ToDictionary(id => id, _ => 0);
+        foreach (var (id, delta) in overrides)
+        {
+            deltas[new CharacteristicId(id)] = delta;
+        }
+
+        return deltas;
+    }
+
+    private static Character Build(params (string Id, int Delta)[] characteristicDeltas) =>
+        new CharacterBuilder(CreationRuleset, AbilityRuleset, SkillRegistry).Build(new CharacterCreationRequest
+        {
+            Id = new CharacterId("pc"),
+            Name = "Test Subject",
+            CharacteristicDeltas = Deltas(characteristicDeltas),
+        });
+
+    [Fact]
+    public void A_player_built_characters_effective_rating_is_base_rating_plus_its_category_bonus()
+    {
+        // DEX 15 (delta +5, costs 15 of 24) -> Combat category bonus +5 (INT/STR neutral).
+        var character = Build(("DEX", 5));
+
+        var brawl = character.Skill(Brawl);
+        Assert.Equal(25, brawl.CurrentRating);                 // base = printed 25% + 0 points
+        Assert.Equal(5, character.CategoryBonus(Brawl, Bonuses));
+        Assert.Equal(30, character.EffectiveRating(Brawl, Bonuses)); // base + bonus, the ADR 0006 rating
+    }
+
+    [Fact]
+    public void With_neutral_characteristics_the_bonus_is_zero_so_effective_equals_base()
+    {
+        var character = Build(); // every characteristic at 10
+
+        Assert.Equal(0, character.CategoryBonus(Brawl, Bonuses));
+        Assert.Equal(character.Skill(Brawl).CurrentRating, character.EffectiveRating(Brawl, Bonuses));
+    }
+
+    [Fact]
+    public void The_effective_rating_recomputes_when_a_characteristic_is_drained()
+    {
+        var character = Build(("DEX", 5)); // DEX 15 -> Combat +5
+        Assert.Equal(30, character.EffectiveRating(Brawl, Bonuses));
+
+        // Poison/injury drains DEX to 8. Ch 2 p.13 requires derived values to move immediately;
+        // ADR 0006 puts the category bonus on the same footing.
+        character.Abilities.Set(new CharacteristicId("DEX"), 8); // -> Combat -2
+
+        Assert.Equal(25, character.Skill(Brawl).CurrentRating);       // base rating is untouched
+        Assert.Equal(-2, character.CategoryBonus(Brawl, Bonuses));
+        Assert.Equal(23, character.EffectiveRating(Brawl, Bonuses));  // recomputed live
+    }
+
+    [Fact]
+    public void An_authored_final_effective_rating_is_reproduced_exactly_and_never_double_bonused()
+    {
+        // Authored content (per ADR 0006 / tools/skill_bonus.py) treats its numbers as FINAL
+        // effective ratings and stores the base by subtraction: base = effective - bonus. A
+        // character with DEX 15 has a +5 Combat bonus, so an authored Brawl 60 stores base 55.
+        var abilities = new AbilitySet(
+            AbilityRuleset,
+            AbilityRuleset.Characteristics.Keys.ToDictionary(
+                id => id, id => id.Value == "DEX" ? 15 : 10));
+        var definition = SkillRegistry[Brawl];
+
+        var authored = CharacterSkill.FromEffectiveRating(definition, effectiveRating: 60, abilities, Bonuses);
+
+        Assert.Equal(55, authored.CurrentRating);                     // base was derived by subtraction
+        Assert.Equal(60, authored.EffectiveRating(abilities, Bonuses)); // reproduces the authored 60 exactly
+
+        // The trap the subtraction avoids: had the authored 60 been stored as a base rating, the
+        // engine would add the +5 bonus a second time and inflate it to 65.
+        var doubleApplied = new CharacterSkill(definition, currentRating: 60);
+        Assert.Equal(65, doubleApplied.EffectiveRating(abilities, Bonuses));
+        Assert.NotEqual(authored.EffectiveRating(abilities, Bonuses), doubleApplied.EffectiveRating(abilities, Bonuses));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #110

## Exact behavioral claim

The skill category bonus mandated by ADR 0006 is now computed in the engine: a `Character`'s effective
skill rating = base + category bonus, derived from the live `AbilitySet` so it **recomputes when a
characteristic changes** (like HP), with authored content protected from double-application via a
base-by-subtraction seam. Previously the bonus existed only in a Python tool, so player-built characters'
effective ratings omitted it.

## Scope

New: `SkillCategoryBonusRuleset` policy + `SkillCategoryModifierSpec` (`Brp.Core.Skills`), the data
(`skill-category-bonus-ruleset.json` + loader, registered in the csproj), `Character.EffectiveRating` /
`CharacterSkill.EffectiveRating` / `FromEffectiveRating`, and ADR 0022. `CurrentRating` stays the base;
the bonus is applied on read, not baked. Skill *data* is unchanged (skills already carry a category).

## Rules conformance

Source: **Ch 2 "Skill Category Bonuses (Option)", pp.18-19** (pages re-verified against the PDF).
`rules-conformance`: formula exact (primary ±1/point-from-10; secondary ±1/2-points, magnitude toward zero;
negative = inverted primary), matching `tools/skill_bonus.py`; the full **Skill Bonus Table (21 rows × 3
columns) and the 6-row category→characteristic table reproduced cell-by-cell**; the book's worked example
(STR14/CON13/INT8/... → Combat +3, Communication −3, Mental −2, ...) confirmed; the no-double-apply
subtraction seam arithmetically sound. No defects, no misattributed citations. All values in the ruleset JSON.

## Tests and evidence

- `dotnet build NoiRPG.slnx` → 0 warnings, 0 errors.
- `dotnet test NoiRPG.slnx` → **2253 passed, 0 failed** (~46 new). Re-run independently.
- `dotnet format NoiRPG.slnx --verify-no-changes` → clean; `tools/skill_bonus.py --check` still passes.

## Decisions and tradeoffs

**This is the computation foundation, not the end-to-end fix.** The effective rating is computed and
exposed but **not yet consumed by any roll pipeline** — `SkillRoll.Resolve`/the CLI take a caller-supplied
chance, and advancement still rolls against base. Wiring effective rating into resolved rolls (and deciding
whether advancement rolls against effective or base) is a **tracked follow-up**, referenced from this PR.
Splitting compute-and-expose (objective, ADR-0006-mandated) from wire-into-resolution (has a design question)
keeps each concern clean. ADR 0022 records this candidly.

## Known limitations

Until the follow-up lands, a player's resolved skill roll does not yet reflect the category bonus — the
number is correct and available but not consumed. Sub-zero effective ratings are unclamped (matches
`skill_bonus.py`; a sub-zero chance always fails at resolution).

## Agent provenance

Implemented by a build agent as `engine-dev` (Claude, via Claude Code) from ADR 0006 + the book + the
verified `skill_bonus.py`. Verified by adversarial `rules-conformance` (formula + full tables + pages — PASS)
and `scope-warden` (data-driven, recompute, no double-apply — PASS; and it flagged the not-yet-consumed
gap, hence the follow-up). Orchestrated at the owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
