### PR TITLE
Make dispatch label-aware and split Brp.Data routing

### DIFF
--- a/.github/route-map
+++ b/.github/route-map
@@ -29,8 +29,14 @@ global.json                tooling
 src/Brp.Core/**            rules
 src/Brp.Rules/**           rules
 
-# Formula / threshold data — ruleset JSON is printed numeric tables
-src/Brp.Data/**            formulas
+# Ruleset data. Split by kind so a boring loader edit doesn't trigger the
+# expensive independent cross-check:
+#   *.json — printed numeric tables/thresholds -> formulas (verify every value).
+#   *.cs   — loaders/models -> rules; content escalation still promotes a .cs
+#            change to formulas when its diff actually touches numeric content.
+# (Last matching rule wins, so the .json rule must come after the catch-all.)
+src/Brp.Data/**            rules
+src/Brp.Data/**/*.json     formulas
 
 # Architecture — project boundaries and references (last, so they win for these
 # files even under src/**). Adds architecture-review on top of normal gates.

--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -23,6 +23,12 @@ no longer an automated check.
    to `formulas` when the diff actually touches numeric tables or thresholds — so the
    expensive independent cross-check fires when a *value* could be wrong, not merely
    because a rules file was edited.
+3. **Issue-intent floor (asymmetric).** A change may declare, via its issue's
+   `route:*` label, that it is riskier than its filenames suggest. The label can only
+   *raise* the route — `max(diff-route, issue-route)` — never lower it. Pass it with
+   `tools/route.sh --issue <n>` (reads the label) or `--issue-route <route>` (supplies
+   it directly). A `route:architecture` intent *adds* the architecture review rather
+   than replacing the base route.
 
 ## Routes and required gates
 
@@ -30,8 +36,8 @@ no longer an automated check.
 |---|---|---|
 | `docs` | `*.md`, `docs/**` | `ci`, `scope-warden` |
 | `tooling` | `.github/**`, `tools/**`, `*.sln`, `global.json`, anything unmatched | `ci`, `scope-warden` |
-| `rules` | `src/Brp.Core/**`, `src/Brp.Rules/**` (ordinary implementation) | `ci`, `scope-warden`, `rules-conformance` |
-| `formulas` | `src/Brp.Data/**` ruleset JSON, **or** a `rules` change whose diff touches numeric tables/thresholds | `ci`, `scope-warden`, `rules-conformance`, `codex-conformance` |
+| `rules` | `src/Brp.Core/**`, `src/Brp.Rules/**`, `src/Brp.Data/**/*.cs` (loaders/models — ordinary implementation) | `ci`, `scope-warden`, `rules-conformance` |
+| `formulas` | `src/Brp.Data/**/*.json` (printed numeric tables), **or** a `rules` change whose diff touches numeric tables/thresholds | `ci`, `scope-warden`, `rules-conformance`, `codex-conformance` |
 | `architecture` | `**/*.csproj`, `Directory.Build.props` (project boundaries/refs) | *(above, per the other files)* **+** `architecture-review` |
 
 `formulas` is a strict superset of `rules`. `architecture` composes with whatever
@@ -69,11 +75,21 @@ tools/route.sh --base origin/main
 # Classify specific paths
 tools/route.sh src/Brp.Data/damage-ruleset.json
 
