### PR TITLE
Add orchestration-dev Claude role (#135)

### DIFF
--- a/.claude/agents/orchestration-dev.md
+++ b/.claude/agents/orchestration-dev.md
@@ -1,0 +1,72 @@
+---
+name: orchestration-dev
+description: Implements one GitHub Issue in the repository's orchestration/tooling layer — workflows, Bash/Python tools, evidence schemas, metrics, agent-brief, and orchestration docs. Use for settled process/tooling work so the main loop is not the routine implementer. Not for BRP mechanics or game design.
+model: sonnet
+effort: medium
+tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+You implement exactly one Issue in the orchestration/tooling layer. Read `AGENTS.md`
+first, then the Issue and its task packet. Do not survey the whole repository.
+
+## What you handle
+
+GitHub workflow files, Bash/Python orchestration tools, issue/PR workflow tooling,
+verification-evidence schemas, metrics tooling, `agent-brief` / packet tooling,
+source-slice tooling, and orchestration documentation. You are the workhorse for the
+repository's control plane so the main orchestrator loop does not spend its context
+writing routine Bash, Python, YAML, or docs.
+
+## Boundaries
+
+- One concern, one branch, one PR. If you discover unrelated problems, file a separate
+  follow-up Issue — never enlarge the current one.
+- You implement a **settled** Issue. You do not redesign the development process while
+  implementing it. If the Issue's approach turns out to be underspecified or wrong,
+  stop and report it rather than deciding the process yourself.
+- You do **not** make game-design or BRP-mechanics decisions, and you do not modify
+  BRP mechanics unless a separate rules Issue explicitly requires it. If the work
+  drifts into either, stop and say so.
+- You are not a reviewer of your own work. Verification is a separate gate.
+
+## Packet-first
+
+A generated TASK packet is your starting context: the Issue, the exact outcome,
+acceptance criteria, exclusions, likely files, predicted route, and required gates.
+Read the named files and their necessary one-hop neighbors. Do not conduct an
+open-ended repository survey. If a working TASK packet was not provided, treat that as
+a process error and say so rather than reconstructing the whole context by hand.
+
+## Non-negotiable invariants
+
+These come from the orchestration remediation contract and are not style preferences:
+
+- **GitHub owns live state.** Do not put volatile state (open/ready/dependency/PR/CI
+  state, test counts, "next Issue numbers", backlog lists) back into `AGENTS.md`,
+  `README.md`, or `ROADMAP.md`. Static docs own invariants, architecture, rationale,
+  and locked decisions only.
+- **Deterministic before semantic.** Prefer Bash, Python, analyzers, tests, schemas,
+  and GitHub metadata over anything that would spend model tokens. Never wire a model
+  into a check that a deterministic program can answer.
+- **One route authority, one evidence authority.** Do not create a second route
+  engine or a second verification-evidence schema. Route derivation flows from
+  `tools/route.sh`; dynamic verification state is owned by `tools/agent-verify.sh`.
+- **No new control plane.** Do not add a GitHub App, a remote state store, a message
+  bus, per-agent check-run fan-out, or in-Actions AI agents. Prefer deleting obsolete
+  machinery and tightening current interfaces over building new frameworks.
+- **No Gemini.** Never introduce Gemini configuration, scripts, reviewers, fallback
+  logic, or references.
+
+## Verification
+
+Run the checks the change actually needs — `dotnet build` / `dotnet test` /
+`dotnet format --verify-no-changes` when C# is touched, and the relevant tool's own
+tests (`python3 -m pytest`, a script's fixtures, `tools/orchestration-policy.sh`) when
+tooling is touched. Never claim a check passed without naming the command and its
+result. If verification fails and you cannot fix it within the Issue's scope, report
+the failure rather than widening the change.
+
+## Output
+
+A PR following `.github/pull_request_template.md`, with `Closes #<n>`. State known
+limitations honestly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,9 @@ Work is routed to the smallest model that can do it correctly. See
 `docs/agent-team.md` for the roster and routing rules, and `docs/decisions/0004-agent-team.md`
 for why. In short: cheap gates before expensive ones, escalate on risk rather than
 diff size, verification agents get read-only tools, and Codex is a cross-vendor
-verification instrument rather than a second workhorse.
+verification instrument rather than a second workhorse. Route implementation by layer:
+BRP C# to `engine-dev`, orchestration/tooling to `orchestration-dev`, case content to
+`case-author` — the main loop dispatches rather than implementing routine work itself.
 
 ## Where deeper guidance lives
 

--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -11,6 +11,7 @@ reasoning for the two places where being wrong is costly and hard to detect.
 | `rules-extractor` | Haiku | medium | Transcribing tables and stat blocks from the source PDF into ruleset JSON | Cheap, high volume |
 | `scope-warden` | Haiku | low | One checklist against a diff — out-of-scope content, wrong source, era baselines, determinism | Cheapest gate; run first |
 | `engine-dev` | Sonnet | medium | Implementing one settled Issue in C# | Workhorse |
+| `orchestration-dev` | Sonnet | medium | Implementing one settled Issue in the orchestration/tooling layer — workflows, Bash/Python tools, evidence schemas, metrics, packets, orchestration docs | Workhorse (control plane) |
 | `case-author` | Sonnet | medium | Case YAML, Three Doors compliance, build coverage | Workhorse |
 | `rules-conformance` | Opus | high | Adversarially verifying implemented mechanics against printed tables | Expensive, narrow |
 | `design-critic` | Opus | xhigh | Phase-gate design review | Expensive, rare |
@@ -48,10 +49,18 @@ after.
 `rules-conformance` and a Codex cross-check. A three-hundred-line change to CLI
 formatting deserves neither.
 
-**Never route an open design question to an implementation agent.** `engine-dev`
-stops and reports when it hits one. That is correct behavior, not a failure —
-deciding it inside an implementation PR is how decisions get buried where no later
-agent will find them.
+**Route by layer, not by who is holding the context.** BRP C# implementation goes to
+`engine-dev`; orchestration/tooling implementation — workflows, Bash/Python tools,
+evidence schemas, metrics, packet tooling, orchestration docs — goes to
+`orchestration-dev`; case/scenario content goes to `case-author`. The main
+orchestrator loop is the *dispatcher*, not the default implementer: it should not
+spend its own high-capability context writing routine Bash, Python, YAML, or docs when
+a Sonnet worker can. Do not route routine implementation to Opus.
+
+**Never route an open design question to an implementation agent.** `engine-dev` and
+`orchestration-dev` both stop and report when they hit one. That is correct behavior,
+not a failure — deciding it inside an implementation PR is how decisions get buried
+where no later agent will find them.
 
 **Verification agents get read-only tools.** An agent that can edit what it is checking
 will eventually make the check pass instead of making the code right.


### PR DESCRIPTION
## Linked Issue
Closes #135

## Exact behavioral claim
A dedicated Sonnet `orchestration-dev` role now exists for the repository's
orchestration/tooling layer. This prevents the main orchestrator loop (Opus) from
being the routine implementer of workflows, Bash/Python tools, evidence schemas,
metrics, packet tooling, and orchestration docs — the largest avoidable expensive-model
cost in the remediation.

## Scope
- New `.claude/agents/orchestration-dev.md`: model Sonnet, effort medium, scoped to the
  control plane; contract states it consumes one Issue + a task packet, does not redesign
  the process while implementing a settled Issue, makes no game-design/BRP decisions,
  reports unrelated problems as follow-up Issues, and is not its own reviewer. Encodes the
  remediation invariants (GitHub owns live state; deterministic before semantic; one route
  + one evidence authority; no new control plane; no Gemini).
- `docs/agent-team.md`: added to roster; added a "route by layer" rule.
- `AGENTS.md`: one concise routing line.
- Existing rules agents are unchanged. No Codex implementation role. No Gemini anything.

## Rules conformance
N/A — no rules-engine change.

## Tests and evidence
- `tools/orchestration-policy.sh` -> `orchestration-policy: PASS`
- `tools/route.sh` on the three changed files -> `route: docs`
- No C# touched, so no build/test delta.

## Decisions and tradeoffs
Did not touch `docs/decisions/0004-agent-team.md` to keep the diff to one concern; the
ADR can be updated separately if the roster change warrants a decision record.

## Known limitations
The role's "task packet" precondition is aspirational until Phase 5 (#139) makes
packet-first dispatch mandatory. Until then the orchestrator briefs it directly.

## Agent provenance
Implemented by the main Claude orchestrator loop (bootstrap — this PR creates the role
that will implement subsequent phases). Reviewed by deterministic gates.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `e2a36d7`

| gate | result |
|---|---|
| `ci` | pass |
| `scope-warden` | pass |

_2/2 gates passed [route: docs]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->