### PR TITLE
Stop storing live issue/test state in ROADMAP, AGENTS, README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,18 +93,21 @@ characteristics with live-recomputing derived values (`Abilities/`), and the ski
 (`Skills/`). `Brp.Rules` (Layers 3–4) adds characters — point-buy creation and tick-on-use
 experience — and combat: range bands, the combat round, the attack/defense matrix, gear,
 damage/wounds, spot rules, injury, and fumble tables (`Combat/`). `Brp.Data` supplies the
-ruleset JSON. The solution has ~2,168 tests, including printed tables reproduced cell by cell.
+ruleset JSON. The test suite reproduces the printed tables cell by cell (`dotnet test`
+reports the live count — it is deliberately not pinned here, where it would only go stale).
 
 `tools/Brp.Cli` is the `brp` command line over that kernel — one command, `roll`, which
 resolves a check and prints its whole derivation. It has its own `AGENTS.md`.
 
 **What's left — the engine is NOT complete.** A 2026-08-31 completeness audit found Layers 0–1
 and skill *data* correct, but a real backlog of in-scope, book-derivable gaps — several marked ON
-by the scope filter/ADRs yet never built. See [`ROADMAP.md`](ROADMAP.md) for the ordered backlog;
-the high-priority ones: skill category bonus not applied in the engine (#110), Major Wounds effect
-(#111), hit locations (#112), healing/recovery (#109). Layer 5 — the noir game (cases, clue-routing,
-interrogation, #98) — has not started and is design-led. `engine-implementation-plan.md` §3 has the
-layer map — the *structure* there is sound even though its formulas are not.
+by the scope filter/ADRs yet never built. See [`ROADMAP.md`](ROADMAP.md) for the ordered *plan*
+(priority and rationale); the live backlog itself is the open `rules`/`data` feature issues —
+`tools/ready-issues.sh --ready` selects the next one. (Specific issue numbers are deliberately not
+listed here; they drift as issues merge. GitHub owns state, this file owns the invariants.) Layer 5
+— the noir game (cases, clue-routing, interrogation) — has not started and is design-led.
+`engine-implementation-plan.md` §3 has the layer map — the *structure* there is sound even though
+its formulas are not.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ in Issues. Neither is duplicated here.
 
 ## Status
 
-Phase 1 validation underway alongside engine Layer 0, which is complete (dice, resolution kernel, modifier pipeline, resistance and opposed rolls; ~890 tests). Phase 0 decisions locked — see the development plan). Decisions made so far: modern-day era, player-created protagonist via point-buy with background packages, open city structured as map nodes with multiple concurrent intersecting cases, junction-only case decay, pre-seeded rolls, tick-on-use advancement, commercial release intent. Platform and engine undecided until the vertical slice.
+The BRP engine is built through Layer 4 (dice and resolution kernel, abilities, skills,
+characters, and combat), with an objective completeness backlog; Layer 5 — the noir game —
+has not started and is design-led. See [`ROADMAP.md`](ROADMAP.md) for the ordered plan and
+GitHub Issues for live status (this section states no counts or per-issue state, which only
+go stale). Phase 0 decisions are locked — see the development plan. Decisions made so far:
+modern-day era, player-created protagonist via point-buy with background packages, open city
+structured as map nodes with multiple concurrent intersecting cases, junction-only case decay,
+pre-seeded rolls, tick-on-use advancement, commercial release intent. Platform and engine
+undecided until the vertical slice.
 
 ## Licensing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,7 @@ NoiRPG is an **engine** (`Brp.*`, a faithful Basic Roleplaying rules engine) wit
 |---|---|---|
 | 0 | dice / entropy / resolution kernel / modifier pipeline | ✅ done |
 | 1 | abilities: characteristics-as-data, rolls, recomputing derived values | ✅ done |
-| 2 | skills: definitions, specialties, registry (category-bonus *application* is a gap — #110) | ✅ data done |
+| 2 | skills: definitions, specialties, registry | ✅ data done |
 | 3 | characters: aggregate, point-buy, tick-on-use experience | ✅ done |
 | 4 | combat: range bands (#21), combat round (#47), attack/defense matrix (#49), gear, damage (#52), spot rules (#50), injury (#96), fumble tables (#97) | 🚧 scaffold done; **completeness backlog open** — see below |
 | 5 | the noir game: cases, clue-routing, interrogation | ⬜ not started (design-led) |
@@ -45,8 +45,8 @@ NoiRPG is an **engine** (`Brp.*`, a faithful Basic Roleplaying rules engine) wit
 **A 2026-08-31 engine-completeness audit** (six parallel domain auditors vs. the book + `orc-scope-filter.md`)
 found Layers 0–1 and skill *data* complete and correct, but a real backlog of in-scope, book-derivable
 gaps — several of them mechanics the scope filter/ADRs marked **ON** that were never built. So the engine
-is **not** complete; "Layer 4 nearly done" was wrong. The backlog is objective (no playtesting) and tracked
-below.
+is **not** complete; "Layer 4 nearly done" was wrong. The backlog is objective (no playtesting); its live
+contents live on GitHub (see below), not in this file.
 
 **Game — Phase 0/1 partially done on paper** (interrogation design, a paper case, the case
 schema, advancement sim), **Phase 2+ (game code) not started, and design-led (needs a human, not agents).**
@@ -55,40 +55,41 @@ schema, advancement sim), **Phase 2+ (game code) not started, and design-led (ne
 
 ## What to build next (ordered)
 
+Two bodies of work remain, and they differ in *kind* — one is objective and closable
+cold, the other is design-led. This section owns the **ordering and the reasons**;
+GitHub owns the live list of what is open. (This file used to enumerate specific
+issues as "still to build" and drifted the moment they merged — don't reintroduce
+that. State lives in the issue tracker; meaning lives here.)
+
 ### 1. Complete the engine (objective, book-derivable — no playtesting; the audit's backlog)
 
-All of these are ideal team work (engine-dev implements; rules-extractor / rules-conformance /
-scope-warden verify — the workflow that shipped #50/#96/#97).
+This is ideal team work: engine-dev implements; rules-extractor / rules-conformance /
+scope-warden verify. It needs no playtesting — where the book prints a table, that
+table is the authority.
 
-**🔴 High** — the four that stand between here and a whole injure→heal→advance engine:
-- **[#110] Skill category bonus** applied in the engine (ADR 0006 mandates it; today it lives only in a Python tool, so player-built characters silently lack it).
-- **[#111] Major Wounds effect** + a damage amount on `Wound` (only the *threshold* exists).
-- **[#112] Hit locations** — formally decided ON (#4), only string scaffolding exists.
-- **[#109] Healing / recovery** — First Aid, natural healing (flat 1D3/week), characteristic restoration.
-
-**🟡 Medium:**
-- **[#113]** special-damage *effects* (crushing stun, impaling lodged) + Fighting Defensively.
-- **[#114]** complimentary/augment skills (+1/5).
-- **[#115]** advancement: Research (self-study) + the default-+3 gain option.
-
-**🟢 Low-Med:**
-- **[#116]** Ch 8 world cluster — equipment quality, gear↔skill, wealth, item HP, vehicles, drugs.
+**The live backlog is on GitHub, not here:** the open `feature` issues labelled
+`rules` / `data`. `tools/ready-issues.sh --ready` selects the next dispatchable one.
+Work it highest-value-first — finish the injure → heal → advance spine (hit locations
+and the remaining combat-completeness and advancement mechanics) before the lower-value
+Ch 8 world cluster (equipment quality, gear↔skill, wealth, item HP, vehicles, drugs).
+The issue labels and `ready-issues.sh` carry the per-item detail and current status.
 
 ### 2. Then Layer 5 — the game (design-led; the owner drives, agents support)
-- **[#98] Epic: the noir game layer (`Noir.Rules` + `Noir.Scenario`)** — case schema→code, the
-  Three Doors clue-routing engine, narrative-state junction budget, and the **interrogation
-  minigame**.
 
-> **Read this before choosing.** `development-plan.md` is blunt: *"if interrogations are fun, the
-> game works; if not, nothing else rescues it."* The engine is the well-understood, objective part;
-> the game's three original systems (clue routing, narrative state, interrogation) are the real risk
-> and the actual product — and they are **design work that needs a human, not agents** (the #98
-> entry point #101 is a paper playtest only a person can judge). Its sub-issues are decomposed under
-> #98 (#101–#105).
+The noir game layer (`Noir.Rules` + `Noir.Scenario`) — case schema → code, the Three
+Doors clue-routing engine, the narrative-state junction budget, and the **interrogation
+minigame** — is the real risk and the actual product.
 
-**Recommended sequence:** finish the engine backlog above (the team, in priority order — start with
-the 🔴 items), which is objective and closable cold; the Layer-5 game (#98) advances when the owner
-runs the Phase-1 playtest and drives the design.
+> **Read this before choosing.** `development-plan.md` is blunt: *"if interrogations are
+> fun, the game works; if not, nothing else rescues it."* The engine is the
+> well-understood, objective part; the game's three original systems (clue routing,
+> narrative state, interrogation) are **design work that needs a human, not agents** —
+> their entry point is a paper playtest only a person can judge. The epic and its
+> sub-issues live on GitHub (labelled `scenario` / `noir`, and `needs-design` where a
+> human gate applies).
+
+**Recommended sequence:** finish the engine backlog first (objective, closable cold);
+the Layer-5 game advances when the owner runs the Phase-1 playtest and drives the design.
 
 ---
 


### PR DESCRIPTION
## Linked Issue

Closes #127

## Exact behavioral claim

`ROADMAP.md`, `AGENTS.md`, and `README.md` no longer assert per-issue open/closed state or hard test counts — state that GitHub already owns and that had drifted stale. This prevents a reader (human or agent) from acting on a doc that lists merged work as "still to build": before this change ROADMAP listed #109/#110/#111 as open High gaps (all merged as #123/#121/#120), AGENTS pinned "~2,168 tests" and the same merged issues, and README called the engine "Layer 0, complete" with "~890 tests" (it is built through Layer 4).

The docs keep what is stable — ordering, rationale, invariants — and defer live state to GitHub: `tools/ready-issues.sh --ready` selects the next dispatchable issue; `dotnet test` reports the live count.

## Scope

Changed: `ROADMAP.md` ("What to build next" rewritten to own ordering/rationale, not an issue list; stale gap note removed from the layer table), `AGENTS.md` (test count and merged-issue list removed), `README.md` (Status paragraph corrected and de-pinned).

Deliberately unchanged: historical *provenance* references to merged issues (e.g. the layer-4 "shipped by #96/#97" notes) — a merged issue stays merged, so those don't drift. Only forward-looking status assertions were removed. No engine code touched.

## Rules conformance

N/A — documentation only; no rules engine code and no printed table.

## Tests and evidence

- `tools/route.sh ROADMAP.md AGENTS.md README.md` → `docs` (gates: `ci`, `scope-warden`).
- `grep -rnE '~?[0-9,]+ tests' --include='*.md'` → no live-state test counts remain in the three docs (only a historical per-merge note in `docs/agent-team.md`, which is a record, not live state).
- `bash tools/orchestration-policy.sh` → PASS.
- Rendered the three files; links and tables intact.

## Decisions and tradeoffs

- README's Status paragraph had a second drift beyond the review's list ("Layer 0 … ~890 tests"); fixed in the same pass since it is the identical failure mode and the file already declares "current and future work lives in Issues; neither is duplicated here."
- Kept the 2026-08-31 audit reference and the "engine is NOT complete" framing — those are stable facts about the plan, not per-issue state.

## Known limitations

- The agent-brief packet (`tools/agent-brief.py`) is the intended place to surface live issue status into an agent's context; this PR removes the stale duplication but does not add new brief fields. If a future reader wants status inline, it should come from the brief, not be re-pinned here.

## Agent provenance

Implemented by Claude (Opus 4.8) driving the repo directly. Verified locally with the commands above.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).