+# Raise the route to a linked issue's declared intent (never lowers it)
+tools/route.sh --base origin/main --issue 112
+tools/route.sh --issue-route formulas src/SomeLoader.cs
+
 # Machine-readable, for the orchestrator / state machine
 tools/route.sh --json --base origin/main
 ```
 
-`--json` emits `{ "route", "architecture", "escalated", "gates": [...], "files": [...] }`.
+`--json` emits
+`{ "route", "architecture", "escalated", "issueRoute", "issueRaised", "gates": [...], "files": [...] }`.
+
+`src/Brp.Data` is split by kind: the `*.json` files are the printed numeric tables
+(route `formulas` — verify every value), while the `*.cs` loaders/models route to
+`rules` and are promoted to `formulas` only when their diff actually touches numeric
+content. So editing a loader no longer triggers the expensive Codex route.
 
 ## Labels
 
@@ -83,10 +99,15 @@ The derived route can be surfaced on issues/PRs as a `route:*` label
 applied automatically by the now-removed `route-gates` workflow; apply them by hand
 (or from a new workflow) if you want them.
 
+A `route:*` label on an **issue** is also an *input*, not just a readout: it declares
+the change's intended risk, and `tools/route.sh --issue <n>` reads it as the
+asymmetric floor described above.
+
 ## Enforcement
 
-Merges into `main` are gated by `build-and-test` (required status check) plus the
-`pr-policy` and `orchestration-policy` workflows. The model-driven per-route gates
+Merges into `main` are gated by three required status checks — `build-and-test`,
+`pr-policy`, and `orchestration-policy` (strict policy: the branch must be current
+with `main`). The model-driven per-route gates
 (`scope-warden`, `rules-conformance`, `codex-conformance`, `architecture-review`)
 and the `gates-satisfied` aggregate that once combined them were removed in #90/#91
 — they never posted a result on any PR. The route table above is retained as the

--- a/tools/ready-issues.sh
+++ b/tools/ready-issues.sh
@@ -1,32 +1,83 @@
 #!/usr/bin/env bash
-# tools/ready-issues.sh — the scheduler query: which open issues have no unresolved
-# blockers (the "ready leaves"). This is the deterministic question the orchestrator
-# asks to pick the next work, now that dependencies are a native GitHub graph rather
-# than prose.
+# tools/ready-issues.sh — the scheduler query: which open issues are actually
+# DISPATCHABLE for autonomous implementation (the "ready leaves").
 #
-#   tools/ready-issues.sh           classify every open issue as READY or blocked
-#   tools/ready-issues.sh --ready   print only the ready issue numbers (one per line)
+#   tools/ready-issues.sh           classify every open issue, with the reason
+#   tools/ready-issues.sh --ready   print only the dispatchable issue numbers
 #
-# An issue is READY when none of its native `blocked_by` dependencies are still open.
+# Two independent concepts, deliberately kept apart:
+#
+#   * mechanically unblocked — none of the issue's native `blocked_by`
+#     dependencies are still open. This is a GitHub-graph fact.
+#   * approved for autonomous work — the issue carries the `ready` label and is
+#     not held by a human gate (`blocked` / `needs-design`) and is not an epic
+#     (an umbrella that is never itself implementable).
+#
+# An issue is DISPATCHABLE only when BOTH hold. The old query consulted only
+# `blocked_by` and so reported epics, human-gated design issues, and even a
+# `blocked`-labelled issue as ready — an autonomous dispatcher would then pick up
+# an epic or a design issue first. See issue #124.
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# A human gate: an issue carrying any of these labels is NOT for autonomous work,
+# even if its label:ready and its blockers are closed. `epic` is handled
+# separately (it also fails the label:ready requirement in practice, but we never
+# want an umbrella dispatched even if someone mislabels it `ready`).
+HUMAN_GATE_LABELS=(blocked needs-design)
 
 ready_only=0
 [ "${1:-}" = "--ready" ] && ready_only=1
 
-mapfile -t open < <(gh issue list --state open --limit 200 --json number --jq '.[].number' | sort -n)
+# One list call carries number, title, and labels — we only hit the per-issue
+# dependencies API for candidates that already pass the label filter.
+issues_json="$(gh issue list --state open --limit 200 \
+  --json number,title,labels --jq 'sort_by(.number)')"
 
-for n in "${open[@]}"; do
-  open_blockers="$(gh api "repos/{owner}/{repo}/issues/$n/dependencies/blocked_by" \
-    --jq '[.[] | select(.state=="open") | .number] | join(" ")' 2>/dev/null || true)"
-  if [ -z "$open_blockers" ]; then
+# Does this issue's label set contain $1 ?
+has_label() { printf '%s' "$2" | tr ',' '\n' | grep -qx "$1"; }
+
+open_blockers_of() {
+  gh api "repos/{owner}/{repo}/issues/$1/dependencies/blocked_by" \
+    --jq '[.[] | select(.state=="open") | .number] | join(" ")' 2>/dev/null || true
+}
+
+# Walk issues via a stable, newline-delimited projection (no subshell-per-issue).
+while IFS=$'\t' read -r n title labels; do
+  [ -z "$n" ] && continue
+
+  # --- label gate: cheap, deterministic, no API call ---------------------- #
+  reason=""
+  is_epic=0
+  # Epic by label, or by the "Epic:" title convention as a fallback.
+  if has_label epic "$labels" || [[ "$title" =~ ^Epic: ]]; then
+    is_epic=1
+    reason="epic (umbrella, not implementable)"
+  fi
+  if [ -z "$reason" ]; then
+    for g in "${HUMAN_GATE_LABELS[@]}"; do
+      if has_label "$g" "$labels"; then reason="human-gated (label:$g)"; break; fi
+    done
+  fi
+  if [ -z "$reason" ] && ! has_label ready "$labels"; then
+    reason="not approved (no label:ready)"
+  fi
+
+  # --- dependency gate: only for label-clean candidates ------------------- #
+  open_blockers=""
+  if [ -z "$reason" ]; then
+    open_blockers="$(open_blockers_of "$n")"
+    [ -n "$open_blockers" ] && reason="blocked_by: $open_blockers"
+  fi
+
+  if [ -z "$reason" ]; then
     if [ "$ready_only" = 1 ]; then
       echo "$n"
     else
-      title="$(gh issue view "$n" --json title --jq .title)"
-      printf 'READY    #%-4s %s\n' "$n" "$title"
+      printf 'READY      #%-4s %s\n' "$n" "$title"
     fi
   elif [ "$ready_only" = 0 ]; then
-    printf 'blocked  #%-4s waiting on: %s\n' "$n" "$open_blockers"
+    printf 'not-ready  #%-4s %-40s %s\n' "$n" "$reason" "$title"
   fi
-done
+done < <(printf '%s\n' "$issues_json" \
+  | jq -r '.[] | [(.number|tostring), .title, ([.labels[].name]|join(","))] | @tsv')

--- a/tools/route.sh
+++ b/tools/route.sh
@@ -27,16 +27,39 @@ MAP="$ROOT/.github/route-map"
 
 JSON=0
 BASE=""
+ISSUE_ROUTE=""     # an explicit intent floor, e.g. --issue-route formulas
+ISSUE_NUM=""       # or --issue N, from which we read the issue's route:* label
 FILES=()
 while [ $# -gt 0 ]; do
   case "$1" in
-    --json) JSON=1; shift ;;
-    --base) BASE="${2:-}"; shift 2 ;;
+    --json)        JSON=1; shift ;;
+    --base)        BASE="${2:-}"; shift 2 ;;
+    --issue-route) ISSUE_ROUTE="${2:-}"; shift 2 ;;
+    --issue)       ISSUE_NUM="${2:-}"; shift 2 ;;
     --)     shift; while [ $# -gt 0 ]; do FILES+=("$1"); shift; done ;;
     -*)     echo "unknown option: $1" >&2; exit 2 ;;
     *)      FILES+=("$1"); shift ;;
   esac
 done
+
+# Issue-intent escalation is ASYMMETRIC: a change's declared intent may RAISE its
+# route but never lower it. The diff sees only filenames; an issue's `route:*`
+# label carries the author's knowledge that a change is riskier than it looks.
+# `--issue N` reads that label; `--issue-route R` supplies it directly.
+iprec() { case "$1" in docs) echo 1 ;; tooling) echo 2 ;; rules) echo 3 ;; formulas) echo 4 ;; architecture) echo 5 ;; *) echo 0 ;; esac; }
+if [ -n "$ISSUE_NUM" ] && [ -z "$ISSUE_ROUTE" ]; then
+  # Take the highest-precedence route:* label if the issue carries more than one.
+  while IFS= read -r r; do
+    [ -z "$r" ] && continue
+    [ "$(iprec "$r")" -gt "$(iprec "${ISSUE_ROUTE:-}")" ] && ISSUE_ROUTE="$r"
+  done < <(gh issue view "$ISSUE_NUM" --json labels \
+             --jq '.labels[].name | select(startswith("route:")) | ltrimstr("route:")' \
+             2>/dev/null || true)
+fi
+case "${ISSUE_ROUTE:-}" in
+  ""|docs|tooling|rules|formulas|architecture) ;;
+  *) echo "invalid --issue-route: $ISSUE_ROUTE (docs|tooling|rules|formulas|architecture)" >&2; exit 2 ;;
+esac
 
 if [ ${#FILES[@]} -eq 0 ]; then
   if [ -n "$BASE" ]; then
@@ -121,6 +144,18 @@ if [ "$base" = "rules" ]; then
   fi
 fi
 
+# Issue-intent floor (asymmetric): raise the route to the declared intent, never
+# lower it. `architecture` intent adds the architecture review rather than
+# replacing the base route (it composes, exactly like a changed .csproj would).
+issue_raised=0
+if [ -n "$ISSUE_ROUTE" ]; then
+  if [ "$ISSUE_ROUTE" = "architecture" ]; then
+    [ "$arch" = 0 ] && { arch=1; issue_raised=1; }
+  elif [ "$(prec "$ISSUE_ROUTE")" -gt "$(prec "$base")" ]; then
+    base="$ISSUE_ROUTE"; issue_raised=1
+  fi
+fi
+
 case "$base" in
   docs | tooling) gates="ci scope-warden" ;;
   rules)          gates="ci scope-warden rules-conformance" ;;
@@ -131,11 +166,14 @@ esac
 if [ "$JSON" = 1 ]; then
   gj=""; for x in $gates; do gj+="\"$x\","; done; gj="${gj%,}"
   fj=""; for x in "${FILES[@]}"; do [ -z "$x" ] && continue; fj+="\"$x\","; done; fj="${fj%,}"
-  printf '{"route":"%s","architecture":%s,"escalated":%s,"gates":[%s],"files":[%s]}\n' \
+  printf '{"route":"%s","architecture":%s,"escalated":%s,"issueRoute":%s,"issueRaised":%s,"gates":[%s],"files":[%s]}\n' \
     "$base" "$([ "$arch" = 1 ] && echo true || echo false)" \
-    "$([ "$escalated" = 1 ] && echo true || echo false)" "$gj" "$fj"
+    "$([ "$escalated" = 1 ] && echo true || echo false)" \
+    "$([ -n "$ISSUE_ROUTE" ] && echo "\"$ISSUE_ROUTE\"" || echo null)" \
+    "$([ "$issue_raised" = 1 ] && echo true || echo false)" "$gj" "$fj"
 else
   suffix=""; [ "$arch" = 1 ] && suffix=" (+architecture)"; [ "$escalated" = 1 ] && suffix="$suffix (content-escalated)"
+  [ "$issue_raised" = 1 ] && suffix="$suffix (issue-intent: route:$ISSUE_ROUTE)"
   echo "route: ${base}${suffix}"
   echo "gates: ${gates// /, }"
 fi


### PR DESCRIPTION
## Linked Issue

Closes #124
Closes #125

## Exact behavioral claim

`tools/ready-issues.sh --ready` now lists only issues that are genuinely dispatchable for autonomous implementation — open, `label:ready`, no open `blocked_by`, not human-gated (`blocked`/`needs-design`), and not an epic. Against today's board that is exactly `#112`. This prevents an autonomous dispatcher from picking up an epic (#53/#98) or a human-gated design issue (#61 is `blocked`, #101/#104/#105 are `needs-design`) as its next unit of work — the old query consulted only native `blocked_by` and reported 11 issues as READY.

