### PR TITLE
Add tools/ledger-log.sh: frictionless ledger append

### DIFF
--- a/docs/agent-team-ledger/README.md
+++ b/docs/agent-team-ledger/README.md
@@ -14,8 +14,27 @@ instrumented tasks would transform C2."* This ledger is that log.
 - [`jobs.csv`](jobs.csv) — one row per **agent job** (a single subagent dispatch).
 - [`findings.csv`](findings.csv) — one row per **finding** a verification stage raised, with
   independent validation and primary-source location. Serves the paper's blocker #3 and its Table 4.
+- [`human-minutes.csv`](human-minutes.csv) — one row per **merged unit**: the wall-clock human
+  minutes and intervention count it cost. This is the headline optimization target and lives in no
+  API — it must be logged by hand. Seeded header-only; **never add a fabricated row.**
 - [`layers.md`](layers.md) — per-layer rollups: build/verify/rework shares plus the §6.5 net-value
   metric skeleton.
+
+## Appending a row
+
+Do not hand-edit the CSVs — one command keeps the columns aligned and the unmeasured fields set to
+`NI` (never `0`):
+
+```bash
+tools/ledger-log.sh job   --layer 4 --issue 112 --pr 130 --seq 1 --phase build \
+                          --agent-role engine-dev-implement --model sonnet --effort medium \
+                          --tokens-total 210000 --tests-after 2260 --outcome "…"
+tools/ledger-log.sh human --issue 112 --pr 130 --merge-sha <sha> --interventions 0 \
+                          --note "one review pass, merged clean"
+```
+
+`ledger-log.sh human` refuses an all-`NI` row, so the file never fills with invented measurements.
+Any field name is a `--kebab-case` flag of its column; omitted fields default to `NI`.
 
 ## Unit of record
 

--- a/docs/agent-team-ledger/human-minutes.csv
+++ b/docs/agent-team-ledger/human-minutes.csv
@@ -1,0 +1,1 @@
+issue,pr,merge_sha,human_minutes,interventions,note

--- a/docs/orchestration/metrics.md
+++ b/docs/orchestration/metrics.md
@@ -99,12 +99,20 @@ many minutes a human spent, or how many times they had to step in. The tool read
 optional log if present, and otherwise prints `(not tracked / needs manual input)` so the
 target stays visible on every report even before it is instrumented.
 
-## The optional `human-minutes.csv`
+## The `human-minutes.csv`
 
