### PR TITLE
Add healing & recovery: First Aid, natural healing, Medicine

### DIFF
--- a/docs/decisions/0023-healing-and-recovery.md
+++ b/docs/decisions/0023-healing-and-recovery.md
@@ -1,0 +1,148 @@
+# 0023. Healing & recovery: First Aid per-wound healing, natural healing, Medicine, and the Conditions of Medical Care table
+
+## Status
+
+Accepted — 2026-08-31. Resolves #109 (Layer 4, healing & recovery). Builds on the damage/HP path
+(ADR 0017), the wound damage amount and fatal-wound rescue (ADR 0021, #111), the Layer 1
+derived-characteristic recompute (ADR 0008), and the skill kernel / modifier pipeline (ADR 0007).
+Follows the named-adjudication-port precedent of ADR 0018 (#50), ADR 0019 (#96), and ADR 0021 (#111).
+
+## Context
+
+The engine could damage hit points, add wounds (`Wound.DamageAmount`, #111), and drain
+characteristics (poison/disease, #96), but nothing healed. This record covers the book's recovery
+surface: First Aid's per-wound healing, natural healing over game weeks, the Medicine skill's role,
+and the Conditions of Medical Care table.
+
+Every value below was verified against the printed book text with `pdftotext`, not the issue or
+`engine-implementation-plan.md` (AGENTS.md invariant 2). The issue's original body was superseded by
+its own correction comment on the healing amounts and rates; both were re-checked against the pages.
+The First Aid Special/Critical amounts were the specific audit flag — confirmed against the Ch 3
+First Aid skill description.
+
+## Decision
+
+### First Aid — per-wound healing — sourced
+
+Ch 3: Skills, "First Aid" (p.39): "Base Chance: 30%." A successful roll heals **1D3** hit points "to
+a single wound or injury"; **Special 2D3**; **Critical 3+1D3**. A **Fumble** deals "1 general hit
+point of damage" and heals nothing; a **Failure** heals nothing and "no further First Aid attempts
+may be made." System Notes: healing is capped at "the amount of hit points the injury inflicted," and
+"only one attempt may be made per wound." `HealingResolver.ResolveFirstAid` resolves the roll through
+the skill kernel, then on a healing grade rolls the grade's dice, caps at
+`Wound.DamageAmount` (#111), restores hit points through `AbilitySet.SetCurrentHitPoints` (the same
+path damage removes them by, which clamps at maximum so healing cannot over-heal), and removes the
+healed points from the wound (fully healed → removed; partially → reduced). Entropy order: the d100
+roll, then the grade's healing dice (none on Fumble/Failure).
+
+- **Stacking bonuses — sourced effect, house rounding.** "may add 1/2 of their Medicine skill rating
+  and 1/5 of their Science (Pharmacy) skill rating," and equipment "may add up to a +20% bonus"
+  (p.39). These are supplied as `AdditiveModifier`s of kind **Permanent** — figured into the rating
+  before any Difficult grade halves it (ADR 0007), because the book frames them as bonuses to the
+  rating itself. The fractions **round down** (house choice — the book prints no rounding rule; the
+  numerators/denominators and the +20% cap are all data). "Hazardous or unsanitary conditions may
+  make rolls Difficult" (p.39) is supplied as a `DifficultyModifier.Difficult`.
+- **"Once per wound" is a caller seam — sourced constraint, house boundary.** A single attempt heals
+  up to the whole wound, so the cap is enforced within the call; not re-attempting a wound already
+  First-Aided (or after a Failure/Fumble) is caller-tracked, reported as
+  `FirstAidOutcome.BlocksFurtherAttempts`, the same caller-tracked pattern as #111's same-day totals.
+
+### The fatal-wound rescue is reused, not duplicated — sourced
+
+First Aid's "A character at 0 or negative hit points … can be restored to life if their hit point
+total is brought to 1+" (p.39) **is** the #111 fatal-wound rescue window (Ch 6, "Fatal Wounds",
+p.156). First Aid's only role is to raise hit points; `HealingResolver.ResolvesFatalWoundRescue`
+forwards to `MajorWoundResolver.SurvivesFatalWound` (which itself reuses
+`DamageResolver.ResolvesToDeath` for the death threshold and adds the rescue window). No second copy
+of the death threshold or the window exists.
+
+### Natural healing — flat 1D3/week, reported — sourced
+
+Ch 6, "Healing Naturally" (p.157): "Your character will normally heal 1D3 hit points per game week."
+A **flat** rate, **not** CON-tied (the issue's "tie to CON/Stamina" hint was wrong and is ignored per
+the correction comment). `RollNaturalHealingRate` **reports** the rolled rate; wall-clock accrual over
+weeks is a caller seam (a fresh roll each week — the same "resolver reports the rate, caller applies
+it over time" seam as disease #96). `ApplyWeeklyHealing` removes accrued points from wounds "spreading
+the healing between multiple wounds as evenly as possible" (p.157) — distributed one hit point at a
+time, round-robin, across wounds with remaining damage — and caps the healing that lands at the total
+outstanding wound damage.
+
+### Medicine — doubled rate and characteristic restoration — sourced
+
+Ch 3: Skills, "Medicine" (p.46) / Ch 6 (p.157): "Base Chance: 05%." A success "doubles the healing
+rate from 1D3 to **2D3** hit points per week" (`RollMedicineHealingRate`, reported like natural
+healing). A stabilized poisoned/diseased character "recovers **1D3-1** hit points or characteristic
+points per week" (Success), **1D3** (Special), or **1D3+1** (Critical) — `RollCharacteristicRestorationRate`
+**reports** the grade's rolled rate; `ApplyCharacteristicRestoration` raises the characteristic through
+`AbilitySet.Set` so derived values recompute live (Ch 2, p.13; ADR 0008), capped at the ruleset
+maximum. Major-wound characteristic loss recovers only "through training or various means" (p.156,
+vague) — **not** modeled with an invented clean rate, per the issue's instruction to report rather
+than invent.
+
+- **Restoration does not resurrect clamped hit points — sourced.** Ch 2 (p.13): a reduced maximum
+  clamps current hit points at mutation time, and `AbilitySet.Set` enforces that a later restoration
+  cannot un-clamp them. So restoring CON raises maximum hit points without healing current ones — a
+  tested behavior (`Applying_characteristic_restoration_recomputes_derived_values_via_ability_set`).
+
+### Conditions of Medical Care table — sourced, reproduced row-by-row
+
+Ch 6, "Conditions of Medical Care" (p.157) is data in `Brp.Data/healing-ruleset.json`, loaded into a
+`ConditionsOfMedicalCareTable` / `MedicalCareRow` lookup keyed by `MedicalCareTier`, reproduced **row
+by row** in tests (`NoirHealingRulesetTests`, `[Theory][MemberData]` + an exact-count `[Fact]` = 3
+rows). Natural healing is 1D3/week on every printed row.
+
+| Care tier | Conditions | Effect on healing rate |
+|---|---|---|
+| Poor | Poor/unsanitary/stressful; mobile & exerting; or no care | Caregiver must succeed a **Difficult** First Aid or Medicine roll for any healing. Success → 1D3/week; failure → none; **fumble → 1D3 additional damage**. |
+| Decent | Decent, sanitary, restful, moderate exertion | Heals **1D3** naturally (no roll). |
+| Excellent | Excellent conditions/equipment, full bedrest & therapy, full-time care | Heals **1D3** naturally; a further successful First Aid/Medicine use allows **possible additional healing**. |
+
+`ResolveConditionsOfCare` drives the healing-rate modifier: the poor tier gates all healing behind a
+Difficult caregiver roll (through the skill kernel) and inflicts 1D3 on a fumble; the excellent tier's
+"possible additional healing" is reported as an `AllowsAdditionalHealing` flag — that further use is a
+separate First Aid/Medicine call, and the book prints no additional amount, so none is invented.
+
+### Gamemaster-discretion points become named adjudication ports — following ADR 0018/0019/0021
+
+Two calls the healing rules hand to the gamemaster become first-class ports on a new
+`IHealingAdjudicator` (in `Brp.Core.Contests`), with a `HealingDecisionId` enum, canonical kebab-case
+ids (`HealingDecisionIds.CanonicalId`), and a `DefaultHealingAdjudicator`. Return types are
+`Brp.Core` values (no `Brp.Rules` dependency; AGENTS.md invariant 6).
+
+| Decision id | What the book leaves open | Timing | Default | Source |
+|---|---|---|---|---|
+| `healing-conditions-tier` | Which of the three Conditions of Medical Care tiers the patient's environment falls in | pre-healing | Decent | **sourced** — Ch 6 p.157 |
+| `healing-caregiver` | Who provides care, and therefore whether they roll First Aid or Medicine ("a Difficult First Aid or Medicine roll") | pre-roll | First Aid | **sourced** — Ch 6 p.157 |
+
+- **Sourced ports, house defaults.** Each decision *port* is sourced to the passage that leaves the
+  call open; the *default answers* are a house choice of the most neutral reading (documented on
+  `DefaultHealingAdjudicator`): the middle care tier, and the more broadly trained skill. Tests drive
+  every port with a deterministic stub.
+
+## Out of scope (per `orc-scope-filter.md` and the issue)
+
+Powers / fantastical / futuristic-tech healing (the "make rolls Easy" tech tier is noted but not
+modeled — no equipment tier exists here); surgery / long-term-care simulation beyond the printed
+rules; hit-location-specific healing and the "stop bleeding to a hit location" First Aid effect
+(#112); the fatal-wound rescue *mechanic* itself (#111 — First Aid only triggers it); and any
+wall-clock accrual over game weeks (rates are reported for a clock-aware caller, not simulated). The
+Medicine effect "halts ongoing poison/disease damage" is the #96 drain's stop condition and is not
+re-modeled here.
+
+## Consequences
+
+- `Brp.Rules.Combat` gains `HealingResolver` (with `FirstAidOutcome`, `FirstAidSupport`,
+  `WeeklyHealingRate`, `CharacteristicRestorationRate`, `WoundHealing`, `HealingApplication`,
+  `ConditionsOfCareOutcome`), the `HealingRuleset` / `FirstAidRuleset` / `NaturalHealingRuleset` /
+  `MedicineRuleset` data model, and the `ConditionsOfMedicalCareTable` / `MedicalCareRow` /
+  `HealingRollDifficulty` table model. `Brp.Data` gains `healing-ruleset.json` and
+  `NoirHealingRuleset`. `Brp.Core.Contests` gains `IHealingAdjudicator`,
+  `HealingDecisionId`/`HealingDecisionIds`, `DefaultHealingAdjudicator`, `MedicalCareTier`,
+  `CaregiverSkill`, and `CaregiverRuling`.
+- First Aid heals through the existing `AbilitySet.SetCurrentHitPoints` and `Wound` paths; Medicine
+  characteristic restoration through `AbilitySet.Set` (recompute); the fatal-wound rescue through the
+  #111 `MajorWoundResolver.SurvivesFatalWound` seam. No new HP or death logic is duplicated.
+- Wall-clock accrual, the caregiver's identity/skill, and the environment tier all need
+  caller/GM/time state this resolver does not hold. As in ADR 0018/0019/0021, the resolver computes
+  the recovery and names the open calls; whichever piece orchestrates campaign time wires the ports
+  and the accrual.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -45,3 +45,4 @@ supersedes it — the original is not edited or deleted.
 | [0020](0020-fumble-tables.md) | Combat fumble tables: the four D100 consequence tables, a context-selecting resolver, and the ally/reroll seams | Accepted |
 | [0021](0021-major-wounds.md) | Major Wounds: the wound damage amount, the shock/Luck/table effect, cumulative minors, and the fatal-wound rescue window | Accepted |
 | [0022](0022-skill-category-bonus-application.md) | Skill category bonus applied in the engine as base + category bonus, live-recomputed, by subtraction for authored ratings | Accepted |
+| [0023](0023-healing-and-recovery.md) | Healing & recovery: First Aid per-wound healing, natural healing, Medicine, and the Conditions of Medical Care table | Accepted |

--- a/src/Brp.Core/Contests/IHealingAdjudicator.cs
+++ b/src/Brp.Core/Contests/IHealingAdjudicator.cs
@@ -1,0 +1,140 @@
+namespace Brp.Core.Contests;
+
+/// <summary>
+/// The named gamemaster-adjudication points the Ch 6: Combat, "Healing Naturally" / "Conditions of
+/// Medical Care" rules (p.157) and the First Aid / Medicine skill descriptions (Ch 3, pp.39, 46)
+/// leave open. The healing sibling of <see cref="IInjuryAdjudicator"/> (the Ch 7 injury spot rules,
+/// #96) and <see cref="IMajorWoundAdjudicator"/> (Ch 6 Major Wounds, #111): each member is a call
+/// the healing rules hand to the gamemaster -- which environmental care tier the patient is under,
+/// and who provides the care (and therefore which skill they roll) -- rather than resolving
+/// mechanically. Naming them as first-class ids keeps <c>HealingResolver</c> from silently
+/// hardcoding these calls. The canonical kebab-case id for each is given in its summary and returned
+/// by <see cref="HealingDecisionIds.CanonicalId"/>. See <c>docs/decisions/0023-healing-and-recovery.md</c>.
+/// </summary>
+public enum HealingDecisionId
+{
+    /// <summary>
+    /// Canonical id <c>healing-conditions-tier</c>. Ch 6, "Conditions of Medical Care" (p.157): the
+    /// table "offers guidelines for various conditions and the effect on the healing rate," but which
+    /// of the three tiers (poor, decent, excellent) a patient's actual environment falls in is a
+    /// gamemaster judgment of the fiction (sanitation, rest, exertion, quality of care). A pre-healing
+    /// ruling: it selects the <see cref="Contests.MedicalCareTier"/> row whose effect the resolver
+    /// applies.
+    /// </summary>
+    ConditionsTier,
+
+    /// <summary>
+    /// Canonical id <c>healing-caregiver</c>. Ch 6, "Conditions of Medical Care" (p.157): the poor-tier
+    /// roll is made by the "Caregiver (doctor, nurse, healer, self, etc.)," and the caregiver "must
+    /// succeed in a Difficult First Aid or Medicine roll." Who the caregiver is -- and, consequently,
+    /// whether they apply the First Aid or the Medicine skill (each a legitimate reading of the printed
+    /// "First Aid or Medicine roll") -- is a gamemaster/narrative call. A pre-roll ruling: it selects
+    /// which skill's printed base chance the caregiver's roll resolves against.
+    /// </summary>
+    Caregiver,
+}
+
+/// <summary>Canonical kebab-case ids for the <see cref="HealingDecisionId"/> ports.</summary>
+public static class HealingDecisionIds
+{
+    /// <summary>
+    /// The canonical kebab-case id for <paramref name="decisionId"/> -- the stable string a GM tool,
+    /// authored policy, or log keys on (e.g. <c>healing-conditions-tier</c>), matching the ids named
+    /// in Issue #109 and ADR 0023.
+    /// </summary>
+    public static string CanonicalId(HealingDecisionId decisionId) => decisionId switch
+    {
+        HealingDecisionId.ConditionsTier => "healing-conditions-tier",
+        HealingDecisionId.Caregiver => "healing-caregiver",
+        _ => throw new ArgumentOutOfRangeException(nameof(decisionId), decisionId, "Unknown healing decision id."),
+    };
+}
+
+/// <summary>
+/// The environmental care tier of Ch 6, "Conditions of Medical Care" (p.157), selected by the
+/// <see cref="HealingDecisionId.ConditionsTier"/> ruling. The three printed rows, worst to best.
+/// </summary>
+public enum MedicalCareTier
+{
+    /// <summary>
+    /// Poorly equipped, unsanitary, or stressful conditions; a patient mobile and exerting heavily; or
+    /// no medical care at all. Requires a Difficult First Aid or Medicine roll for any healing (p.157).
+    /// </summary>
+    Poor,
+
+    /// <summary>Decent, sanitary, restful conditions with care and only moderate exertion: heals normally (p.157).</summary>
+    Decent,
+
+    /// <summary>
+    /// Excellent conditions and equipment, full bedrest and therapy, full-time high-quality care: heals
+    /// normally, and a further successful skill use allows possible additional healing (p.157).
+    /// </summary>
+    Excellent,
+}
+
+/// <summary>
+/// Which skill a caregiver applies, for the <see cref="HealingDecisionId.Caregiver"/> ruling
+/// (Ch 6, p.157: "a Difficult First Aid or Medicine roll"). The two skills have different printed
+/// base chances, so the choice changes the 5%-floor behavior of the roll.
+/// </summary>
+public enum CaregiverSkill
+{
+    /// <summary>The caregiver applies the First Aid skill (Ch 3, p.39).</summary>
+    FirstAid,
+
+    /// <summary>The caregiver applies the Medicine skill (Ch 3, p.46).</summary>
+    Medicine,
+}
+
+/// <summary>
+/// The gamemaster's ruling on who provides care, for the <see cref="HealingDecisionId.Caregiver"/>
+/// port (Ch 6, p.157).
+/// </summary>
+/// <param name="Skill">Which skill the caregiver applies to the healing roll.</param>
+public readonly record struct CaregiverRuling(CaregiverSkill Skill);
+
+/// <summary>
+/// A gamemaster-discretion port for the Ch 6 healing rules, modeled -- like
+/// <see cref="IInjuryAdjudicator"/> and <see cref="IMajorWoundAdjudicator"/> -- as a first-class
+/// interface rather than a set of silent hardcoded choices. Each method answers one
+/// <see cref="HealingDecisionId"/> the book leaves open. A GM tool can prompt a human; an unattended
+/// simulation can supply an authored policy; tests supply a deterministic stub. The return types are
+/// ordinary <c>Brp.Core</c> values so this port stays within <c>Brp.Core</c> and does not invert the
+/// layer dependency (AGENTS.md invariant 6). See <c>docs/decisions/0023-healing-and-recovery.md</c>.
+/// </summary>
+public interface IHealingAdjudicator
+{
+    /// <summary>
+    /// Decides which environmental care tier the patient is under
+    /// (<see cref="HealingDecisionId.ConditionsTier"/>). Pre-healing.
+    /// </summary>
+    MedicalCareTier DecideConditionsTier();
+
+    /// <summary>
+    /// Decides who provides care and therefore which skill they roll
+    /// (<see cref="HealingDecisionId.Caregiver"/>). Pre-roll.
+    /// </summary>
+    CaregiverRuling DecideCaregiver();
+}
+
+/// <summary>
+/// The documented default policy for every <see cref="HealingDecisionId"/>: the most
+/// minimal-assumption answer to a call the book leaves open, mirroring
+/// <see cref="DefaultInjuryAdjudicator"/> and <see cref="DefaultMajorWoundAdjudicator"/>. A table with
+/// a house rule or a human gamemaster should supply its own <see cref="IHealingAdjudicator"/> instead.
+/// </summary>
+public sealed class DefaultHealingAdjudicator : IHealingAdjudicator
+{
+    /// <summary>
+    /// Defaults to <see cref="MedicalCareTier.Decent"/> -- the middle tier, which heals normally with
+    /// no gating roll and asserts nothing about the environment beyond "ordinary care," the least
+    /// assuming reading when the book does not say.
+    /// </summary>
+    public MedicalCareTier DecideConditionsTier() => MedicalCareTier.Decent;
+
+    /// <summary>
+    /// Defaults to <see cref="CaregiverSkill.FirstAid"/> -- the more broadly trained of the two skills
+    /// (base chance 30% vs Medicine's 05%), the reading most tables mean by "someone renders aid."
+    /// </summary>
+    public CaregiverRuling DecideCaregiver() => new(CaregiverSkill.FirstAid);
+}

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -27,6 +27,7 @@
     <EmbeddedResource Include="spot-rule-ruleset.json" />
     <EmbeddedResource Include="injury-ruleset.json" />
     <EmbeddedResource Include="major-wound-ruleset.json" />
+    <EmbeddedResource Include="healing-ruleset.json" />
     <EmbeddedResource Include="fumble-ruleset.json" />
   </ItemGroup>
 

--- a/src/Brp.Data/NoirHealingRuleset.cs
+++ b/src/Brp.Data/NoirHealingRuleset.cs
@@ -1,0 +1,142 @@
+using System.Text.Json;
+using Brp.Core.Contests;
+using Brp.Core.Dice;
+using Brp.Rules.Combat;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's healing and recovery values from embedded JSON. Sourced: Ch 3: Skills -- "First Aid"
+/// (p.39) and "Medicine" (p.46) -- and Ch 6: Combat -- "Healing Naturally" and "Conditions of Medical
+/// Care" (p.157). See each field on <see cref="HealingRuleset"/> for its exact citation. Recorded in
+/// <c>docs/decisions/0023-healing-and-recovery.md</c>.
+/// </summary>
+public static class NoirHealingRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable healing ruleset from the shipped data.</summary>
+    public static HealingRuleset Load()
+    {
+        var assembly = typeof(NoirHealingRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.healing-ruleset.json")
+            ?? throw new InvalidOperationException("The healing ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<HealingRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The healing ruleset data is empty.");
+
+        return new HealingRuleset(
+            BuildFirstAid(data.FirstAid),
+            BuildNaturalHealing(data.NaturalHealing),
+            BuildMedicine(data.Medicine),
+            BuildConditionsOfMedicalCare(data.ConditionsOfMedicalCare));
+    }
+
+    private static FirstAidRuleset BuildFirstAid(FirstAidData data) => new(
+        printedBaseChancePercent: data.PrintedBaseChancePercent,
+        successHealing: DiceExpression.Parse(data.SuccessHealingFormula),
+        specialHealing: DiceExpression.Parse(data.SpecialHealingFormula),
+        criticalHealing: DiceExpression.Parse(data.CriticalHealingFormula),
+        fumbleSelfDamage: data.FumbleSelfDamage,
+        medicineBonusNumerator: data.MedicineBonusNumerator,
+        medicineBonusDenominator: data.MedicineBonusDenominator,
+        sciencePharmacyBonusNumerator: data.SciencePharmacyBonusNumerator,
+        sciencePharmacyBonusDenominator: data.SciencePharmacyBonusDenominator,
+        equipmentBonusMaxPercent: data.EquipmentBonusMaxPercent);
+
+    private static NaturalHealingRuleset BuildNaturalHealing(NaturalHealingData data) =>
+        new(weeklyRate: DiceExpression.Parse(data.WeeklyRateFormula));
+
+    private static MedicineRuleset BuildMedicine(MedicineData data) => new(
+        printedBaseChancePercent: data.PrintedBaseChancePercent,
+        doubledWeeklyRate: DiceExpression.Parse(data.DoubledWeeklyRateFormula),
+        characteristicRestorationSuccess: DiceExpression.Parse(data.CharacteristicRestorationSuccessFormula),
+        characteristicRestorationSpecial: DiceExpression.Parse(data.CharacteristicRestorationSpecialFormula),
+        characteristicRestorationCritical: DiceExpression.Parse(data.CharacteristicRestorationCriticalFormula));
+
+    private static ConditionsOfMedicalCareTable BuildConditionsOfMedicalCare(
+        IReadOnlyList<MedicalCareRowData> rows)
+    {
+        var built = rows.Select(row => new MedicalCareRow(
+            Enum.Parse<MedicalCareTier>(row.Tier),
+            row.Conditions,
+            row.RequiresCaregiverRoll,
+            Enum.Parse<HealingRollDifficulty>(row.CaregiverRollDifficulty),
+            DiceExpression.Parse(row.NaturalHealingFormula),
+            row.FumbleAdditionalDamageFormula is null ? null : DiceExpression.Parse(row.FumbleAdditionalDamageFormula),
+            row.AllowsAdditionalHealing));
+
+        return new ConditionsOfMedicalCareTable(built);
+    }
+
+    private sealed class HealingRulesetData
+    {
+        public required FirstAidData FirstAid { get; init; }
+
+        public required NaturalHealingData NaturalHealing { get; init; }
+
+        public required MedicineData Medicine { get; init; }
+
+        public required IReadOnlyList<MedicalCareRowData> ConditionsOfMedicalCare { get; init; }
+    }
+
+    private sealed class FirstAidData
+    {
+        public required int PrintedBaseChancePercent { get; init; }
+
+        public required string SuccessHealingFormula { get; init; }
+
+        public required string SpecialHealingFormula { get; init; }
+
+        public required string CriticalHealingFormula { get; init; }
+
+        public required int FumbleSelfDamage { get; init; }
+
+        public required int MedicineBonusNumerator { get; init; }
+
+        public required int MedicineBonusDenominator { get; init; }
+
+        public required int SciencePharmacyBonusNumerator { get; init; }
+
+        public required int SciencePharmacyBonusDenominator { get; init; }
+
+        public required int EquipmentBonusMaxPercent { get; init; }
+    }
+
+    private sealed class NaturalHealingData
+    {
+        public required string WeeklyRateFormula { get; init; }
+    }
+
+    private sealed class MedicineData
+    {
+        public required int PrintedBaseChancePercent { get; init; }
+
+        public required string DoubledWeeklyRateFormula { get; init; }
+
+        public required string CharacteristicRestorationSuccessFormula { get; init; }
+
+        public required string CharacteristicRestorationSpecialFormula { get; init; }
+
+        public required string CharacteristicRestorationCriticalFormula { get; init; }
+    }
+
+    private sealed class MedicalCareRowData
+    {
+        public required string Tier { get; init; }
+
+        public required string Conditions { get; init; }
+
+        public required bool RequiresCaregiverRoll { get; init; }
+
+        public required string CaregiverRollDifficulty { get; init; }
+
+        public required string NaturalHealingFormula { get; init; }
+
+        public string? FumbleAdditionalDamageFormula { get; init; }
+
+        public required bool AllowsAdditionalHealing { get; init; }
+    }
+}

--- a/src/Brp.Data/healing-ruleset.json
+++ b/src/Brp.Data/healing-ruleset.json
@@ -1,0 +1,62 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 6: Combat (Damage & Healing) and Chapter 3: Skills",
+    "notes": "Healing and recovery (#109): First Aid's per-wound healing (Ch 3, First Aid, p.39), natural healing (Ch 6, Healing Naturally, p.157), the Medicine skill's doubled rate and characteristic restoration (Ch 3, Medicine, p.46; p.157), and the Conditions of Medical Care Table (p.157, reproduced row by row). All values verified against the printed book text. See docs/decisions/0023-healing-and-recovery.md."
+  },
+  "firstAid": {
+    "printedBaseChancePercent": 30,
+    "successHealingFormula": "1D3",
+    "specialHealingFormula": "2D3",
+    "criticalHealingFormula": "3+1D3",
+    "fumbleSelfDamage": 1,
+    "medicineBonusNumerator": 1,
+    "medicineBonusDenominator": 2,
+    "sciencePharmacyBonusNumerator": 1,
+    "sciencePharmacyBonusDenominator": 5,
+    "equipmentBonusMaxPercent": 20,
+    "notes": "Ch 3, First Aid (p.39): Base Chance 30%. Success heals 1D3 to a single wound, Special 2D3, Critical 3+1D3; Fumble deals 1 general hit point; Failure blocks further attempts. May add 1/2 Medicine + 1/5 Science(Pharmacy) + up to +20% equipment to the roll. Healing is capped at the wound's inflicted damage, one attempt per wound (System Notes)."
+  },
+  "naturalHealing": {
+    "weeklyRateFormula": "1D3",
+    "notes": "Ch 6, Healing Naturally (p.157): a flat 1D3 hit points per game week (the normal healing rate), NOT tied to CON. Rolled fresh each week; recovered points removed from wounds, spread as evenly as possible."
+  },
+  "medicine": {
+    "printedBaseChancePercent": 5,
+    "doubledWeeklyRateFormula": "2D3",
+    "characteristicRestorationSuccessFormula": "1D3-1",
+    "characteristicRestorationSpecialFormula": "1D3",
+    "characteristicRestorationCriticalFormula": "1D3+1",
+    "notes": "Ch 3, Medicine (p.46) / Ch 6 (p.157): Base Chance 05%. Success doubles the weekly healing rate from 1D3 to 2D3; a stabilized poisoned/diseased character recovers 1D3-1 hit points or characteristic points per week (Success), 1D3 (Special), or 1D3+1 (Critical)."
+  },
+  "conditionsOfMedicalCareTableSource": "Ch 6, Conditions of Medical Care (p.157), transcribed row by row (three tiers). Each row's effect on the weekly healing rate is data; the descriptive Medical Conditions cell is summarized. Natural healing is 1D3/week on every row.",
+  "conditionsOfMedicalCare": [
+    {
+      "tier": "Poor",
+      "conditions": "Poorly equipped, unsanitary, and/or stressful; patient mobile and exerting heavily (combat, rugged travel); or receiving no medical care.",
+      "requiresCaregiverRoll": true,
+      "caregiverRollDifficulty": "Difficult",
+      "naturalHealingFormula": "1D3",
+      "fumbleAdditionalDamageFormula": "1D3",
+      "allowsAdditionalHealing": false
+    },
+    {
+      "tier": "Decent",
+      "conditions": "Decent and sanitary conditions, restful environment, care provided, only moderate physical exertion.",
+      "requiresCaregiverRoll": false,
+      "caregiverRollDifficulty": "None",
+      "naturalHealingFormula": "1D3",
+      "fumbleAdditionalDamageFormula": null,
+      "allowsAdditionalHealing": false
+    },
+    {
+      "tier": "Excellent",
+      "conditions": "Excellent conditions and equipment, environment conducive to healing, full bedrest and therapy, full-time high-quality medical care.",
+      "requiresCaregiverRoll": false,
+      "caregiverRollDifficulty": "None",
+      "naturalHealingFormula": "1D3",
+      "fumbleAdditionalDamageFormula": null,
+      "allowsAdditionalHealing": true
+    }
+  ]
+}

--- a/src/Brp.Rules/Combat/ConditionsOfMedicalCareTable.cs
+++ b/src/Brp.Rules/Combat/ConditionsOfMedicalCareTable.cs
@@ -1,0 +1,39 @@
+using Brp.Core.Contests;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Data-backed lookup for Ch 6: Combat, "Conditions of Medical Care" (p.157). The three printed rows
+/// (poor, decent, excellent) are represented as <see cref="MedicalCareRow"/> entries, cross-indexed by
+/// <see cref="MedicalCareTier"/>. Mirrors <see cref="MajorWoundTable"/> / <see cref="IllnessSeverityTable"/>.
+/// </summary>
+public sealed class ConditionsOfMedicalCareTable
+{
+    private readonly List<MedicalCareRow> _rows;
+
+    /// <summary>Creates a table from ordered ruleset rows (one per care tier).</summary>
+    public ConditionsOfMedicalCareTable(IEnumerable<MedicalCareRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        _rows = rows.ToList();
+        if (_rows.Count == 0)
+        {
+            throw new ArgumentException("Conditions of medical care table must contain at least one row.", nameof(rows));
+        }
+
+        var duplicateTier = _rows.GroupBy(row => row.Tier).FirstOrDefault(group => group.Count() > 1);
+        if (duplicateTier is not null)
+        {
+            throw new ArgumentException(
+                $"Conditions of medical care table has more than one row for tier '{duplicateTier.Key}'.", nameof(rows));
+        }
+    }
+
+    /// <summary>Every printed row, in load order.</summary>
+    public IReadOnlyList<MedicalCareRow> Rows => _rows;
+
+    /// <summary>Returns the row for the given care tier.</summary>
+    public MedicalCareRow ForTier(MedicalCareTier tier) =>
+        _rows.SingleOrDefault(row => row.Tier == tier)
+            ?? throw new ArgumentOutOfRangeException(nameof(tier), tier, "No conditions-of-care row covers this tier.");
+}

--- a/src/Brp.Rules/Combat/HealingResolver.cs
+++ b/src/Brp.Rules/Combat/HealingResolver.cs
@@ -1,0 +1,586 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+using Brp.Core.Modifiers;
+using Brp.Core.Primitives;
+using Brp.Core.Randomness;
+using Brp.Core.Resolution;
+using Brp.Rules.Characters;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Resolves Ch 6: Combat healing and recovery (#109): First Aid's per-wound healing (Ch 3, p.39),
+/// natural healing (p.157), the Medicine skill's doubled rate and characteristic restoration (Ch 3,
+/// p.46; p.157), and the Conditions of Medical Care Table (p.157). The injure->heal counterpart to
+/// <see cref="DamageResolver"/> / <see cref="MajorWoundResolver"/>: healing restores hit points
+/// through the same <see cref="AbilitySet.SetCurrentHitPoints"/> path damage removes them by, removes
+/// the recovered points from the recorded <see cref="Wound"/>s, and restores drained characteristics
+/// through <see cref="AbilitySet.Set"/> so derived values recompute live (Ch 2, p.13; ADR 0008).
+/// First Aid and Medicine rolls resolve through the skill kernel (<see cref="ModifierPipeline"/> +
+/// <see cref="SkillResolver"/>), with the printed +1/2 Medicine / +1/5 Science(Pharmacy) / +20%
+/// equipment bonuses and any hazardous-conditions Difficult grade supplied as modifiers. See
+/// <c>docs/decisions/0023-healing-and-recovery.md</c>.
+/// <para>
+/// <strong>Rates are reported; wall-clock accrual is a caller seam.</strong> Natural healing (1D3/game
+/// week) and Medicine's doubled (2D3/week) and characteristic-restoration (1D3-1/week) rates accrue
+/// over campaign time this layer does not model, so <see cref="RollNaturalHealingRate"/>,
+/// <see cref="RollMedicineHealingRate"/>, and <see cref="RollCharacteristicRestorationRate"/> report a
+/// rolled rate that a clock-aware caller applies via <see cref="ApplyWeeklyHealing"/> /
+/// <see cref="ApplyCharacteristicRestoration"/> -- the same "resolver reports the rate, caller applies
+/// it over time" seam as disease/poison (#96). First Aid, by contrast, is immediate and applies its
+/// own healing.
+/// </para>
+/// <para>
+/// <strong>The fatal-wound rescue is reused, not duplicated.</strong> First Aid's "restore a character
+/// at 0 or negative hit points to life if their total is brought to 1+" (Ch 3, p.39) is exactly the
+/// #111 fatal-wound rescue window (Ch 6, p.156): First Aid raises hit points, and
+/// <see cref="ResolvesFatalWoundRescue"/> forwards to <see cref="MajorWoundResolver.SurvivesFatalWound"/>
+/// (which itself reuses <see cref="DamageResolver.ResolvesToDeath"/>) to decide survival -- no second
+/// copy of the death threshold or the rescue window.
+/// </para>
+/// </summary>
+public static class HealingResolver
+{
+    /// <summary>
+    /// Resolves and applies a First Aid attempt on a single wound, per Ch 3: Skills, "First Aid"
+    /// (p.39). The roll resolves through the skill kernel with the support bonuses (+1/2 Medicine,
+    /// +1/5 Science(Pharmacy), +20% equipment) figured into the rating and any hazardous-conditions
+    /// Difficult grade halving it. On a healing grade the rolled amount (Success 1D3, Special 2D3,
+    /// Critical 3+1D3) is capped at the wound's <see cref="Wound.DamageAmount"/> ("potentially healing
+    /// it up to the amount of hit points the injury inflicted", System Notes, p.39), the hit points are
+    /// restored through <see cref="AbilitySet.SetCurrentHitPoints"/>, and the healed points are removed
+    /// from the wound (fully healed -> removed; partially -> reduced). A Fumble deals
+    /// <see cref="FirstAidRuleset.FumbleSelfDamage"/> (1 hit point) and heals nothing; a Failure heals
+    /// nothing. Both a Failure and a Fumble set <see cref="FirstAidOutcome.BlocksFurtherAttempts"/> --
+    /// "no further First Aid attempts may be made" (p.39).
+    /// <para>
+    /// Consumes entropy in a fixed order: the First Aid d100 roll; then, only on a healing grade, the
+    /// grade's healing dice. A Fumble and a Failure consume only the d100.
+    /// </para>
+    /// </summary>
+    /// <param name="firstAidRating">The caregiver's current First Aid rating.</param>
+    /// <param name="support">The stacking support bonuses and hazardous-conditions flag.</param>
+    /// <param name="wound">The single wound being treated (its <see cref="Wound.DamageAmount"/> caps the heal).</param>
+    /// <param name="patient">The wounded character (hit points restored through the existing HP path).</param>
+    /// <param name="wounds">The patient's wound track (the treated wound is reduced or removed).</param>
+    /// <param name="ruleset">The healing values.</param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    public static FirstAidOutcome ResolveFirstAid(
+        Percent firstAidRating,
+        FirstAidSupport support,
+        Wound wound,
+        AbilitySet patient,
+        WoundTrack wounds,
+        HealingRuleset ruleset,
+        IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(wound);
+        ArgumentNullException.ThrowIfNull(patient);
+        ArgumentNullException.ThrowIfNull(wounds);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var roll = ResolveFirstAidRoll(firstAidRating, support, ruleset, entropy);
+
+        if (roll.Level == SuccessLevel.Fumble)
+        {
+            // "Fumble: The patient takes 1 general hit point of damage" (p.39): removed through the same
+            // HP path damage uses, recording no new wound (the condition is unchanged).
+            var damage = ruleset.FirstAid.FumbleSelfDamage;
+            patient.SetCurrentHitPoints(patient.CurrentHitPoints - damage);
+            return new FirstAidOutcome(
+                roll, HealedHitPoints: 0, SelfDamage: damage, WoundFullyHealed: false,
+                BlocksFurtherAttempts: true, patient.CurrentHitPoints);
+        }
+
+        if (!roll.Succeeded)
+        {
+            // "Failure: No effect, and no further First Aid attempts may be made" (p.39).
+            return new FirstAidOutcome(
+                roll, HealedHitPoints: 0, SelfDamage: 0, WoundFullyHealed: false,
+                BlocksFurtherAttempts: true, patient.CurrentHitPoints);
+        }
+
+        var healingDice = roll.Level switch
+        {
+            SuccessLevel.Critical => ruleset.FirstAid.CriticalHealing,
+            SuccessLevel.Special => ruleset.FirstAid.SpecialHealing,
+            _ => ruleset.FirstAid.SuccessHealing,
+        };
+
+        // Capped at the hit points this wound inflicted (System Notes, p.39). One attempt per wound, so
+        // the cap is the whole wound damage rather than a running per-wound tally kept across calls --
+        // "once per wound" is the caller's not-again seam (see the outcome remarks).
+        var rolled = healingDice.Roll(entropy).Total;
+        var healed = Math.Min(rolled, wound.DamageAmount);
+
+        patient.SetCurrentHitPoints(patient.CurrentHitPoints + healed);
+        var fullyHealed = ReduceWound(wounds, wound, healed);
+
+        return new FirstAidOutcome(
+            roll, healed, SelfDamage: 0, fullyHealed, BlocksFurtherAttempts: false, patient.CurrentHitPoints);
+    }
+
+    /// <summary>
+    /// Whether a fatally wounded character (0 or negative hit points) survives after First Aid (or any
+    /// other aid) has restored hit points, per Ch 3: Skills, "First Aid" (p.39: "A character at 0 or
+    /// negative hit points in this or the previous round, can be restored to life if their hit point
+    /// total is brought to 1+") and Ch 6, "Fatal Wounds" (p.156). This does not re-implement the
+    /// rescue: it forwards to <see cref="MajorWoundResolver.SurvivesFatalWound"/> (built in #111),
+    /// which reuses <see cref="DamageResolver.ResolvesToDeath"/> for the death threshold and adds the
+    /// rescue window. First Aid's only job is to raise <paramref name="patient"/>'s hit points (via
+    /// <see cref="ResolveFirstAid"/>) before this is checked.
+    /// </summary>
+    /// <param name="patient">The character, whose current hit points already reflect the aid.</param>
+    /// <param name="roundsSinceFatalWound">0 is the wound round, 1 the round immediately after.</param>
+    /// <param name="majorWoundRuleset">Supplies the rescue-window length (#111).</param>
+    /// <param name="damageRuleset">Supplies the dead hit-point level (Ch 2, p.13; Ch 6, p.156).</param>
+    public static bool ResolvesFatalWoundRescue(
+        AbilitySet patient,
+        int roundsSinceFatalWound,
+        MajorWoundRuleset majorWoundRuleset,
+        DamageRuleset damageRuleset)
+    {
+        ArgumentNullException.ThrowIfNull(patient);
+        return MajorWoundResolver.SurvivesFatalWound(
+            patient.CurrentHitPoints, roundsSinceFatalWound, majorWoundRuleset, damageRuleset);
+    }
+
+    /// <summary>
+    /// Rolls and reports the flat natural healing rate for one game week, per Ch 6, "Healing Naturally"
+    /// (p.157): "Your character will normally heal 1D3 hit points per game week." Reports the rate only
+    /// -- the accrual over weeks, and applying the recovered points to wounds, is a caller seam
+    /// (<see cref="ApplyWeeklyHealing"/>); a fresh roll is made each week, so the rate can vary. The
+    /// rate is flat and not tied to CON.
+    /// </summary>
+    public static WeeklyHealingRate RollNaturalHealingRate(HealingRuleset ruleset, IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+        return new WeeklyHealingRate(ruleset.NaturalHealing.WeeklyRate.Roll(entropy).Total, Doubled: false);
+    }
+
+    /// <summary>
+    /// Rolls and reports the Medicine-doubled healing rate for one game week, per Ch 3: Skills,
+    /// "Medicine" (p.46) / Ch 6 (p.157): "The patient's healing rate doubles from 1D3 to 2D3 hit points
+    /// per week." Reports the rate only -- accrual is a caller seam (<see cref="ApplyWeeklyHealing"/>),
+    /// the same as natural healing. A successful Medicine roll is the caller's precondition for choosing
+    /// this effect (Medicine offers several success effects, player choice); this method rolls the rate
+    /// that choice yields.
+    /// </summary>
+    public static WeeklyHealingRate RollMedicineHealingRate(HealingRuleset ruleset, IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+        return new WeeklyHealingRate(ruleset.Medicine.DoubledWeeklyRate.Roll(entropy).Total, Doubled: true);
+    }
+
+    /// <summary>
+    /// Applies <paramref name="hitPoints"/> of accrued healing to <paramref name="patient"/>, removing
+    /// the recovered points from existing wounds "spreading the healing between multiple wounds as
+    /// evenly as possible" (Ch 6, "Healing Naturally", p.157), and restoring the character's hit points
+    /// through <see cref="AbilitySet.SetCurrentHitPoints"/>. The healing that lands is capped at the
+    /// total outstanding wound damage (a character with no wounds recovers nothing to apply). Points
+    /// are distributed one at a time, round-robin, across the wounds that still have damage, so the
+    /// spread is as even as the wound sizes allow. Fully healed wounds are removed; partially healed
+    /// wounds are reduced.
+    /// </summary>
+    /// <param name="patient">The healing character (hit points restored through the existing HP path).</param>
+    /// <param name="wounds">The patient's wound track (recovered points removed from wounds).</param>
+    /// <param name="hitPoints">The accrued hit points to apply (e.g. a reported weekly rate).</param>
+    public static HealingApplication ApplyWeeklyHealing(AbilitySet patient, WoundTrack wounds, int hitPoints)
+    {
+        ArgumentNullException.ThrowIfNull(patient);
+        ArgumentNullException.ThrowIfNull(wounds);
+        ArgumentOutOfRangeException.ThrowIfNegative(hitPoints);
+
+        // Work against a mutable copy of the current wound damages, distributing 1 HP at a time across
+        // the wounds that still have capacity so the spread is as even as possible (p.157).
+        var remaining = wounds.Wounds.Select(w => new WoundHealingState(w, w.DamageAmount)).ToList();
+        var toApply = Math.Min(hitPoints, remaining.Sum(w => w.RemainingDamage));
+        var applied = 0;
+
+        while (applied < toApply)
+        {
+            var progressedThisPass = false;
+            foreach (var state in remaining)
+            {
+                if (applied >= toApply)
+                {
+                    break;
+                }
+
+                if (state.RemainingDamage <= 0)
+                {
+                    continue;
+                }
+
+                state.RemainingDamage--;
+                applied++;
+                progressedThisPass = true;
+            }
+
+            if (!progressedThisPass)
+            {
+                break;
+            }
+        }
+
+        // Commit: restore the character's hit points, then reconcile the wound track.
+        patient.SetCurrentHitPoints(patient.CurrentHitPoints + applied);
+
+        var perWound = new List<WoundHealing>();
+        foreach (var state in remaining)
+        {
+            var healedOnThisWound = state.Original.DamageAmount - state.RemainingDamage;
+            if (healedOnThisWound == 0)
+            {
+                continue;
+            }
+
+            var fullyHealed = state.RemainingDamage == 0;
+            wounds.Remove(state.Original);
+            if (!fullyHealed)
+            {
+                wounds.Add(new Wound(state.Original.Description, state.RemainingDamage));
+            }
+
+            perWound.Add(new WoundHealing(state.Original, healedOnThisWound, fullyHealed));
+        }
+
+        return new HealingApplication(applied, perWound, patient.CurrentHitPoints);
+    }
+
+    /// <summary>
+    /// Rolls and reports the Medicine-gated characteristic restoration rate for one week, per Ch 3:
+    /// Skills, "Medicine" (p.46): a stabilized poisoned/diseased character "recovers 1D3-1 hit points or
+    /// characteristic points per week" (Success), "1D3 characteristic points" (Special), or "1D3+1
+    /// characteristic points" (Critical). Reports the rolled rate only -- applying it to a characteristic
+    /// (and accruing it week to week) is a caller seam (<see cref="ApplyCharacteristicRestoration"/>),
+    /// since the recovery accrues over campaign time this layer does not model. Major-wound
+    /// characteristic loss recovers only "through training or various means" (p.156, vague) -- this
+    /// method does not model that; it reports the Medicine-gated rate the book prints.
+    /// </summary>
+    /// <param name="grade">The grade of the successful Medicine roll (drives which formula is rolled).</param>
+    /// <param name="ruleset">The healing values.</param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    public static CharacteristicRestorationRate RollCharacteristicRestorationRate(
+        SuccessLevel grade, HealingRuleset ruleset, IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+        if (grade < SuccessLevel.Success)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(grade), grade, "Characteristic restoration requires a successful Medicine roll.");
+        }
+
+        var dice = grade switch
+        {
+            SuccessLevel.Critical => ruleset.Medicine.CharacteristicRestorationCritical,
+            SuccessLevel.Special => ruleset.Medicine.CharacteristicRestorationSpecial,
+            _ => ruleset.Medicine.CharacteristicRestorationSuccess,
+        };
+
+        return new CharacteristicRestorationRate(grade, dice.Roll(entropy).Total);
+    }
+
+    /// <summary>
+    /// Applies <paramref name="points"/> of accrued characteristic restoration to
+    /// <paramref name="characteristic"/> through <see cref="AbilitySet.Set"/> so the Layer 1 derived
+    /// characteristics (hit points, major-wound level, skill category modifiers) recompute live (Ch 2,
+    /// p.13; ADR 0008) -- the same recompute path the #96 injury drain lowers a characteristic by, run
+    /// in reverse. The new value is capped at the characteristic's ruleset maximum where one is defined
+    /// (a characteristic cannot be restored above its allowed ceiling); restoring only up to the
+    /// pre-drain value is the caller's concern (this layer does not remember the original). Returns the
+    /// resulting characteristic value. Note (Ch 2, p.13): restoring a characteristic does not resurrect
+    /// a current-hit-point total already clamped by an earlier reduction -- <see cref="AbilitySet"/>
+    /// enforces that, so a restored CON raises maximum hit points without healing current ones.
+    /// </summary>
+    public static int ApplyCharacteristicRestoration(AbilitySet patient, CharacteristicId characteristic, int points)
+    {
+        ArgumentNullException.ThrowIfNull(patient);
+        ArgumentOutOfRangeException.ThrowIfNegative(points);
+
+        if (!patient.Ruleset.Characteristics.TryGetValue(characteristic, out var definition))
+        {
+            throw new KeyNotFoundException($"Unknown characteristic '{characteristic}'.");
+        }
+
+        var raised = patient.ValueOf(characteristic) + points;
+        var capped = definition.Maximum is int maximum ? Math.Min(raised, maximum) : raised;
+        patient.Set(characteristic, capped);
+        return capped;
+    }
+
+    /// <summary>
+    /// Resolves the healing a Conditions of Medical Care tier grants for one week, per Ch 6:
+    /// "Conditions of Medical Care" (p.157), and applies it to <paramref name="patient"/>. The three
+    /// printed tiers:
+    /// <list type="bullet">
+    /// <item><description>
+    /// <strong>Poor</strong> -- the caregiver must succeed a Difficult First Aid or Medicine roll for
+    /// any healing. Success heals the row's natural rate (1D3); Failure heals nothing; a Fumble instead
+    /// deals the row's additional damage (1D3). The roll resolves through the skill kernel with the
+    /// Difficult grade applied.
+    /// </description></item>
+    /// <item><description><strong>Decent</strong> -- heals the row's natural rate (1D3) with no roll.</description></item>
+    /// <item><description>
+    /// <strong>Excellent</strong> -- heals the row's natural rate (1D3) with no roll, and reports that a
+    /// further successful First Aid or Medicine use allows possible additional healing (that additional
+    /// use is a separate <see cref="ResolveFirstAid"/> / Medicine call -- the book prints no amount, so
+    /// this does not invent one).
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// Consumes entropy in a fixed order: for the poor tier, the caregiver d100 roll first, then (only
+    /// on success) the natural-healing dice or (only on a fumble) the additional-damage dice; for the
+    /// decent and excellent tiers, only the natural-healing dice.
+    /// </para>
+    /// </summary>
+    /// <param name="tier">The care tier (an <see cref="IHealingAdjudicator.DecideConditionsTier"/> ruling).</param>
+    /// <param name="caregiverRating">
+    /// The caregiver's current rating in whichever skill they apply (an
+    /// <see cref="IHealingAdjudicator.DecideCaregiver"/> ruling). Used only by the poor tier's gating roll.
+    /// </param>
+    /// <param name="caregiverPrintedBaseChance">
+    /// The printed base chance of the caregiver's chosen skill (First Aid 30% or Medicine 05%), for the
+    /// 5%-floor rule. Used only by the poor tier's gating roll.
+    /// </param>
+    /// <param name="patient">The healing character.</param>
+    /// <param name="wounds">The patient's wound track.</param>
+    /// <param name="ruleset">The healing values (the Conditions of Medical Care table).</param>
+    /// <param name="entropy">The entropy source, per AGENTS.md invariant 5.</param>
+    public static ConditionsOfCareOutcome ResolveConditionsOfCare(
+        MedicalCareTier tier,
+        Percent caregiverRating,
+        Percent caregiverPrintedBaseChance,
+        AbilitySet patient,
+        WoundTrack wounds,
+        HealingRuleset ruleset,
+        IEntropySource entropy)
+    {
+        ArgumentNullException.ThrowIfNull(patient);
+        ArgumentNullException.ThrowIfNull(wounds);
+        ArgumentNullException.ThrowIfNull(ruleset);
+        ArgumentNullException.ThrowIfNull(entropy);
+
+        var row = ruleset.ConditionsOfMedicalCare.ForTier(tier);
+
+        if (!row.RequiresCaregiverRoll)
+        {
+            // Decent / Excellent: heal the natural rate with no gating roll.
+            var healingRate = row.NaturalHealing.Roll(entropy).Total;
+            var application = ApplyWeeklyHealing(patient, wounds, healingRate);
+            return new ConditionsOfCareOutcome(
+                tier, CaregiverRoll: null, HealingRate: healingRate, application, AdditionalDamage: 0,
+                row.AllowsAdditionalHealing);
+        }
+
+        // Poor: a Difficult First Aid or Medicine roll gates all healing.
+        var modifiers = row.CaregiverRollDifficulty == HealingRollDifficulty.Difficult
+            ? new Modifier[] { DifficultyModifier.Difficult($"conditions of medical care: {tier}") }
+            : [];
+        var caregiverRoll = ModifierPipeline.Evaluate(caregiverRating, modifiers)
+            .Resolve(caregiverPrintedBaseChance, entropy)
+            ?? throw new InvalidOperationException("The conditions-of-care caregiver roll was unexpectedly gated.");
+
+        if (caregiverRoll.Level == SuccessLevel.Fumble)
+        {
+            // "A fumble inflicts 1D3 additional hit points in damage" (p.157): applied through the
+            // non-weapon damage path so hit-point tracking and the wound record are identical to any
+            // other injury.
+            var additionalDamage = row.FumbleAdditionalDamage is null
+                ? 0
+                : row.FumbleAdditionalDamage.Roll(entropy).Total;
+            if (additionalDamage > 0)
+            {
+                patient.SetCurrentHitPoints(patient.CurrentHitPoints - additionalDamage);
+            }
+
+            return new ConditionsOfCareOutcome(
+                tier, caregiverRoll, HealingRate: 0, Application: null, additionalDamage, AllowsAdditionalHealing: false);
+        }
+
+        if (!caregiverRoll.Succeeded)
+        {
+            // "if unsuccessful no healing occurs" (p.157).
+            return new ConditionsOfCareOutcome(
+                tier, caregiverRoll, HealingRate: 0, Application: null, AdditionalDamage: 0, AllowsAdditionalHealing: false);
+        }
+
+        // "If successful, the patient heals normally (1D3 hit points/week)" (p.157).
+        var rate = row.NaturalHealing.Roll(entropy).Total;
+        var applied = ApplyWeeklyHealing(patient, wounds, rate);
+        return new ConditionsOfCareOutcome(
+            tier, caregiverRoll, rate, applied, AdditionalDamage: 0, row.AllowsAdditionalHealing);
+    }
+
+    private static RollOutcome ResolveFirstAidRoll(
+        Percent firstAidRating, FirstAidSupport support, HealingRuleset ruleset, IEntropySource entropy)
+    {
+        var firstAid = ruleset.FirstAid;
+        var modifiers = new List<Modifier>();
+
+        // "may add 1/2 of their Medicine skill rating and 1/5 of their Science (Pharmacy) skill rating
+        // as a temporary bonus" (p.39). These are bonuses to the rating itself (part of what the
+        // caregiver brings), so they are Permanent -- figured in before any hazardous-conditions
+        // Difficult grade halves the roll (ADR 0007). The fractions round down (house choice -- the
+        // book prints no rounding; see ADR 0023).
+        var medicineBonus = Rounding.Divide(
+            support.MedicineRating * firstAid.MedicineBonusNumerator, firstAid.MedicineBonusDenominator, RoundingMode.Down);
+        if (medicineBonus > 0)
+        {
+            modifiers.Add(new AdditiveModifier("+1/2 Medicine", medicineBonus, AdditiveKind.Permanent));
+        }
+
+        var pharmacyBonus = Rounding.Divide(
+            support.SciencePharmacyRating * firstAid.SciencePharmacyBonusNumerator,
+            firstAid.SciencePharmacyBonusDenominator,
+            RoundingMode.Down);
+        if (pharmacyBonus > 0)
+        {
+            modifiers.Add(new AdditiveModifier("+1/5 Science (Pharmacy)", pharmacyBonus, AdditiveKind.Permanent));
+        }
+
+        // Equipment "may add up to a +20% bonus" (p.39): the caller supplies the actual bonus, capped
+        // at the data-defined maximum.
+        var equipmentBonus = Math.Min(support.EquipmentBonusPercent, firstAid.EquipmentBonusMaxPercent);
+        if (equipmentBonus > 0)
+        {
+            modifiers.Add(new AdditiveModifier("medical equipment", equipmentBonus, AdditiveKind.Permanent));
+        }
+
+        if (support.HazardousConditions)
+        {
+            // "Hazardous or unsanitary conditions may make rolls Difficult" (p.39).
+            modifiers.Add(DifficultyModifier.Difficult("hazardous or unsanitary conditions"));
+        }
+
+        return ModifierPipeline.Evaluate(firstAidRating, modifiers)
+            .Resolve(firstAid.PrintedBaseChance, entropy)
+            ?? throw new InvalidOperationException("The First Aid roll was unexpectedly gated.");
+    }
+
+    private static bool ReduceWound(WoundTrack wounds, Wound wound, int healed)
+    {
+        // A single First Aid attempt heals up to the wound's whole damage, so "reduce" here is either
+        // a full removal or a one-shot reduction; there is no running per-wound tally to keep.
+        wounds.Remove(wound);
+        var remainingDamage = wound.DamageAmount - healed;
+        if (remainingDamage <= 0)
+        {
+            return true;
+        }
+
+        wounds.Add(new Wound(wound.Description, remainingDamage));
+        return false;
+    }
+
+    private sealed class WoundHealingState(Wound original, int remainingDamage)
+    {
+        public Wound Original { get; } = original;
+
+        public int RemainingDamage { get; set; } = remainingDamage;
+    }
+}
+
+/// <summary>
+/// The stacking support a caregiver brings to a First Aid roll (Ch 3: Skills, "First Aid", p.39):
+/// the caregiver's Medicine and Science (Pharmacy) ratings (which add fractions of themselves to the
+/// roll), medical equipment (up to +20%), and whether hazardous or unsanitary conditions make the
+/// roll Difficult. All default to none -- an unaided First Aid roll passes <c>default</c>.
+/// </summary>
+/// <param name="MedicineRating">The caregiver's Medicine rating; 1/2 of it is added to the roll.</param>
+/// <param name="SciencePharmacyRating">The caregiver's Science (Pharmacy) rating; 1/5 of it is added.</param>
+/// <param name="EquipmentBonusPercent">The equipment bonus, capped at the ruleset maximum (+20%).</param>
+/// <param name="HazardousConditions">Whether conditions make the roll Difficult.</param>
+public readonly record struct FirstAidSupport(
+    int MedicineRating = 0,
+    int SciencePharmacyRating = 0,
+    int EquipmentBonusPercent = 0,
+    bool HazardousConditions = false);
+
+/// <summary>
+/// The result of a First Aid attempt on a single wound (Ch 3: Skills, "First Aid", p.39).
+/// </summary>
+/// <param name="Roll">The resolved First Aid skill roll (base chance, effective chance, and grade).</param>
+/// <param name="HealedHitPoints">The hit points restored (0 on a Failure or Fumble; capped at the wound's damage).</param>
+/// <param name="SelfDamage">The hit points a Fumble dealt the patient (0 otherwise).</param>
+/// <param name="WoundFullyHealed">Whether the treated wound was fully healed and removed from the track.</param>
+/// <param name="BlocksFurtherAttempts">
+/// Whether "no further First Aid attempts may be made" on this wound (true after any Failure or
+/// Fumble). Enforcing "only one attempt per wound" across calls -- not re-treating a wound already
+/// successfully First-Aided -- is the caller's seam, the same as #111's caller-tracked same-day totals.
+/// </param>
+/// <param name="ResultingHitPoints">The patient's current hit points after the attempt.</param>
+public sealed record FirstAidOutcome(
+    RollOutcome Roll,
+    int HealedHitPoints,
+    int SelfDamage,
+    bool WoundFullyHealed,
+    bool BlocksFurtherAttempts,
+    int ResultingHitPoints);
+
+/// <summary>
+/// A reported weekly healing rate (Ch 6, "Healing Naturally", p.157): a rolled quantity of hit points
+/// a clock-aware caller applies over game weeks. Deliberately carries no applied effect -- the accrual
+/// is a caller seam.
+/// </summary>
+/// <param name="HitPointsPerWeek">The rolled hit points to heal this week.</param>
+/// <param name="Doubled">Whether this is the Medicine-doubled rate (2D3) rather than the natural rate (1D3).</param>
+public readonly record struct WeeklyHealingRate(int HitPointsPerWeek, bool Doubled);
+
+/// <summary>
+/// A reported Medicine-gated characteristic restoration rate (Ch 3: Skills, "Medicine", p.46): a
+/// rolled quantity of characteristic points recovered per week, by the grade of the Medicine roll.
+/// Carries no applied effect -- the accrual is a caller seam (<see cref="HealingResolver.ApplyCharacteristicRestoration"/>).
+/// </summary>
+/// <param name="Grade">The grade of the successful Medicine roll the rate was rolled for.</param>
+/// <param name="PointsPerWeek">The rolled characteristic points to recover this week (1D3-1 floors at 0).</param>
+public readonly record struct CharacteristicRestorationRate(SuccessLevel Grade, int PointsPerWeek);
+
+/// <summary>One wound's share of an applied healing (Ch 6, "Healing Naturally", p.157).</summary>
+/// <param name="Wound">The wound the healing was removed from (the original record).</param>
+/// <param name="HealedHitPoints">The hit points removed from this wound.</param>
+/// <param name="FullyHealed">Whether the wound was fully healed and removed from the track.</param>
+public sealed record WoundHealing(Wound Wound, int HealedHitPoints, bool FullyHealed);
+
+/// <summary>
+/// The result of applying accrued healing across a character's wounds (Ch 6, "Healing Naturally",
+/// p.157): the total hit points restored (capped at outstanding wound damage), the per-wound spread,
+/// and the resulting hit points.
+/// </summary>
+/// <param name="TotalHealed">The hit points actually restored (may be less than requested if wounds ran out).</param>
+/// <param name="PerWound">Each wound that received healing, with its share.</param>
+/// <param name="ResultingHitPoints">The patient's current hit points after the healing.</param>
+public sealed record HealingApplication(
+    int TotalHealed,
+    IReadOnlyList<WoundHealing> PerWound,
+    int ResultingHitPoints);
+
+/// <summary>
+/// The result of resolving a Conditions of Medical Care tier's weekly healing (Ch 6, "Conditions of
+/// Medical Care", p.157).
+/// </summary>
+/// <param name="Tier">The care tier resolved.</param>
+/// <param name="CaregiverRoll">
+/// The gating caregiver roll (poor tier only), or <see langword="null"/> for the decent and excellent
+/// tiers, which heal without a roll.
+/// </param>
+/// <param name="HealingRate">The hit points healed this week (0 when a poor-tier roll failed or fumbled).</param>
+/// <param name="Application">
+/// The applied healing spread across wounds, or <see langword="null"/> when no healing occurred.
+/// </param>
+/// <param name="AdditionalDamage">The extra damage a fumbled poor-tier roll dealt (0 otherwise).</param>
+/// <param name="AllowsAdditionalHealing">
+/// Whether a further successful First Aid or Medicine use allows possible additional healing (excellent
+/// tier only) -- that use is a separate resolver call; no amount is invented here.
+/// </param>
+public sealed record ConditionsOfCareOutcome(
+    MedicalCareTier Tier,
+    RollOutcome? CaregiverRoll,
+    int HealingRate,
+    HealingApplication? Application,
+    int AdditionalDamage,
+    bool AllowsAdditionalHealing);