Routing: `src/Brp.Data/*.json` (printed numeric tables) routes to `formulas`; `src/Brp.Data/*.cs` loaders route to `rules` and escalate to `formulas` only on numeric-content change — so editing a boring loader no longer triggers the expensive Codex route. An issue's `route:*` label can now *raise* a change's route (`--issue`/`--issue-route`) but never lower it.

## Scope

Changed: `tools/ready-issues.sh` (label-aware dispatch), `tools/route.sh` (asymmetric issue-intent floor), `.github/route-map` (Brp.Data split), `docs/orchestration/routing.md` (docs). Also added an `epic` label and applied it to #53/#98 so umbrellas are excluded deterministically.

Deliberately unchanged: the native `blocked_by` dependency graph, the content-escalation regex set, and the route→gates table. Escalation remains asymmetric — it only ever *raises* the gate set.

## Rules conformance

N/A — this is orchestration tooling and docs; it touches no rules engine code (`Brp.Core`/`Brp.Rules`/`Brp.Data`) and no printed table.

## Tests and evidence

Local verification (no CI-visible engine change):

- `bash -n tools/ready-issues.sh && bash -n tools/route.sh` — syntax OK.
- `tools/ready-issues.sh --ready` → `112` (was: `53 61 98 101 105 112 113 114 115 116 122`).
- `tools/ready-issues.sh` → full listing prints the hold reason for every non-ready issue (epic / human-gated / no label:ready / blocked_by).
- `tools/route.sh src/Brp.Data/damage-ruleset.json` → `formulas`; `tools/route.sh src/Brp.Data/NoirDamageRuleset.cs` → `rules`.
- `tools/route.sh --issue-route formulas README.md` → raised to `formulas`; `tools/route.sh --issue-route docs src/Brp.Data/damage-ruleset.json` → stays `formulas` (never lowered); `tools/route.sh --issue-route architecture src/Brp.Core/Foo.cs` → `rules (+architecture)`; invalid route → exit 2.
- `tools/route.sh --issue 125 README.md` → `tooling` (reads the issue's `route:tooling` label).
- `bash tools/orchestration-policy.sh` → PASS.

## Decisions and tradeoffs

- Epics are excluded by an `epic` label (applied to #53/#98), with a `^Epic:` title fallback — a deterministic signal rather than title-parsing alone.
- Human-gate label set is `blocked`, `needs-design` (a named constant in the script).
- The `.cs`→`rules` split relies on the existing content-escalation to catch numeric edits. The ruleset `.cs` files are near-numberless loaders (the tables are the embedded `*.json`), so this is the correct place to draw the line.

## Known limitations

- `--issue` reads the label via `gh`; in an offline/unauthenticated context it degrades to no-raise (the diff route stands). Wiring `--issue` automatically into `pr-policy` CI is left as follow-up.
- The content-escalation regex targets table/threshold shapes (`=>`, `:`, `[`, comparisons, `,`), not plain `= N` assignments — unchanged from before, and adequate because the numeric data lives in the `*.json` files.

## Agent provenance

Implemented by Claude (Opus 4.8) driving the repo directly. Verified locally with the commands above.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).