-To start capturing the headline metric, create
-`docs/agent-team-ledger/human-minutes.csv` with this header (one row per merged
-issue/PR). **Do not commit fabricated rows** — add a row only when you have actually
-measured the time:
+The headline metric is captured one row per merged issue/PR in
+`docs/agent-team-ledger/human-minutes.csv` (seeded header-only). **Do not commit
+fabricated rows** — add a row only when you have actually measured the time. Append
+with the ledger helper rather than editing the CSV by hand:
+
+```bash
+tools/ledger-log.sh human --issue 112 --pr 130 --merge-sha <sha> \
+                          --human-minutes 6 --interventions 0 --note "merged clean"
+```
+
+The helper refuses an all-`NI` row, so a real measurement (`--human-minutes` and/or
+`--interventions`) is required. The header is:
 
 ```csv
 issue,pr,merge_sha,human_minutes,interventions,note

--- a/tools/ledger-log.sh
+++ b/tools/ledger-log.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# tools/ledger-log.sh — append one row to an agent-team ledger CSV, so logging a
+# job or a human-attention datum is a single command instead of hand-editing a
+# 28-column CSV. This is the frictionless capture the metrics tool
+# (tools/orchestration-metrics.py) has been waiting on: the ledger only measures
+# what actually gets written, and a manual CSV edit per agent run does not happen.
+#
+#   tools/ledger-log.sh job   --layer 4 --issue 112 --pr 130 --seq 1 \
+#                             --phase build --agent-role engine-dev-implement \
+#                             --model sonnet --effort medium --tokens-total 210000 \
+#                             --tests-after 2260 --outcome "Hit-location table + resolver"
+#
+#   tools/ledger-log.sh human --issue 112 --pr 130 --merge-sha abc1234 \
+#                             --human-minutes 6 --interventions 0 \
+#                             --note "one review pass, merged clean"
+#
+# Design rules (matching docs/orchestration/metrics.md and the ledger README):
+#   * Unmeasured numeric fields default to `NI` ("not instrumented"), never 0 —
+#     the metrics tool skips NI rather than treating it as a real value.
+#   * `human` refuses an all-NI row: at least one of --human-minutes /
+#     --interventions must be a real measurement. Do NOT commit fabricated rows.
+#   * Values are CSV-escaped; the row is appended atomically after a header check.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LEDGER="$ROOT/docs/agent-team-ledger"
+JOBS_CSV="$LEDGER/jobs.csv"
+HUMAN_CSV="$LEDGER/human-minutes.csv"
+
+die() { echo "ledger-log: $*" >&2; exit 2; }
+
+# The column order is the CONTRACT with jobs.csv / metrics.py — do not reorder.
+JOB_COLS=(layer issue pr seq date phase agent_role model effort risk_class
+  review_layer tokens_total tokens_R tokens_A tokens_H tool_uses duration_ms
+  human_minutes cost_usd commit merge_sha defects_found false_positives
+  defects_fixed deterministic_controls_added repeated_error tests_after outcome)
+HUMAN_COLS=(issue pr merge_sha human_minutes interventions note)
+
+# --kebab-flag -> snake_case column name.
+flag_to_col() { printf '%s' "${1#--}" | tr '-' '_'; }
+
+# CSV-escape one field: quote it when it holds a comma, quote, CR, or LF.
+csv_escape() {
+  local v="$1"
+  if [[ "$v" == *[,\"$'\n'$'\r']* ]]; then
+    v="${v//\"/\"\"}"
+    printf '"%s"' "$v"
+  else
+    printf '%s' "$v"
+  fi
+}
+
+# Append CSV row "$@" to file $1, ensuring the file ends in a newline first.
+append_row() {
+  local file="$1"; shift
+  local line="" first=1 f
+  for f in "$@"; do
+    [ "$first" = 1 ] && first=0 || line+=","
+    line+="$(csv_escape "$f")"
+  done
+  # Guarantee a trailing newline on the existing file so we never join two rows.
+  [ -s "$file" ] && [ -n "$(tail -c1 "$file")" ] && printf '\n' >> "$file"
+  printf '%s\n' "$line" >> "$file"
+}
+
+# Verify the on-disk header matches our column contract, so a silent schema drift
+# fails loudly instead of writing misaligned rows.
+check_header() {
+  local file="$1"; shift
+  local expected; expected="$(IFS=,; echo "$*")"
+  local actual; actual="$(head -1 "$file")"
+  [ "$actual" = "$expected" ] || die "header mismatch in $(basename "$file")
+  expected: $expected
+  actual:   $actual"
+}
+
+subcmd="${1:-}"; shift || true
+[ -n "$subcmd" ] || die "usage: ledger-log.sh {job|human} --field value ..."
+
+declare -A VAL=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --*) [ $# -ge 2 ] || die "flag $1 needs a value"
+         VAL["$(flag_to_col "$1")"]="$2"; shift 2 ;;
+    *)   die "unexpected argument: $1 (use --field value)" ;;
+  esac
+done
+
+case "$subcmd" in
+  job)
+    check_header "$JOBS_CSV" "${JOB_COLS[@]}"
+    # date defaults to today; a logging timestamp, not engine state.
+    [ -n "${VAL[date]:-}" ] || VAL[date]="$(date +%F)"
+    row=()
+    for c in "${JOB_COLS[@]}"; do
+      if [ "$c" = outcome ]; then
+        row+=("${VAL[$c]:-}")            # free-text summary; empty is fine
+      else
+        row+=("${VAL[$c]:-NI}")          # unmeasured -> NI, never 0
+      fi
+    done
+    # Reject unknown flags — a typo'd column name is a silent data-loss bug.
+    for k in "${!VAL[@]}"; do
+      printf '%s\n' "${JOB_COLS[@]}" | grep -qx "$k" || die "unknown job field: --${k//_/-}"
+    done
+    append_row "$JOBS_CSV" "${row[@]}"
+    echo "logged job: issue=${VAL[issue]:-NI} pr=${VAL[pr]:-NI} seq=${VAL[seq]:-NI} role=${VAL[agent_role]:-NI}"
+    ;;
+
+  human)
+    # Never fabricate: require at least one real measurement.
+    hm="${VAL[human_minutes]:-}"; iv="${VAL[interventions]:-}"
+    if { [ -z "$hm" ] || [ "$hm" = NI ]; } && { [ -z "$iv" ] || [ "$iv" = NI ]; }; then
+      die "refusing an all-NI row — measure --human-minutes and/or --interventions first"
+    fi
+    for k in "${!VAL[@]}"; do
+      printf '%s\n' "${HUMAN_COLS[@]}" | grep -qx "$k" || die "unknown human field: --${k//_/-}"
+    done
+    if [ ! -f "$HUMAN_CSV" ]; then
+      (IFS=,; echo "${HUMAN_COLS[*]}") > "$HUMAN_CSV"
+    fi
+    check_header "$HUMAN_CSV" "${HUMAN_COLS[@]}"
+    row=()
+    for c in "${HUMAN_COLS[@]}"; do
+      if [ "$c" = note ]; then row+=("${VAL[$c]:-}"); else row+=("${VAL[$c]:-NI}"); fi
+    done
+    append_row "$HUMAN_CSV" "${row[@]}"
+    echo "logged human: issue=${VAL[issue]:-NI} pr=${VAL[pr]:-NI} minutes=${hm:-NI} interventions=${iv:-NI}"
+    ;;
+
+  *) die "unknown subcommand: $subcmd (job|human)" ;;
+esac


### PR DESCRIPTION
## Linked Issue

Closes #128

## Exact behavioral claim

Appending an agent-team ledger row is now one command instead of hand-editing a 28-column CSV. `tools/ledger-log.sh job …` appends a `jobs.csv` row per agent run; `tools/ledger-log.sh human …` appends a `human-minutes.csv` row per merged unit. This is the friction that kept the ledger empty (only #40/#41 logged) and the headline "human attention per merged unit" metric unpopulated. The `human` subcommand refuses an all-`NI` row, so the headline file can never fill with fabricated measurements.

## Scope

Added: `tools/ledger-log.sh`; `docs/agent-team-ledger/human-minutes.csv` (header only — no rows). Changed: `docs/agent-team-ledger/README.md` and `docs/orchestration/metrics.md` to point at the helper instead of hand-editing.

Deliberately unchanged: `jobs.csv` / `findings.csv` contents (no rows added — this PR ships the mechanism, not fabricated data), the 28-column `jobs.csv` schema (the tool treats it as a contract and fails loudly on drift), and `orchestration-metrics.py` (it already reads all three CSVs and degrades gracefully on a header-only file).

## Rules conformance

N/A — orchestration tooling and docs; no rules engine code, no printed table.

## Tests and evidence

- `bash -n tools/ledger-log.sh` → OK.
- `tools/ledger-log.sh job --layer 4 --issue 112 --pr 130 --seq 1 --phase build --agent-role engine-dev-implement --model sonnet --effort medium --tokens-total 210000 --tests-after 2260 --outcome "…"` → appended a row; `csv.reader` confirms 28 fields, aligned with the header; `date` auto-filled; free-text `outcome` correctly quoted. (Tested against a backup copy, then restored — `git diff jobs.csv` is empty.)
- `tools/ledger-log.sh human … --interventions 0` → creates the file with header and appends an aligned 6-field row; with no measurement it exits 2 (`refusing an all-NI row`).
- Unknown field (`--bogus-field`) → exits 2 (`unknown job field`).
- `tools/orchestration-metrics.py --limit 1` → reads the header-only `human-minutes.csv` and prints "no rows logged" (no crash).
- `bash tools/orchestration-policy.sh` → PASS.

## Decisions and tradeoffs

- The review asked the orchestrator to append a jobs row "automatically." The orchestrator is the main Claude loop (per the ledger README, it is not itself a job row), and per-agent token telemetry is not machine-parseable from `codex-agent.sh`, so the frictionless primitive is a one-command append the orchestrator calls — "data, not more code." Auto-appending from `codex-agent.sh` would write NI-heavy noise.
- Unmeasured fields default to `NI`, never `0`, matching the existing ledger/metrics convention so the metrics tool keeps skipping them rather than averaging in zeros.

## Known limitations

- Token R/A/H decomposition and `cost_usd` remain `NI` — the underlying telemetry gap the ledger README already documents; this PR does not close it.
- The helper is invoked by the orchestrator; it does not itself watch for merges. Populating historical rows is a separate, manual, measure-first activity.

## Agent provenance

Implemented by Claude (Opus 4.8) driving the repo directly. Verified locally with the commands above.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `e124c22`

| gate | result |
|---|---|
| `ci` | pass |
| `scope-warden` | pass |

_2/2 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->