### PR TITLE
Point routing.md Enforcement at agent-verify.sh

### DIFF
--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -111,6 +111,11 @@ with `main`). The model-driven per-route gates
 (`scope-warden`, `rules-conformance`, `codex-conformance`, `architecture-review`)
 and the `gates-satisfied` aggregate that once combined them were removed in #90/#91
 — they never posted a result on any PR. The route table above is retained as the
-map of which review a change *should* get; wiring an automated enforcer back up is
-future work under the #53 epic.
+map of which review a change *should* get.
+
+The enforcer is now [`tools/agent-verify.sh`](../../tools/agent-verify.sh): the local
+orchestrator runs the route's gates for a PR head SHA and posts a single
+`agent-verification` commit status (success only if every required gate passed). It is
+an informative, non-blocking status until deliberately added to the required set — see
+[`agent-verification.md`](agent-verification.md) for how it works and how to require it.
 


### PR DESCRIPTION
## Linked Issue

Closes #133

## Exact behavioral claim

`docs/orchestration/routing.md`'s Enforcement section no longer calls the route enforcer "future work" — it now describes `tools/agent-verify.sh` and links `agent-verification.md`. This removes a doc-drift introduced when #132 merged.

## Scope

One paragraph in `docs/orchestration/routing.md`. No code, no other docs.

## Rules conformance

N/A — documentation only.

## Tests and evidence

- `tools/route.sh docs/orchestration/routing.md` → `docs`.
- Rendered; the new link resolves to `agent-verification.md` in the same directory.

## Decisions and tradeoffs

Kept the historical #90/#91 note (why the old gate system was removed) — that is stable context; only the "future work" clause was stale.

## Known limitations

None.

## Agent provenance

Claude (Opus 4.8), direct.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).