--- a/src/Brp.Rules/Combat/HealingRollDifficulty.cs
+++ b/src/Brp.Rules/Combat/HealingRollDifficulty.cs
@@ -1,0 +1,15 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Whether a Conditions of Medical Care tier requires a difficulty-graded caregiver roll (Ch 6:
+/// Combat, "Conditions of Medical Care", p.157). Only the poor tier gates healing behind a roll, and
+/// that roll is Difficult; the decent and excellent tiers heal without a gating roll.
+/// </summary>
+public enum HealingRollDifficulty
+{
+    /// <summary>No gating roll is required for healing to occur (the decent and excellent tiers).</summary>
+    None,
+
+    /// <summary>The caregiver must succeed a Difficult First Aid or Medicine roll (the poor tier).</summary>
+    Difficult,
+}

--- a/src/Brp.Rules/Combat/HealingRuleset.cs
+++ b/src/Brp.Rules/Combat/HealingRuleset.cs
@@ -1,0 +1,186 @@
+using Brp.Core.Dice;
+using Brp.Core.Primitives;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The data-defined values of Ch 6: Combat healing and recovery (AGENTS.md invariant 7: rules values
+/// are data, not constants): the First Aid skill's per-wound healing (Ch 3, p.39), natural healing
+/// (p.157), the Medicine skill's doubled rate and characteristic restoration (Ch 3, p.46; p.157), and
+/// the Conditions of Medical Care Table (p.157). Loaded from <c>healing-ruleset.json</c> by
+/// <c>Brp.Data.NoirHealingRuleset.Load()</c>. See <c>docs/decisions/0023-healing-and-recovery.md</c>.
+/// </summary>
+public sealed class HealingRuleset
+{
+    /// <summary>Creates a healing ruleset from data-defined values.</summary>
+    public HealingRuleset(
+        FirstAidRuleset firstAid,
+        NaturalHealingRuleset naturalHealing,
+        MedicineRuleset medicine,
+        ConditionsOfMedicalCareTable conditionsOfMedicalCare)
+    {
+        ArgumentNullException.ThrowIfNull(firstAid);
+        ArgumentNullException.ThrowIfNull(naturalHealing);
+        ArgumentNullException.ThrowIfNull(medicine);
+        ArgumentNullException.ThrowIfNull(conditionsOfMedicalCare);
+
+        FirstAid = firstAid;
+        NaturalHealing = naturalHealing;
+        Medicine = medicine;
+        ConditionsOfMedicalCare = conditionsOfMedicalCare;
+    }
+
+    /// <summary>Ch 3, "First Aid" (p.39): the per-wound healing skill's values.</summary>
+    public FirstAidRuleset FirstAid { get; }
+
+    /// <summary>Ch 6, "Healing Naturally" (p.157): the flat weekly natural-healing rate.</summary>
+    public NaturalHealingRuleset NaturalHealing { get; }
+
+    /// <summary>Ch 3, "Medicine" (p.46) and Ch 6 (p.157): the Medicine skill's recovery values.</summary>
+    public MedicineRuleset Medicine { get; }
+
+    /// <summary>Ch 6, "Conditions of Medical Care" (p.157): the three-tier healing-rate modifier table.</summary>
+    public ConditionsOfMedicalCareTable ConditionsOfMedicalCare { get; }
+}
+
+/// <summary>
+/// The data-defined values of the Ch 3: Skills, "First Aid" (p.39) skill's healing effect. First Aid
+/// restores hit points to a single wound, capped at the hit points that wound inflicted, once per
+/// wound (System Notes, p.39).
+/// </summary>
+public sealed class FirstAidRuleset
+{
+    /// <summary>Creates a First Aid ruleset from data-defined values.</summary>
+    public FirstAidRuleset(
+        int printedBaseChancePercent,
+        DiceExpression successHealing,
+        DiceExpression specialHealing,
+        DiceExpression criticalHealing,
+        int fumbleSelfDamage,
+        int medicineBonusNumerator,
+        int medicineBonusDenominator,
+        int sciencePharmacyBonusNumerator,
+        int sciencePharmacyBonusDenominator,
+        int equipmentBonusMaxPercent)
+    {
+        ArgumentNullException.ThrowIfNull(successHealing);
+        ArgumentNullException.ThrowIfNull(specialHealing);
+        ArgumentNullException.ThrowIfNull(criticalHealing);
+        ArgumentOutOfRangeException.ThrowIfNegative(printedBaseChancePercent);
+        ArgumentOutOfRangeException.ThrowIfNegative(fumbleSelfDamage);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(medicineBonusDenominator);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sciencePharmacyBonusDenominator);
+        ArgumentOutOfRangeException.ThrowIfNegative(medicineBonusNumerator);
+        ArgumentOutOfRangeException.ThrowIfNegative(sciencePharmacyBonusNumerator);
+        ArgumentOutOfRangeException.ThrowIfNegative(equipmentBonusMaxPercent);
+
+        PrintedBaseChancePercent = printedBaseChancePercent;
+        SuccessHealing = successHealing;
+        SpecialHealing = specialHealing;
+        CriticalHealing = criticalHealing;
+        FumbleSelfDamage = fumbleSelfDamage;
+        MedicineBonusNumerator = medicineBonusNumerator;
+        MedicineBonusDenominator = medicineBonusDenominator;
+        SciencePharmacyBonusNumerator = sciencePharmacyBonusNumerator;
+        SciencePharmacyBonusDenominator = sciencePharmacyBonusDenominator;
+        EquipmentBonusMaxPercent = equipmentBonusMaxPercent;
+    }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "Base Chance: 30%." The printed base chance the 5% floor keys on.</summary>
+    public int PrintedBaseChancePercent { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "Success: ... Heal 1D3 hit points to a single wound or injury."</summary>
+    public DiceExpression SuccessHealing { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "Special: As above but healing 2D3 hit points."</summary>
+    public DiceExpression SpecialHealing { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "Critical: As above but healing 3+1D3 hit points."</summary>
+    public DiceExpression CriticalHealing { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "Fumble: The patient takes 1 general hit point of damage."</summary>
+    public int FumbleSelfDamage { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "may add 1/2 of their Medicine skill rating." Bonus numerator.</summary>
+    public int MedicineBonusNumerator { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "1/2 of their Medicine skill rating." Bonus denominator.</summary>
+    public int MedicineBonusDenominator { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "1/5 of their Science (Pharmacy) skill rating." Bonus numerator.</summary>
+    public int SciencePharmacyBonusNumerator { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): "1/5 of their Science (Pharmacy) skill rating." Bonus denominator.</summary>
+    public int SciencePharmacyBonusDenominator { get; }
+
+    /// <summary>Ch 3, "First Aid" (p.39): medical equipment "may add up to a +20% bonus to skill ratings."</summary>
+    public int EquipmentBonusMaxPercent { get; }
+
+    /// <summary>The First Aid printed base chance as a <see cref="Percent"/>.</summary>
+    public Percent PrintedBaseChance => Percent.Of(PrintedBaseChancePercent);
+}
+
+/// <summary>
+/// The data-defined values of Ch 6: Combat, "Healing Naturally" (p.157): "Your character will
+/// normally heal 1D3 hit points per game week. This is the normal healing rate." A flat rate, not
+/// tied to CON.
+/// </summary>
+public sealed class NaturalHealingRuleset
+{
+    /// <summary>Creates a natural-healing ruleset from data-defined values.</summary>
+    public NaturalHealingRuleset(DiceExpression weeklyRate)
+    {
+        ArgumentNullException.ThrowIfNull(weeklyRate);
+        WeeklyRate = weeklyRate;
+    }
+
+    /// <summary>Ch 6, "Healing Naturally" (p.157): the flat 1D3 hit points healed per game week.</summary>
+    public DiceExpression WeeklyRate { get; }
+}
+
+/// <summary>
+/// The data-defined values of the Ch 3: Skills, "Medicine" (p.46) skill and its Ch 6 (p.157) role:
+/// doubling the natural healing rate, and stabilizing a poisoned/diseased character to restore hit
+/// points or characteristic points per week.
+/// </summary>
+public sealed class MedicineRuleset
+{
+    /// <summary>Creates a Medicine ruleset from data-defined values.</summary>
+    public MedicineRuleset(
+        int printedBaseChancePercent,
+        DiceExpression doubledWeeklyRate,
+        DiceExpression characteristicRestorationSuccess,
+        DiceExpression characteristicRestorationSpecial,
+        DiceExpression characteristicRestorationCritical)
+    {
+        ArgumentNullException.ThrowIfNull(doubledWeeklyRate);
+        ArgumentNullException.ThrowIfNull(characteristicRestorationSuccess);
+        ArgumentNullException.ThrowIfNull(characteristicRestorationSpecial);
+        ArgumentNullException.ThrowIfNull(characteristicRestorationCritical);
+        ArgumentOutOfRangeException.ThrowIfNegative(printedBaseChancePercent);
+
+        PrintedBaseChancePercent = printedBaseChancePercent;
+        DoubledWeeklyRate = doubledWeeklyRate;
+        CharacteristicRestorationSuccess = characteristicRestorationSuccess;
+        CharacteristicRestorationSpecial = characteristicRestorationSpecial;
+        CharacteristicRestorationCritical = characteristicRestorationCritical;
+    }
+
+    /// <summary>Ch 3, "Medicine" (p.46): "Base Chance: 05%." The printed base chance the 5% floor keys on.</summary>
+    public int PrintedBaseChancePercent { get; }
+
+    /// <summary>Ch 3, "Medicine" (p.46) / Ch 6 (p.157): "The patient's healing rate doubles from 1D3 to 2D3 hit points per week."</summary>
+    public DiceExpression DoubledWeeklyRate { get; }
+
+    /// <summary>Ch 3, "Medicine" (p.46): "recovers 1D3-1 hit points or characteristic points per week." Success grade.</summary>
+    public DiceExpression CharacteristicRestorationSuccess { get; }
+
+    /// <summary>Ch 3, "Medicine" (p.46): "1D3 characteristic points are recovered." Special grade.</summary>
+    public DiceExpression CharacteristicRestorationSpecial { get; }
+
+    /// <summary>Ch 3, "Medicine" (p.46): "1D3+1 characteristic points are recovered." Critical grade.</summary>
+    public DiceExpression CharacteristicRestorationCritical { get; }
+
+    /// <summary>The Medicine printed base chance as a <see cref="Percent"/>.</summary>
+    public Percent PrintedBaseChance => Percent.Of(PrintedBaseChancePercent);
+}

--- a/src/Brp.Rules/Combat/MedicalCareRow.cs
+++ b/src/Brp.Rules/Combat/MedicalCareRow.cs
@@ -1,0 +1,46 @@
+using Brp.Core.Contests;
+using Brp.Core.Dice;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// One row of Ch 6: Combat, "Conditions of Medical Care" (p.157), keyed by its
+/// <see cref="MedicalCareTier"/>. Carries the printed cell's mechanical effect on the weekly healing
+/// rate: whether a gating caregiver roll is required (and its difficulty), the natural healing the
+/// row grants, the extra damage a fumbled gating roll inflicts, and whether the row permits further
+/// possible healing beyond the natural rate. The descriptive "Medical Conditions" cell is kept as
+/// free text for the game layer to render; the mechanical fields are what the printed grid makes
+/// normative. Mirrors <see cref="MajorWoundRow"/> / <see cref="IllnessSeverityBand"/>.
+/// </summary>
+/// <param name="Tier">The care tier this row describes (the table's key).</param>
+/// <param name="Conditions">
+/// The printed "Medical Conditions" cell, summarized for the game layer to render. Narrative only.
+/// </param>
+/// <param name="RequiresCaregiverRoll">
+/// Whether any healing requires a successful caregiver roll first (true only for the poor tier).
+/// </param>
+/// <param name="CaregiverRollDifficulty">
+/// The difficulty of the gating caregiver roll (<see cref="HealingRollDifficulty.Difficult"/> for the
+/// poor tier, <see cref="HealingRollDifficulty.None"/> otherwise).
+/// </param>
+/// <param name="NaturalHealing">
+/// The hit points healed naturally per week when the row's conditions are met (1D3 on every printed
+/// row -- the same normal rate as "Healing Naturally", p.157).
+/// </param>
+/// <param name="FumbleAdditionalDamage">
+/// The additional damage a fumbled gating roll inflicts (1D3 for the poor tier; <see langword="null"/>
+/// for tiers with no gating roll).
+/// </param>
+/// <param name="AllowsAdditionalHealing">
+/// Whether a further successful First Aid or Medicine use allows possible additional healing beyond
+/// the natural rate (true only for the excellent tier). The additional amount is left to that separate
+/// skill use -- the book does not print one, so this row does not invent it.
+/// </param>
+public sealed record MedicalCareRow(
+    MedicalCareTier Tier,
+    string Conditions,
+    bool RequiresCaregiverRoll,
+    HealingRollDifficulty CaregiverRollDifficulty,
+    DiceExpression NaturalHealing,
+    DiceExpression? FumbleAdditionalDamage,
+    bool AllowsAdditionalHealing);

--- a/tests/Brp.Core.Tests/Contests/HealingAdjudicatorTests.cs
+++ b/tests/Brp.Core.Tests/Contests/HealingAdjudicatorTests.cs
@@ -1,0 +1,57 @@
+using Brp.Core.Contests;
+
+namespace Brp.Core.Tests.Contests;
+
+/// <summary>
+/// Covers the named gamemaster-discretion ports for the Ch 6 healing rules (#109): the canonical
+/// decision ids, the documented neutral defaults of <see cref="DefaultHealingAdjudicator"/>, and that
+/// a deterministic stub can drive every port for replayable tests. See
+/// <c>docs/decisions/0023-healing-and-recovery.md</c>.
+/// </summary>
+public class HealingAdjudicatorTests
+{
+    [Theory]
+    [InlineData(HealingDecisionId.ConditionsTier, "healing-conditions-tier")]
+    [InlineData(HealingDecisionId.Caregiver, "healing-caregiver")]
+    public void Every_decision_id_has_its_canonical_kebab_case_string(HealingDecisionId id, string expected)
+    {
+        Assert.Equal(expected, HealingDecisionIds.CanonicalId(id));
+    }
+
+    [Fact]
+    public void The_named_discretion_points_are_exactly_those_issue_109_calls_out()
+    {
+        Assert.Equal(2, Enum.GetValues<HealingDecisionId>().Length);
+    }
+
+    [Fact]
+    public void The_default_adjudicator_returns_the_documented_minimal_assumption_answers()
+    {
+        var adjudicator = new DefaultHealingAdjudicator();
+
+        // The middle tier heals normally with no gating roll -- the least-assuming reading.
+        Assert.Equal(MedicalCareTier.Decent, adjudicator.DecideConditionsTier());
+
+        // First Aid is the more broadly trained skill (30% vs Medicine's 05%).
+        Assert.Equal(new CaregiverRuling(CaregiverSkill.FirstAid), adjudicator.DecideCaregiver());
+    }
+
+    [Fact]
+    public void A_deterministic_stub_drives_every_port_with_scripted_answers()
+    {
+        IHealingAdjudicator adjudicator = new ScriptedHealingAdjudicator(
+            tier: MedicalCareTier.Poor, caregiver: new CaregiverRuling(CaregiverSkill.Medicine));
+
+        Assert.Equal(MedicalCareTier.Poor, adjudicator.DecideConditionsTier());
+        Assert.Equal(new CaregiverRuling(CaregiverSkill.Medicine), adjudicator.DecideCaregiver());
+    }
+
+    /// <summary>A deterministic test double returning pre-scripted rulings for each port.</summary>
+    private sealed class ScriptedHealingAdjudicator(MedicalCareTier tier, CaregiverRuling caregiver)
+        : IHealingAdjudicator
+    {
+        public MedicalCareTier DecideConditionsTier() => tier;
+
+        public CaregiverRuling DecideCaregiver() => caregiver;
+    }
+}

--- a/tests/Brp.Data.Tests/NoirHealingRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirHealingRulesetTests.cs
@@ -1,0 +1,102 @@
+using Brp.Core.Contests;
+using Brp.Rules.Combat;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped healing data loads and reproduces the printed values: the First Aid healing
+/// amounts and bonuses (Ch 3: Skills, "First Aid", p.39), the natural healing rate (Ch 6, "Healing
+/// Naturally", p.157), the Medicine doubled rate and characteristic restoration (Ch 3, "Medicine",
+/// p.46; p.157), and every row of the "Conditions of Medical Care" table (p.157) -- row by row rather
+/// than sampled, per AGENTS.md's "table-backed rule" convention. See
+/// <c>docs/decisions/0023-healing-and-recovery.md</c>.
+/// </summary>
+public class NoirHealingRulesetTests
+{
+    private static readonly HealingRuleset Ruleset = NoirHealingRuleset.Load();
+
+    [Fact]
+    public void First_aid_healing_amounts_and_bonuses_match_the_book_page_39()
+    {
+        Assert.Equal(30, Ruleset.FirstAid.PrintedBaseChancePercent);
+        Assert.Equal("1D3", Ruleset.FirstAid.SuccessHealing.Notation);
+        Assert.Equal("2D3", Ruleset.FirstAid.SpecialHealing.Notation);
+        // "Critical: As above but healing 3+1D3 hit points" -- the constant leads, then the die.
+        Assert.Equal("3+1D3", Ruleset.FirstAid.CriticalHealing.Notation);
+        Assert.Equal(1, Ruleset.FirstAid.FumbleSelfDamage);
+
+        // "may add 1/2 of their Medicine skill rating and 1/5 of their Science (Pharmacy) skill rating."
+        Assert.Equal(1, Ruleset.FirstAid.MedicineBonusNumerator);
+        Assert.Equal(2, Ruleset.FirstAid.MedicineBonusDenominator);
+        Assert.Equal(1, Ruleset.FirstAid.SciencePharmacyBonusNumerator);
+        Assert.Equal(5, Ruleset.FirstAid.SciencePharmacyBonusDenominator);
+
+        // "medical equipment ... may add up to a +20% bonus to skill ratings."
+        Assert.Equal(20, Ruleset.FirstAid.EquipmentBonusMaxPercent);
+    }
+
+    [Fact]
+    public void Natural_healing_is_a_flat_1d3_per_game_week_page_157()
+    {
+        // "Your character will normally heal 1D3 hit points per game week" -- flat, not CON-tied.
+        Assert.Equal("1D3", Ruleset.NaturalHealing.WeeklyRate.Notation);
+    }
+
+    [Fact]
+    public void Medicine_doubles_the_rate_and_restores_characteristics_pages_46_157()
+    {
+        Assert.Equal(5, Ruleset.Medicine.PrintedBaseChancePercent);
+        // "The patient's healing rate doubles from 1D3 to 2D3 hit points per week."
+        Assert.Equal("2D3", Ruleset.Medicine.DoubledWeeklyRate.Notation);
+        // "recovers 1D3-1 ... characteristic points per week" (Success), "1D3" (Special), "1D3+1" (Critical).
+        Assert.Equal("1D3-1", Ruleset.Medicine.CharacteristicRestorationSuccess.Notation);
+        Assert.Equal("1D3", Ruleset.Medicine.CharacteristicRestorationSpecial.Notation);
+        Assert.Equal("1D3+1", Ruleset.Medicine.CharacteristicRestorationCritical.Notation);
+    }
+
+    // (tier, requiresRoll, difficulty, naturalHealing, fumbleAdditionalDamage-or-null, allowsAdditional)
+    // -- one case per printed row of the Conditions of Medical Care table, Ch 6 p.157.
+    public static IEnumerable<object?[]> PrintedRows()
+    {
+        yield return new object?[] { MedicalCareTier.Poor, true, HealingRollDifficulty.Difficult, "1D3", "1D3", false };
+        yield return new object?[] { MedicalCareTier.Decent, false, HealingRollDifficulty.None, "1D3", null, false };
+        yield return new object?[] { MedicalCareTier.Excellent, false, HealingRollDifficulty.None, "1D3", null, true };
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintedRows))]
+    public void Every_conditions_of_medical_care_row_matches_the_book_page_157(
+        MedicalCareTier tier,
+        bool requiresRoll,
+        HealingRollDifficulty difficulty,
+        string naturalHealing,
+        string? fumbleAdditionalDamage,
+        bool allowsAdditional)
+    {
+        var row = Ruleset.ConditionsOfMedicalCare.ForTier(tier);
+
+        Assert.Equal(tier, row.Tier);
+        Assert.Equal(requiresRoll, row.RequiresCaregiverRoll);
+        Assert.Equal(difficulty, row.CaregiverRollDifficulty);
+        Assert.Equal(naturalHealing, row.NaturalHealing.Notation);
+        Assert.False(string.IsNullOrWhiteSpace(row.Conditions));
+
+        if (fumbleAdditionalDamage is null)
+        {
+            Assert.Null(row.FumbleAdditionalDamage);
+        }
+        else
+        {
+            Assert.NotNull(row.FumbleAdditionalDamage);
+            Assert.Equal(fumbleAdditionalDamage, row.FumbleAdditionalDamage!.Notation);
+        }
+
+        Assert.Equal(allowsAdditional, row.AllowsAdditionalHealing);
+    }
+
+    [Fact]
+    public void The_shipped_conditions_table_has_exactly_the_three_printed_rows()
+    {
+        Assert.Equal(3, Ruleset.ConditionsOfMedicalCare.Rows.Count);
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/HealingResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/HealingResolverTests.cs
@@ -1,0 +1,412 @@
+using Brp.Core.Abilities;
+using Brp.Core.Contests;
+using Brp.Core.Primitives;
+using Brp.Core.Resolution;
+using Brp.Data;
+using Brp.Rules.Characters;
+using Brp.Rules.Combat;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Ch 6: Combat healing and recovery (#109): First Aid's per-wound healing (Ch 3, p.39), natural
+/// healing (p.157), the Medicine skill's doubled rate and characteristic restoration (Ch 3, p.46;
+/// p.157), and the Conditions of Medical Care Table (p.157). Rolls are pinned through
+/// <see cref="FixedEntropySource"/> so each grade and amount is exact. See
+/// <c>docs/decisions/0023-healing-and-recovery.md</c>.
+/// </summary>
+public class HealingResolverTests
+{
+    private static readonly HealingRuleset Healing = NoirHealingRuleset.Load();
+    private static readonly DamageRuleset Damage = NoirDamageRuleset.Load();
+    private static readonly MajorWoundRuleset MajorWounds = NoirMajorWoundRuleset.Load();
+
+    private static AbilitySet MakeTarget(int con = 12, int siz = 12)
+    {
+        var ruleset = NoirAbilityRuleset.Load();
+        var values = ruleset.Characteristics.Keys.ToDictionary(id => id, _ => 12);
+        values[new CharacteristicId("CON")] = con;
+        values[new CharacteristicId("SIZ")] = siz;
+        return new AbilitySet(ruleset, values);
+    }
+
+    private static Wound Wound(AbilitySet target, WoundTrack wounds, int damage) =>
+        DamageResolver.ApplyDamage(target, wounds, damage, Damage, "test wound").Wound!;
+
+    // --- First Aid -------------------------------------------------------------------------------
+
+    [Fact]
+    public void First_aid_success_heals_1d3_to_a_single_wound_page_39()
+    {
+        var target = MakeTarget();      // 12 max HP
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 5);   // HP 7, wound damage 5
+        Assert.Equal(7, target.CurrentHitPoints);
+
+        // First Aid 47%: roll 30 is an ordinary Success; then 1D3 heals 2.
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(47), default, wound, target, wounds, Healing, new FixedEntropySource(30, 2));
+
+        Assert.Equal(SuccessLevel.Success, outcome.Roll.Level);
+        Assert.Equal(2, outcome.HealedHitPoints);
+        Assert.Equal(9, outcome.ResultingHitPoints);
+        Assert.False(outcome.WoundFullyHealed);
+        Assert.False(outcome.BlocksFurtherAttempts);
+
+        // The healed points are removed from the wound (5 -> 3), not a new wound.
+        var remaining = Assert.Single(wounds.Wounds);
+        Assert.Equal(3, remaining.DamageAmount);
+    }
+
+    [Fact]
+    public void First_aid_healing_is_capped_at_the_wound_damage_and_removes_a_fully_healed_wound_page_39()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 1);   // HP 11, wound damage 1
+
+        // 1D3 rolls 3, but the wound only inflicted 1, so only 1 is healed ("up to the amount ... inflicted").
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(47), default, wound, target, wounds, Healing, new FixedEntropySource(30, 3));
+
+        Assert.Equal(1, outcome.HealedHitPoints);
+        Assert.Equal(12, outcome.ResultingHitPoints);
+        Assert.True(outcome.WoundFullyHealed);
+        Assert.Empty(wounds.Wounds);
+    }
+
+    [Fact]
+    public void First_aid_special_heals_2d3_page_39()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 6);   // HP 6, wound damage 6
+
+        // First Aid 47%: roll 5 is a Special (critical 3, special 10); then 2D3 heals 2+3 = 5.
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(47), default, wound, target, wounds, Healing, new FixedEntropySource(5, 2, 3));
+
+        Assert.Equal(SuccessLevel.Special, outcome.Roll.Level);
+        Assert.Equal(5, outcome.HealedHitPoints);
+        Assert.Equal(11, outcome.ResultingHitPoints);
+    }
+
+    [Fact]
+    public void First_aid_critical_heals_3_plus_1d3_page_39()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 8);   // HP 4, wound damage 8
+
+        // First Aid 47%: roll 2 is a Critical (<= 3); then 3+1D3 heals 3 + 3 = 6.
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(47), default, wound, target, wounds, Healing, new FixedEntropySource(2, 3));
+
+        Assert.Equal(SuccessLevel.Critical, outcome.Roll.Level);
+        Assert.Equal(6, outcome.HealedHitPoints);
+        Assert.Equal(10, outcome.ResultingHitPoints);
+    }
+
+    [Fact]
+    public void First_aid_fumble_deals_1_hit_point_and_heals_nothing_page_39()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 5);   // HP 7, wound damage 5
+
+        // A roll of 00 (100) always fumbles. No healing dice are drawn.
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(47), default, wound, target, wounds, Healing, new FixedEntropySource(100));
+
+        Assert.Equal(SuccessLevel.Fumble, outcome.Roll.Level);
+        Assert.Equal(0, outcome.HealedHitPoints);
+        Assert.Equal(1, outcome.SelfDamage);
+        Assert.Equal(6, outcome.ResultingHitPoints);
+        Assert.True(outcome.BlocksFurtherAttempts);
+
+        // The wound is untouched by a fumble.
+        Assert.Equal(5, Assert.Single(wounds.Wounds).DamageAmount);
+    }
+
+    [Fact]
+    public void First_aid_failure_heals_nothing_and_blocks_further_attempts_page_39()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 5);   // HP 7
+
+        // First Aid 47%: roll 60 fails.
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(47), default, wound, target, wounds, Healing, new FixedEntropySource(60));
+
+        Assert.Equal(SuccessLevel.Failure, outcome.Roll.Level);
+        Assert.Equal(0, outcome.HealedHitPoints);
+        Assert.Equal(0, outcome.SelfDamage);
+        Assert.Equal(7, outcome.ResultingHitPoints);
+        Assert.True(outcome.BlocksFurtherAttempts);
+        Assert.Equal(5, Assert.Single(wounds.Wounds).DamageAmount);
+    }
+
+    [Fact]
+    public void First_aid_support_bonuses_add_half_medicine_fifth_pharmacy_and_capped_equipment_page_39()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 5);
+
+        // Rating 30 + 1/2 of Medicine 40 (=20) + 1/5 of Science(Pharmacy) 40 (=8) + equipment 25 capped
+        // at 20 = 78. A roll of 70 fails at 30 but succeeds at 78.
+        var support = new FirstAidSupport(MedicineRating: 40, SciencePharmacyRating: 40, EquipmentBonusPercent: 25);
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(30), support, wound, target, wounds, Healing, new FixedEntropySource(70, 1));
+
+        Assert.Equal(78, outcome.Roll.EffectiveChance.Value);
+        Assert.True(outcome.Roll.Succeeded);
+    }
+
+    [Fact]
+    public void First_aid_in_hazardous_conditions_is_difficult_page_39()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 5);
+
+        // Rating 60 halved by the Difficult grade = 30; a roll of 40 succeeds at 60 but fails at 30.
+        var support = new FirstAidSupport(HazardousConditions: true);
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(60), support, wound, target, wounds, Healing, new FixedEntropySource(40));
+
+        Assert.Equal(30, outcome.Roll.EffectiveChance.Value);
+        Assert.False(outcome.Roll.Succeeded);
+    }
+
+    [Fact]
+    public void First_aid_restores_a_fatally_wounded_character_via_the_reused_111_rescue_window_page_39()
+    {
+        // A character at 0 hit points (fatal) is First-Aided to 1+, then the #111 rescue decides survival.
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        var wound = Wound(target, wounds, 12);  // HP 0 -- fatally wounded
+        Assert.Equal(0, target.CurrentHitPoints);
+
+        // First Aid 47%: roll 30 Success; 1D3 heals 3 -> HP 3 (>= 1).
+        var outcome = HealingResolver.ResolveFirstAid(
+            Percent.Of(47), default, wound, target, wounds, Healing, new FixedEntropySource(30, 3));
+        Assert.Equal(3, outcome.ResultingHitPoints);
+
+        // In the wound round (0) or the round after (1): the reused MajorWoundResolver.SurvivesFatalWound
+        // path returns survival because hit points are now above the dead level.
+        Assert.True(HealingResolver.ResolvesFatalWoundRescue(target, roundsSinceFatalWound: 0, MajorWounds, Damage));
+        Assert.True(HealingResolver.ResolvesFatalWoundRescue(target, roundsSinceFatalWound: 1, MajorWounds, Damage));
+
+        // Outside the window, the same restored hit points do not rescue.
+        Assert.False(HealingResolver.ResolvesFatalWoundRescue(target, roundsSinceFatalWound: 2, MajorWounds, Damage));
+    }
+
+    [Fact]
+    public void The_rescue_fails_when_first_aid_did_not_bring_hit_points_above_the_dead_level_page_156()
+    {
+        var target = MakeTarget();
+        target.SetCurrentHitPoints(0);   // still fatally wounded, no aid applied
+
+        Assert.False(HealingResolver.ResolvesFatalWoundRescue(target, roundsSinceFatalWound: 0, MajorWounds, Damage));
+    }
+
+    // --- Natural healing -------------------------------------------------------------------------
+
+    [Fact]
+    public void Natural_healing_reports_a_flat_1d3_weekly_rate_page_157()
+    {
+        // The resolver REPORTS the rolled rate; accrual over weeks is a caller seam.
+        var rate = HealingResolver.RollNaturalHealingRate(Healing, new FixedEntropySource(2));
+
+        Assert.Equal(2, rate.HitPointsPerWeek);
+        Assert.False(rate.Doubled);
+    }
+
+    [Fact]
+    public void Applied_healing_spreads_across_wounds_as_evenly_as_possible_page_157()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        Wound(target, wounds, 4);   // wound A
+        Wound(target, wounds, 3);   // wound B -- HP now 12 - 7 = 5
+        Assert.Equal(5, target.CurrentHitPoints);
+
+        // Apply 4 hit points: distributed round-robin A,B,A,B -> A heals 2, B heals 2.
+        var application = HealingResolver.ApplyWeeklyHealing(target, wounds, 4);
+
+        Assert.Equal(4, application.TotalHealed);
+        Assert.Equal(9, application.ResultingHitPoints);
+        Assert.All(application.PerWound, w => Assert.Equal(2, w.HealedHitPoints));
+        // Remaining outstanding wound damage: 2 + 1 = 3 across two still-open wounds.
+        Assert.Equal(2, wounds.Wounds.Count);
+        Assert.Equal(3, wounds.Wounds.Sum(w => w.DamageAmount));
+    }
+
+    [Fact]
+    public void Applied_healing_is_capped_at_outstanding_wound_damage_page_157()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        Wound(target, wounds, 3);   // HP 9, only 3 outstanding
+
+        // Ask for 10 hit points; only 3 can land (the wound), and the wound is fully healed.
+        var application = HealingResolver.ApplyWeeklyHealing(target, wounds, 10);
+
+        Assert.Equal(3, application.TotalHealed);
+        Assert.Equal(12, application.ResultingHitPoints);
+        Assert.Empty(wounds.Wounds);
+    }
+
+    // --- Medicine --------------------------------------------------------------------------------
+
+    [Fact]
+    public void Medicine_doubles_the_weekly_rate_to_2d3_page_157()
+    {
+        var rate = HealingResolver.RollMedicineHealingRate(Healing, new FixedEntropySource(3, 3));
+
+        Assert.Equal(6, rate.HitPointsPerWeek);
+        Assert.True(rate.Doubled);
+    }
+
+    [Theory]
+    [InlineData(SuccessLevel.Success, new[] { 3 }, 2)]   // 1D3-1: 3 - 1 = 2
+    [InlineData(SuccessLevel.Special, new[] { 2 }, 2)]   // 1D3: 2
+    [InlineData(SuccessLevel.Critical, new[] { 2 }, 3)]  // 1D3+1: 2 + 1 = 3
+    public void Medicine_characteristic_restoration_rate_matches_the_grade_page_46(
+        SuccessLevel grade, int[] dice, int expected)
+    {
+        var rate = HealingResolver.RollCharacteristicRestorationRate(grade, Healing, new FixedEntropySource(dice));
+
+        Assert.Equal(grade, rate.Grade);
+        Assert.Equal(expected, rate.PointsPerWeek);
+    }
+
+    [Fact]
+    public void Medicine_characteristic_restoration_rate_requires_a_successful_roll()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            HealingResolver.RollCharacteristicRestorationRate(SuccessLevel.Failure, Healing, new FixedEntropySource(1)));
+    }
+
+    [Fact]
+    public void Applying_characteristic_restoration_recomputes_derived_values_via_ability_set_pages_13_46()
+    {
+        var target = MakeTarget();   // CON 12, SIZ 12 -> 12 max HP
+        target.Set(new CharacteristicId("CON"), 8);   // drained: max HP now (8+12)/2 = 10, current HP clamped to 10
+        Assert.Equal(10, target.MaximumHitPoints);
+        Assert.Equal(10, target.CurrentHitPoints);
+
+        // Restore 3 CON through AbilitySet.Set: CON 11, and max HP recomputes live to (11+12)/2 = 12 (rounded up).
+        var restored = HealingResolver.ApplyCharacteristicRestoration(target, new CharacteristicId("CON"), 3);
+
+        Assert.Equal(11, restored);
+        Assert.Equal(11, target.ValueOf(new CharacteristicId("CON")));
+        Assert.Equal(12, target.MaximumHitPoints);
+        // Ch 2, p.13: restoring the characteristic does NOT resurrect the already-clamped current hit points.
+        Assert.Equal(10, target.CurrentHitPoints);
+    }
+
+    [Fact]
+    public void Characteristic_restoration_does_not_exceed_the_ruleset_maximum()
+    {
+        var target = MakeTarget();
+        // CON's ruleset maximum is 21; restoring far beyond it caps at 21.
+        var restored = HealingResolver.ApplyCharacteristicRestoration(target, new CharacteristicId("CON"), 50);
+
+        Assert.Equal(21, restored);
+    }
+
+    // --- Conditions of Medical Care --------------------------------------------------------------
+
+    [Fact]
+    public void Decent_conditions_heal_the_natural_rate_with_no_roll_page_157()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        Wound(target, wounds, 5);   // HP 7
+
+        // No gating roll: only the 1D3 natural-healing die is drawn (3).
+        var outcome = HealingResolver.ResolveConditionsOfCare(
+            MedicalCareTier.Decent, Percent.Of(50), Healing.FirstAid.PrintedBaseChance, target, wounds, Healing,
+            new FixedEntropySource(3));
+
+        Assert.Null(outcome.CaregiverRoll);
+        Assert.Equal(3, outcome.HealingRate);
+        Assert.Equal(10, outcome.Application!.ResultingHitPoints);
+        Assert.False(outcome.AllowsAdditionalHealing);
+    }
+
+    [Fact]
+    public void Excellent_conditions_heal_naturally_and_allow_further_healing_page_157()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        Wound(target, wounds, 5);
+
+        var outcome = HealingResolver.ResolveConditionsOfCare(
+            MedicalCareTier.Excellent, Percent.Of(50), Healing.FirstAid.PrintedBaseChance, target, wounds, Healing,
+            new FixedEntropySource(2));
+
+        Assert.Null(outcome.CaregiverRoll);
+        Assert.Equal(2, outcome.HealingRate);
+        Assert.True(outcome.AllowsAdditionalHealing);
+    }
+
+    [Fact]
+    public void Poor_conditions_require_a_difficult_roll_which_heals_normally_on_success_page_157()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        Wound(target, wounds, 5);   // HP 7
+
+        // Caregiver First Aid 80 halved by Difficult = 40; roll 20 succeeds, then 1D3 heals 2.
+        var outcome = HealingResolver.ResolveConditionsOfCare(
+            MedicalCareTier.Poor, Percent.Of(80), Healing.FirstAid.PrintedBaseChance, target, wounds, Healing,
+            new FixedEntropySource(20, 2));
+
+        Assert.NotNull(outcome.CaregiverRoll);
+        Assert.Equal(40, outcome.CaregiverRoll!.EffectiveChance.Value);
+        Assert.Equal(SuccessLevel.Success, outcome.CaregiverRoll.Level);
+        Assert.Equal(2, outcome.HealingRate);
+        Assert.Equal(9, outcome.Application!.ResultingHitPoints);
+        Assert.Equal(0, outcome.AdditionalDamage);
+    }
+
+    [Fact]
+    public void Poor_conditions_yield_no_healing_on_a_failed_roll_page_157()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        Wound(target, wounds, 5);   // HP 7
+
+        // 80 halved = 40; roll 50 fails. No natural-healing die is drawn.
+        var outcome = HealingResolver.ResolveConditionsOfCare(
+            MedicalCareTier.Poor, Percent.Of(80), Healing.FirstAid.PrintedBaseChance, target, wounds, Healing,
+            new FixedEntropySource(50));
+
+        Assert.Equal(SuccessLevel.Failure, outcome.CaregiverRoll!.Level);
+        Assert.Equal(0, outcome.HealingRate);
+        Assert.Null(outcome.Application);
+        Assert.Equal(7, target.CurrentHitPoints);
+    }
+
+    [Fact]
+    public void Poor_conditions_fumble_inflicts_1d3_additional_damage_page_157()
+    {
+        var target = MakeTarget();
+        var wounds = new WoundTrack();
+        Wound(target, wounds, 5);   // HP 7
+
+        // Roll 00 (100) fumbles; then 1D3 additional damage rolls 2.
+        var outcome = HealingResolver.ResolveConditionsOfCare(
+            MedicalCareTier.Poor, Percent.Of(80), Healing.FirstAid.PrintedBaseChance, target, wounds, Healing,
+            new FixedEntropySource(100, 2));
+
+        Assert.Equal(SuccessLevel.Fumble, outcome.CaregiverRoll!.Level);
+        Assert.Equal(0, outcome.HealingRate);
+        Assert.Equal(2, outcome.AdditionalDamage);
+        Assert.Equal(5, target.CurrentHitPoints);   // 7 - 2
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #109

## Exact behavioral claim

Characters can now recover, not just take harm. First Aid restores 1D3/2D3/3+1D3 HP per wound (capped at
that wound's `DamageAmount`, once per wound), natural healing reports 1D3 HP/game week spread across wounds,
Medicine doubles the rate (2D3/week) and drives characteristic restoration, and the Conditions of Medical
Care table modulates the rate. This completes the injure→heal loop (the engine could damage/wound/drain but
nothing healed).

## Scope

New: `HealingResolver` + rulesets/table (`Brp.Rules.Combat`), `healing-ruleset.json` + `NoirHealingRuleset`,
the `IHealingAdjudicator` port (`Brp.Core.Contests`), ADR 0023. First Aid reuses `Wound.DamageAmount` (#111)
as the per-wound cap and forwards fatal-wound rescue to `MajorWoundResolver.SurvivesFatalWound` (no
duplication). Rates are reported; wall-clock accrual is a caller seam (like disease #96). First Aid/Medicine
rolls resolve through the skill kernel.

## Rules conformance

Source: **First Aid Ch 3 p.39, Medicine Ch 3 p.46, Healing Naturally + Conditions of Medical Care p.157**
(all three pages re-verified against the PDF — correct). `rules-conformance` confirmed every value: First Aid
1D3/2D3/3+1D3 + fumble 1HP + failure-blocks + one-attempt-per-wound + cap + (+½ Medicine, +⅕ Science(Pharmacy),
+20% equipment); natural 1D3/week (flat, not CON-tied); Medicine 2D3 doubling + characteristic restoration
1D3−1/1D3/1D3+1; the 3-tier Conditions of Medical Care table reproduced row-by-row with an exact-count. No
defects. All values in `healing-ruleset.json`.

## Tests and evidence

- `dotnet build NoiRPG.slnx` → 0 warnings, 0 errors.
- `dotnet test NoiRPG.slnx` → **2290 passed, 0 failed** (~37 new). Re-run independently.
- `dotnet format NoiRPG.slnx --verify-no-changes` → clean.

## Decisions and tradeoffs

Three book-silent points, all marked **house** in ADR 0023: the ½/⅕ First Aid bonuses **round down** (the book
prints no rule; the one worked value ⅕-of-40=8 is exact — note the nearby days-division uses round-up, a spot
to revisit if book-convention consistency is later preferred); the bonuses modeled as pre-difficulty additives;
and the Excellent tier's "possible additional healing" as a flag with no invented amount. Characteristic
restoration recomputes via `AbilitySet.Set` and correctly does not resurrect already-clamped current HP.

## Known limitations

Weekly accrual (rate × weeks) and "who is the caregiver / conditions tier" are caller seams / adjudicator
decisions — no campaign clock in this layer. Hit-location-specific healing is deferred to #112.

## Agent provenance

Implemented by a build agent as `engine-dev` (Claude, via Claude Code) from a cited extract. Verified by
adversarial `rules-conformance` (every value + all 3 pages — PASS) and `scope-warden` (fatal-rescue forwards
to #111, restoration via recompute, one concern — PASS). Orchestrated at the owner's direction.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
