### PR TITLE
Add tools/agent-verify.sh: one required status for the whole gate set

### DIFF
--- a/docs/orchestration/agent-verification.md
+++ b/docs/orchestration/agent-verification.md
@@ -1,0 +1,68 @@
+# agent-verification — one required status for the whole gate set
+
+[`tools/route.sh`](../../tools/route.sh) already says which reviewers a change
+needs. But after #90/#91 removed the gate-poster App and the `gates-satisfied`
+aggregator, that derivation was *computed and then ignored*: the model-driven gates
+(`scope-warden`, `rules-conformance`, `codex-conformance`, `architecture-review`)
+posted nothing on a PR, so GitHub could only gate on `build-and-test`, `pr-policy`,
+and `orchestration-policy`.
+
+[`tools/agent-verify.sh`](../../tools/agent-verify.sh) closes that loop without
+rebuilding the App fan-out. The **local orchestrator** runs the route's gates for the
+PR head SHA and posts a single `agent-verification` **commit status** — success only
+if `ci` passed *and* every other required gate was supplied as `pass`. GitHub then
+gates on the *contract* ("did every required gate pass for this exact SHA?"), not on
+how any model produced the answer.
+
+## Why a commit status, not a check-run
+
+A commit status binds to a SHA. Push a new commit and the `agent-verification`
+status no longer exists for the new head, so a stale approval can never ride along
+with changed code — the gate re-runs by construction. Branch protection can require
+a status context exactly as it requires a check-run, so `agent-verification` can
+become the single required external gate for the model-driven review set.
+
+## How the orchestrator uses it
+
+After running the gates for a PR (with its branch checked out, so the route — and
+its numeric content-escalation — is derived from the PR's own diff):
+
+```bash
+# 1. See what the route requires and what's missing (dry run).
+tools/agent-verify.sh <PR#>
+
+# 2. Post the aggregate status + a per-gate evidence block in the PR body.
+tools/agent-verify.sh <PR#> \
+  --gate scope-warden=pass \
+  --gate rules-conformance=pass \
+  --post --evidence
+```
+
+- `ci` is **read from GitHub** (the `build-and-test` check-run on the head SHA), never
+  supplied by hand.
+- Every *other* required gate must be supplied via `--gate NAME=pass|fail|skip`. A
+  gate the route does not require is rejected (a typo or a stale assumption); a
+  required gate left unsupplied leaves the aggregate `pending`, so **success is never
+  posted on incomplete evidence**.
+- Default is a dry run. `--post` posts the status; `--evidence` also writes a managed
+  `<!-- agent-verification -->` block into the PR body for humans.
+- Run it with the PR branch checked out. From another branch it degrades to a
+  path-only route (GitHub's changed-file list) and says so — the `rules → formulas`
+  content-escalation can't be seen without the diff.
+
+## Making it required (a deliberate flip)
+
+Posting the status is safe and additive. **Requiring** it is a separate decision with
+real blast radius: once `agent-verification` is a required check, every PR blocks
+until the orchestrator has run the gates and posted the status. Do it only once the
+orchestrator reliably posts on every PR (otherwise merges hang). To require it, add
+the context to the branch ruleset's `required_status_checks` alongside
+`build-and-test` / `pr-policy` / `orchestration-policy`:
+
+```bash
+# contexts must match byte-for-byte; confirm on a live PR first
+gh api repos/:owner/:repo/rulesets/<id> --jq '.rules[]|select(.type=="required_status_checks")'
+```
+
+Until then it is an informative, non-blocking status — the enforcement half of the
+route derivation, ready to be switched on.

--- a/tools/agent-verify.sh
+++ b/tools/agent-verify.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# tools/agent-verify.sh — collapse a PR's whole required-gate set into ONE commit
+# status the branch protection can gate on: `agent-verification`.
+#
+# The route (tools/route.sh) already says which reviewers a change needs, but
+# GitHub ignored that after #90/#91 removed the gate-poster App — the model-driven
+# gates (scope-warden, rules-conformance, codex-conformance, architecture-review)
+# were computed and never enforced. Rebuilding the App fan-out is the wrong shape:
+# GitHub should gate on the *contract* (did every required gate pass for this exact
+# SHA?), not on how any model produced the answer.
+#
+# So the local orchestrator runs the route's gates, and this script posts a single
+# `agent-verification` commit status on the PR head SHA — success only if `ci`
+# passed AND every other required gate was supplied as `pass`. Because a commit
+# status binds to the SHA, any new push invalidates it automatically. Per-gate
+# evidence is written into the PR body for humans.
+#
+# Usage:
+#   tools/agent-verify.sh <PR#> [--gate NAME=pass|fail|skip ...] [--base REF]
+#                               [--post] [--evidence]
+#
+#   * `ci` is read from GitHub (the `build-and-test` check-run) — never supplied.
+#   * every OTHER required gate must be supplied via --gate; a missing one leaves
+#     the aggregate `pending` (success is never posted on incomplete evidence).
+#   * default is a DRY RUN that prints the plan; --post actually posts the status;
+#     --evidence additionally writes the per-gate block into the PR body.
+#
+# Exit: 0 if the aggregate is success, 1 otherwise (so a caller can branch on it).
+set -euo pipefail
+
+CONTEXT="agent-verification"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+die() { echo "agent-verify: $*" >&2; exit 2; }
+
+PR=""; BASE="origin/main"; POST=0; EVIDENCE=0
+declare -A GATE=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --gate) [ $# -ge 2 ] || die "--gate needs NAME=STATE"
+            n="${2%%=*}"; s="${2#*=}"
+            case "$s" in pass|fail|skip) ;; *) die "gate state must be pass|fail|skip: $2" ;; esac
+            GATE["$n"]="$s"; shift 2 ;;
+    --base) BASE="${2:-}"; shift 2 ;;
+    --post) POST=1; shift ;;
+    --evidence) EVIDENCE=1; shift ;;
+    -*) die "unknown option: $1" ;;
+    *)  [ -z "$PR" ] || die "unexpected argument: $1"; PR="$1"; shift ;;
+  esac
+done
+[ -n "$PR" ] || die "usage: agent-verify.sh <PR#> [--gate NAME=STATE ...] [--post] [--evidence]"
+
+# --- resolve the PR ------------------------------------------------------- #
+read -r HEAD_SHA PR_URL PR_STATE < <(gh pr view "$PR" \
+  --json headRefOid,url,state --jq '[.headRefOid, .url, .state] | @tsv') \
+  || die "cannot read PR #$PR"
+[ -n "$HEAD_SHA" ] || die "PR #$PR has no head SHA"
+
+# --- derive the required gate set from the route -------------------------- #
+# The route must reflect the PR's OWN diff, not whatever is checked out. When the
+# working tree is on the PR head we use route.sh --base (full, incl. the numeric
+# content-escalation); otherwise we degrade to GitHub's changed-file list, which
+# is path-only — the rules->formulas content escalation cannot be seen — and say so.
+git -C "$ROOT" rev-parse --verify --quiet "$BASE" >/dev/null 2>&1 \
+  || git -C "$ROOT" fetch -q origin "${BASE#origin/}" 2>/dev/null || true
+LOCAL_HEAD="$(git -C "$ROOT" rev-parse --quiet --verify HEAD 2>/dev/null || echo none)"
+ROUTE_CAVEAT=""
+if [ "$LOCAL_HEAD" = "$HEAD_SHA" ]; then
+  ROUTE_JSON="$(cd "$ROOT" && tools/route.sh --json --base "$BASE" 2>/dev/null || echo '{}')"
+else
+  mapfile -t PR_FILES < <(gh pr diff "$PR" --name-only 2>/dev/null || true)
+  [ "${#PR_FILES[@]}" -gt 0 ] || die "cannot list PR #$PR changed files (and HEAD is not the PR head)"
+  ROUTE_JSON="$(cd "$ROOT" && tools/route.sh --json "${PR_FILES[@]}" 2>/dev/null || echo '{}')"
+  ROUTE_CAVEAT=" (path-only: check out the PR head for content-escalation)"
+fi
+mapfile -t REQUIRED < <(printf '%s' "$ROUTE_JSON" | \
+  python3 -c 'import sys,json;print("\n".join(json.load(sys.stdin).get("gates",[])))' 2>/dev/null || true)
+ROUTE_NAME="$(printf '%s' "$ROUTE_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("route","?"))' 2>/dev/null || echo '?')"
+[ "${#REQUIRED[@]}" -gt 0 ] || die "could not derive required gates (route: $ROUTE_NAME)"
+
+# Reject a --gate that the route does not require (a typo or a stale assumption).
+for n in "${!GATE[@]}"; do
+  printf '%s\n' "${REQUIRED[@]}" | grep -qx "$n" || die "--gate $n is not required by route '$ROUTE_NAME'"
+  [ "$n" = ci ] && die "ci is read from GitHub, not supplied via --gate"
+done
+
+# --- ci: read the build-and-test check-run on the head SHA ---------------- #
+ci_conclusion() {
+  gh api "repos/{owner}/{repo}/commits/$HEAD_SHA/check-runs" \
+    --jq '[.check_runs[] | select(.name=="build-and-test")]
+          | sort_by(.started_at) | last | .conclusion // "pending"' 2>/dev/null || echo "unknown"
+}
+
+# --- assemble per-gate results -------------------------------------------- #
+declare -A RESULT=()
+overall="success"
+for g in "${REQUIRED[@]}"; do
+  if [ "$g" = ci ]; then
+    c="$(ci_conclusion)"
+    case "$c" in success) RESULT[$g]=pass ;; failure|cancelled|timed_out) RESULT[$g]=fail ;; *) RESULT[$g]=pending ;; esac
+  else
+    RESULT[$g]="${GATE[$g]:-pending}"
+  fi
+  case "${RESULT[$g]}" in
+    pass) ;;
+    fail) overall="failure" ;;
+    *)    [ "$overall" = "failure" ] || overall="pending" ;;
+  esac
+done
+
+passed=0; for g in "${REQUIRED[@]}"; do [ "${RESULT[$g]}" = pass ] && passed=$((passed+1)); done
+total=${#REQUIRED[@]}
+DESC="$passed/$total gates passed [route: $ROUTE_NAME]"
+
+# GitHub commit-status states are: success | failure | pending | error.
+STATE="$overall"
+
+# --- render the plan ------------------------------------------------------ #
+echo "PR #$PR  head=$HEAD_SHA  route=$ROUTE_NAME$ROUTE_CAVEAT"
+echo "status: $CONTEXT = $STATE  ($DESC)"
+for g in "${REQUIRED[@]}"; do printf '  %-20s %s\n' "$g" "${RESULT[$g]}"; done
+
+evidence_block() {
+  printf '<!-- agent-verification:start -->\n'
+  printf '### agent-verification — `%s` for `%s`\n\n' "$STATE" "${HEAD_SHA:0:7}"
+  printf '| gate | result |\n|---|---|\n'
+  for g in "${REQUIRED[@]}"; do printf '| `%s` | %s |\n' "$g" "${RESULT[$g]}"; done
+  printf '\n_%s. Regenerated per head SHA by `tools/agent-verify.sh`._\n' "$DESC"
+  printf '<!-- agent-verification:end -->\n'
+}
+
+if [ "$POST" = 1 ]; then
+  gh api -X POST "repos/{owner}/{repo}/statuses/$HEAD_SHA" \
+    -f state="$STATE" -f context="$CONTEXT" -f description="$DESC" -f target_url="$PR_URL" \
+    --jq '"posted: \(.context) = \(.state)"' || die "failed to post status"
+  if [ "$EVIDENCE" = 1 ]; then
+    body="$(gh pr view "$PR" --json body --jq '.body // ""')"
+    # Strip any prior block, then append the fresh one. Update the body via the
+    # REST API rather than `gh pr edit`, which fails on repos still carrying a
+    # projects-classic deprecation (it queries projectCards and errors out).
+    clean="$(printf '%s' "$body" | sed '/<!-- agent-verification:start -->/,/<!-- agent-verification:end -->/d')"
+    newbody="$(printf '%s\n\n%s' "$clean" "$(evidence_block)")"
+    gh api -X PATCH "repos/{owner}/{repo}/pulls/$PR" -f body="$newbody" >/dev/null \
+      && echo "evidence: PR #$PR body updated"
+  fi
+else
+  echo "(dry run — pass --post to post the commit status; --evidence to update the PR body)"
+  [ "$EVIDENCE" = 1 ] && { echo "--- evidence block that would be written ---"; evidence_block; }
+fi
+
+[ "$STATE" = success ] && exit 0 || exit 1


### PR DESCRIPTION
## Linked Issue

Closes #131

## Exact behavioral claim

The route's required gate set can now be enforced by GitHub through a single `agent-verification` commit status. `tools/agent-verify.sh <PR#>` derives the route for the PR head SHA, reads `ci` (the `build-and-test` check-run) from GitHub, takes the model-driven gate results supplied by the orchestrator, and posts one `agent-verification` status — success only if `ci` passed AND every other required gate was supplied as `pass`. This prevents the failure the route derivation has had since #90/#91: gates that are *computed and then ignored*. Because a commit status binds to the SHA, any new push invalidates it — a stale approval can't ride along with changed code.

## Scope

Added: `tools/agent-verify.sh` (the poster) and `docs/orchestration/agent-verification.md` (how it works + how to make it required).

Deliberately unchanged: the branch ruleset — this PR ships the mechanism and posts a **non-blocking** status; making `agent-verification` a *required* check is a separate, deliberate flip (documented) because it would gate every merge on the orchestrator having run. Also unchanged: `routing.md` (its Enforcement section is edited by #126; to avoid a merge conflict the agent-verify docs are a standalone file — a cross-link is a trivial follow-up once both merge).

## Rules conformance

N/A — orchestration tooling and docs; no rules engine code, no printed table.

## Tests and evidence

- `bash -n tools/agent-verify.sh` → OK.
- `tools/agent-verify.sh 130 --gate scope-warden=pass` (dry run) → `agent-verification = success (2/2)`; `ci` read as pass from the `build-and-test` check-run on the head SHA.
- Omitting the gate → `pending (1/2)`; success is never posted on incomplete evidence.
- `--gate rules-conformance=pass` on a `tooling` route → rejected ("not required by route"); `--gate ci=pass` → rejected ("ci is read from GitHub").
- Run from a branch other than the PR head → falls back to GitHub's changed-file list and prints the path-only caveat.
- `--evidence` renders a managed `<!-- agent-verification -->` block (gate table).
- Live end-to-end proof posted on PR #130 (a real `scope-warden` verdict + the status) — see that PR's checks/body.

## Decisions and tradeoffs

- **Commit status, not a check-run:** a status context can be required by branch protection exactly like a check-run, and binds to the SHA. This is the "GitHub gates on the contract, not on how any model works" design from the review.
- **Model-driven gates are supplied, not run by this script:** the gates are agents (scope-warden, rules-conformance, …); the orchestrator that just ran them passes their verdicts in. `ci` is the one gate the script reads itself, since it is a deterministic check-run.
- **Non-blocking by default:** posting is additive and safe; requiring it has real blast radius (every merge blocks until the orchestrator posts), so that flip is left to the owner with the tradeoff written down.

## Known limitations

- Requires the orchestrator to actually run the gates and supply results; it does not itself watch PRs or dispatch agents.
- Route content-escalation (`rules → formulas`) needs the PR branch checked out; from elsewhere the route is path-only (stated in the output).
- `routing.md`'s Enforcement section still describes the enforcer as "future work" until #126 merges; a one-line cross-link to this doc is the follow-up.

## Agent provenance

Implemented by Claude (Opus 4.8) driving the repo directly. The live proof on PR #130 used the `scope-warden` agent for a genuine gate verdict.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).