### PR TITLE
Collapse verification evidence to one canonical model (#136)

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -2,7 +2,9 @@ name: pr-policy
 
 # Make the PR machine-readable: validate that the body carries real evidence
 # (not the template's prompts), derive the verification route, and publish a
-# small evidence artifact the orchestrator / state machine (#62) can read.
+# small STATIC-metadata evidence artifact the orchestrator can read. Dynamic
+# verification state (did each gate pass for this SHA) is owned solely by
+# tools/agent-verify.sh, not this job.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]

--- a/.github/workflows/pr_policy.py
+++ b/.github/workflows/pr_policy.py
@@ -25,6 +25,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 
+# pr-policy emits STATIC PR metadata only — the route, the required gate set, and
+# whether the body satisfies policy. It has no opinion on whether any gate actually
+# passed; that is tools/agent-verify.sh's job (its own --json is the one dynamic
+# verification-evidence object). Bump this when the shape of `evidence` changes.
+SCHEMA_VERSION = 1
+
 # Prompt text from .github/pull_request_template.md. A section whose only content
 # is (a paraphrase of) its prompt counts as empty.
 PROMPTS = {
@@ -164,15 +170,15 @@ def main() -> int:
 
     gates = route.get("gates", [])
     evidence = {
+        "schemaVersion": SCHEMA_VERSION,
         "issue": meta["issue"] or number,
-        "base": base,
-        "head": head,
+        "baseSha": base,
+        "headSha": head,
         "route": route.get("route"),
         "escalated": route.get("escalated", False),
+        "issueRoute": route.get("issueRoute"),
         "requiredGates": gates,
-        # Gate states start pending; the App (#65) / state machine (#62) fill these in.
-        "gateStates": {g: ("pass" if g == "ci" else "pending") for g in gates},
-        "tests": meta["tests"],
+        "testsReported": meta["tests"],
         "prPolicy": "pass" if not violations else "fail",
     }
     Path(args.out).write_text(json.dumps(evidence, indent=2) + "\n")

--- a/tests/tooling/test_agent_verify.sh
+++ b/tests/tooling/test_agent_verify.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# tests/tooling/test_agent_verify.sh — fixture tests for tools/agent-verify.sh's
+# canonical verification-evidence object (Issue #136).
+#
+# agent-verify.sh is the ONE dynamic verification-evidence authority: it reads
+# the real build-and-test check-run from GitHub, combines it with the --gate
+# evidence supplied for the route's other required gates, and must render the
+# same {schemaVersion, pr, issue, headSha, route, requiredGates, gates, aggregate}
+# object through --json/--json-out AND the human --evidence PR-body block.
+#
+# No `gh` CLI network access is available in this environment (or in CI), so
+# this stubs `gh` with a fixture script that answers the exact calls
+# agent-verify.sh makes, driven by MOCK_* environment variables.
+#
+# Run directly:
+#   tests/tooling/test_agent_verify.sh
+#
+# Exit: 0 if every case passes, 1 on the first failure.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/agent-verify.sh"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then ok "$desc"; else
+    fail "$desc (expected [$expected], got [$actual])"
+  fi
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then ok "$desc"; else
+    fail "$desc (expected to find [$needle])"
+  fi
+}
+
+# --- fixture `gh` stub ------------------------------------------------------ #
+# Answers exactly the gh subcommands agent-verify.sh issues: `pr view --json
+# headRefOid,url,state`, `pr view --json body`, `pr diff --name-only`,
+# `api .../check-runs`, `api -X POST .../statuses/...`, `api -X PATCH .../pulls/...`.
+MOCKBIN="$WORKDIR/bin"
+mkdir -p "$MOCKBIN"
+cat > "$MOCKBIN/gh" <<'MOCKGH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+find_flag_value() {
+  local flag="$1"; shift; local args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    if [ "${args[$i]}" = "$flag" ]; then printf '%s' "${args[$((i + 1))]}"; return 0; fi
+  done
+  return 1
+}
+
+emit() {
+  local body="$1"; shift; local jqf
+  if jqf="$(find_flag_value --jq "$@")"; then printf '%s' "$body" | jq -r "$jqf"
+  else printf '%s\n' "$body"; fi
+}
+
+HEAD_SHA="${MOCK_HEAD_SHA:-deadbeef1234567890deadbeef1234567890dead}"
+PR_BODY="${MOCK_PR_BODY:-Closes #136}"
+CI_CONCLUSION="${MOCK_CI_CONCLUSION:-success}"
+
+case "$1 $2" in
+  "pr view")
+    jsonf="$(find_flag_value --json "$@" || true)"
+    case "$jsonf" in
+      headRefOid,url,state)
+        emit "{\"headRefOid\":\"$HEAD_SHA\",\"url\":\"https://example.invalid/pull/999\",\"state\":\"OPEN\"}" "$@" ;;
+      body)
+        emit "{\"body\":\"$PR_BODY\"}" "$@" ;;
+      *) echo "mock gh: unhandled pr view --json $jsonf" >&2; exit 1 ;;
+    esac ;;
+  "pr diff")
+    printf '%s\n' "${MOCK_PR_FILES:-tools/agent-verify.sh}" ;;
+  *)
+    case "$1" in
+      api)
+        shift
+        [ "${1:-}" = "-X" ] && shift 2
+        path="$1"
+        case "$path" in
+          repos/{owner}/{repo}/commits/*/check-runs)
+            emit "{\"check_runs\":[{\"name\":\"build-and-test\",\"started_at\":\"2026-01-01T00:00:00Z\",\"conclusion\":\"$CI_CONCLUSION\"}]}" "$@" ;;
+          repos/{owner}/{repo}/statuses/*)
+            st=""; args=("$@")
+            for ((i = 0; i < ${#args[@]}; i++)); do
+              [ "${args[$i]}" = "-f" ] && [[ "${args[$((i+1))]}" == state=* ]] && st="${args[$((i+1))]#state=}"
+            done
+            emit "{\"context\":\"agent-verification\",\"state\":\"$st\"}" "$@" ;;
+          repos/{owner}/{repo}/pulls/*) : ;;
+          *) echo "mock gh: unhandled api path: $path" >&2; exit 1 ;;
+        esac ;;
+      *) echo "mock gh: unhandled args: $*" >&2; exit 1 ;;
+    esac ;;
+esac
+MOCKGH
+chmod +x "$MOCKBIN/gh"
+export PATH="$MOCKBIN:$PATH"
+
+run_verify() { "$SCRIPT" "$@"; }
+
+# --- case 1: all gates pass -> aggregate success, canonical shape ---------- #
+json="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --json)"
+printf '%s\n' "$json" | python3 -m json.tool >/dev/null \
+  && ok "case1: --json is valid JSON" || fail "case1: --json is valid JSON"
+
+read -r schema pr issue head route agg gate_ci gate_sw <<< "$(printf '%s' "$json" | python3 -c '
+import json, sys
+ev = json.load(sys.stdin)
+print(ev["schemaVersion"], ev["pr"], ev["issue"], ev["headSha"], ev["route"],
+      ev["aggregate"], ev["gates"]["ci"], ev["gates"]["scope-warden"])
+')"
+assert_eq "case1: schemaVersion" "1" "$schema"
+assert_eq "case1: pr number"     "999" "$pr"
+assert_eq "case1: linked issue"  "136" "$issue"
+assert_eq "case1: aggregate"     "success" "$agg"
+assert_eq "case1: ci gate"       "pass" "$gate_ci"
+assert_eq "case1: scope-warden gate" "pass" "$gate_sw"
+
+keys="$(printf '%s' "$json" | python3 -c 'import json,sys; print(sorted(json.load(sys.stdin).keys()))')"
+assert_eq "case1: exact canonical key set" \
+  "['aggregate', 'gates', 'headSha', 'issue', 'pr', 'requiredGates', 'route', 'schemaVersion']" \
+  "$keys"
+
+rc=0; MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass >/dev/null || rc=$?
+assert_eq "case1: exit 0 on success" "0" "$rc"
+
+# --- case 2: a required gate never supplied -> pending, never success ------ #
+json2="$(MOCK_CI_CONCLUSION=success run_verify 999 --json || true)"
+agg2="$(printf '%s' "$json2" | python3 -c 'import json,sys; print(json.load(sys.stdin)["aggregate"])')"
+assert_eq "case2: missing gate evidence never yields success" "pending" "$agg2"
+
+rc2=0; MOCK_CI_CONCLUSION=success run_verify 999 >/dev/null || rc2=$?
+assert_eq "case2: exit non-zero when pending" "1" "$rc2"
+
+# --- case 3: ci fails on GitHub -> aggregate failure, ci fabricated never --- #
+json3="$(MOCK_CI_CONCLUSION=failure run_verify 999 --gate scope-warden=pass --json || true)"
+agg3="$(printf '%s' "$json3" | python3 -c 'import json,sys; print(json.load(sys.stdin)["aggregate"])')"
+gate_ci3="$(printf '%s' "$json3" | python3 -c 'import json,sys; print(json.load(sys.stdin)["gates"]["ci"])')"
+assert_eq "case3: real ci failure -> gates.ci = fail" "fail" "$gate_ci3"
+assert_eq "case3: real ci failure -> aggregate failure" "failure" "$agg3"
+
+# --- case 4: --json-out writes the same object to a file ------------------- #
+OUT="$WORKDIR/evidence.json"
+MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --json-out "$OUT" >/dev/null
+[ -f "$OUT" ] && ok "case4: --json-out wrote a file" || fail "case4: --json-out wrote a file"
+python3 -m json.tool "$OUT" >/dev/null && ok "case4: --json-out file is valid JSON" \
+  || fail "case4: --json-out file is valid JSON"
+
+# --- case 5: --evidence PR-body block renders from the SAME object -------- #
+evidence_out="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --evidence)"
+assert_contains "case5: evidence block has managed start marker" \
+  "$evidence_out" "<!-- agent-verification:start -->"
+assert_contains "case5: evidence block has managed end marker" \
+  "$evidence_out" "<!-- agent-verification:end -->"
+assert_contains "case5: evidence block includes the head SHA" \
+  "$evidence_out" "${MOCK_HEAD_SHA:-deadbeef1234567890deadbeef1234567890dead}"
+assert_contains "case5: evidence block states the same aggregate as --json" \
+  "$evidence_out" '`success` for'
+assert_contains "case5: evidence block reports the same per-gate results" \
+  "$evidence_out" '| `scope-warden` | pass |'
+
+# --- case 6: --json mode leaves stdout as pure JSON, even with --evidence -- #
+combined="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --json --evidence)"
+printf '%s\n' "$combined" | python3 -m json.tool >/dev/null \
+  && ok "case6: --json + --evidence still leaves stdout pure JSON" \
+  || fail "case6: --json + --evidence still leaves stdout pure JSON"
+
+# --- case 7: an unrequired --gate is rejected (unchanged prior behaviour) -- #
+rc7=0; run_verify 999 --gate bogus-gate=pass >/dev/null 2>&1 || rc7=$?
+assert_eq "case7: --gate for a non-required gate is rejected" "2" "$rc7"
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "test_agent_verify.sh: all checks passed"
+  exit 0
+else
+  echo "test_agent_verify.sh: $FAILURES check(s) failed"
+  exit 1
+fi

--- a/tests/tooling/test_pr_policy.py
+++ b/tests/tooling/test_pr_policy.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Unit/fixture tests for .github/workflows/pr_policy.py (Issue #136).
+
+pr_policy.py is one half of the collapsed verification-evidence model: it must
+emit STATIC PR metadata only (route, required gates, body-policy result) and
+must never claim a verification gate passed — that is tools/agent-verify.sh's
+job, covered separately by tests/tooling/test_agent_verify.sh.
+
+No external test framework is set up in this repo (no pytest, no conftest.py)
+so this uses only the standard library, matching how the other tools/*.py
+scripts here are exercised: as real subprocess invocations against a fixture
+PR body, the same way pr-policy.yml runs the script in CI.
+
+Run directly:
+    python3 -m unittest tests/tooling/test_pr_policy.py -v
+or via the repo-root test suite:
+    python3 -m unittest discover -s tests/tooling -p 'test_*.py' -v
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".github" / "workflows" / "pr_policy.py"
+
+COMPLETE_BODY = """\
+## Exact behavioral claim
+pr_policy.py now emits static PR metadata only; it no longer claims any
+verification gate passed.
+
+## Scope
+Only the evidence dict shape in pr_policy.py changed. Route derivation and
+body-policy checks did not change.
+
+## Rules conformance
+N/A — no rules-engine files touched.
+
+## Tests and evidence
+`python3 -m unittest tests/tooling/test_pr_policy.py -v` — all tests pass.
+
+## Decisions and tradeoffs
+None beyond the evidence-schema collapse itself.
+
+## Known limitations
+None known.
+
+## Agent provenance
+orchestration-dev
+
+Closes #136
+"""
+
+INCOMPLETE_BODY = """\
+Closes #136
+
+Did a thing.
+"""
+
+
+def run_pr_policy(body: str, out_path: Path, base: str, head: str) -> subprocess.CompletedProcess:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, dir=out_path.parent) as fh:
+        fh.write(body)
+        body_file = fh.name
+    try:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--body-file", body_file,
+                "--base", base,
+                "--head", head,
+                "--out", str(out_path),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        Path(body_file).unlink(missing_ok=True)
+
+
+class PrPolicyStaticEvidenceTests(unittest.TestCase):
+    """Pin the evidence shape: static PR metadata only, no gateStates."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # An explicit base == head gives an empty diff, so the route is the
+        # deterministic "tooling" baseline regardless of what happens to be
+        # dirty in the working tree while this test runs.
+        cls.head = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ).strip()
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        cls.out_path = Path(cls.tmpdir.name) / "evidence.json"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.tmpdir.cleanup()
+
+    def test_complete_body_passes_and_evidence_has_exact_static_keys(self) -> None:
+        result = run_pr_policy(COMPLETE_BODY, self.out_path, self.head, self.head)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+        evidence = json.loads(self.out_path.read_text())
+
+        expected_keys = {
+            "schemaVersion", "issue", "baseSha", "headSha", "route",
+            "escalated", "issueRoute", "requiredGates", "testsReported",
+            "prPolicy",
+        }
+        self.assertEqual(set(evidence.keys()), expected_keys)
+
+        # The old, App/state-machine-shaped keys must be gone entirely.
+        for stale_key in ("gateStates", "base", "head", "tests"):
+            self.assertNotIn(stale_key, evidence)
+
+    def test_schema_version_present_and_stable(self) -> None:
+        result = run_pr_policy(COMPLETE_BODY, self.out_path, self.head, self.head)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        evidence = json.loads(self.out_path.read_text())
+        self.assertEqual(evidence["schemaVersion"], 1)
+
+    def test_no_gate_is_ever_marked_pass_by_pr_policy(self) -> None:
+        """The defect this issue closes: pr-policy hardcoding ci -> pass."""
+        result = run_pr_policy(COMPLETE_BODY, self.out_path, self.head, self.head)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        evidence = json.loads(self.out_path.read_text())
+
+        self.assertIsInstance(evidence["requiredGates"], list)
+        self.assertIn("ci", evidence["requiredGates"])
+        # requiredGates is a flat list of gate names, not a name->state map —
+        # there is nowhere left in this object to spell {"ci": "pass"}, and the
+        # old gateStates key (which did) is gone (asserted above).
+        for gate in evidence["requiredGates"]:
+            self.assertIsInstance(gate, str)
+        self.assertNotIn("gateStates", evidence)
+
+    def test_metadata_reflects_route_and_head(self) -> None:
+        result = run_pr_policy(COMPLETE_BODY, self.out_path, self.head, self.head)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        evidence = json.loads(self.out_path.read_text())
+
+        self.assertEqual(evidence["headSha"], self.head)
+        self.assertEqual(evidence["baseSha"], self.head)
+        self.assertEqual(evidence["issue"], 136)
+        self.assertEqual(evidence["route"], "tooling")
+        self.assertEqual(sorted(evidence["requiredGates"]), ["ci", "scope-warden"])
+        self.assertEqual(evidence["prPolicy"], "pass")
+        self.assertIn("issueRoute", evidence)  # present even when null
+
+    def test_incomplete_body_is_still_rejected(self) -> None:
+        """The pre-existing incomplete-body gate must still work unchanged."""
+        result = run_pr_policy(INCOMPLETE_BODY, self.out_path, self.head, self.head)
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("::error title=pr-policy::", result.stdout)
+
+        evidence = json.loads(self.out_path.read_text())
+        self.assertEqual(evidence["prPolicy"], "fail")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/agent-verify.sh
+++ b/tools/agent-verify.sh
@@ -15,15 +15,23 @@
 # status binds to the SHA, any new push invalidates it automatically. Per-gate
 # evidence is written into the PR body for humans.
 #
+# This script is the ONE dynamic verification-evidence authority in the repo (see
+# #136). pr_policy.py emits static PR metadata (route, required gates, body
+# policy) and never claims a gate passed; the canonical {gates, aggregate} record
+# for a head SHA is built here, once, and both the machine (--json) and human
+# (--evidence) renderings come from that same in-memory object.
+#
 # Usage:
 #   tools/agent-verify.sh <PR#> [--gate NAME=pass|fail|skip ...] [--base REF]
-#                               [--post] [--evidence]
+#                               [--post] [--evidence] [--json] [--json-out FILE]
 #
 #   * `ci` is read from GitHub (the `build-and-test` check-run) — never supplied.
 #   * every OTHER required gate must be supplied via --gate; a missing one leaves
 #     the aggregate `pending` (success is never posted on incomplete evidence).
 #   * default is a DRY RUN that prints the plan; --post actually posts the status;
 #     --evidence additionally writes the per-gate block into the PR body.
+#   * --json prints the canonical evidence object to stdout as JSON (nothing else
+#     is written to stdout in that mode); --json-out FILE writes it to a file.
 #
 # Exit: 0 if the aggregate is success, 1 otherwise (so a caller can branch on it).
 set -euo pipefail
@@ -32,7 +40,7 @@ CONTEXT="agent-verification"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 die() { echo "agent-verify: $*" >&2; exit 2; }
 
-PR=""; BASE="origin/main"; POST=0; EVIDENCE=0
+PR=""; BASE="origin/main"; POST=0; EVIDENCE=0; JSON=0; JSON_OUT=""
 declare -A GATE=()
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -43,11 +51,13 @@ while [ $# -gt 0 ]; do
     --base) BASE="${2:-}"; shift 2 ;;
     --post) POST=1; shift ;;
     --evidence) EVIDENCE=1; shift ;;
+    --json) JSON=1; shift ;;
+    --json-out) [ $# -ge 2 ] || die "--json-out needs FILE"; JSON_OUT="$2"; shift 2 ;;
     -*) die "unknown option: $1" ;;
     *)  [ -z "$PR" ] || die "unexpected argument: $1"; PR="$1"; shift ;;
   esac
 done
-[ -n "$PR" ] || die "usage: agent-verify.sh <PR#> [--gate NAME=STATE ...] [--post] [--evidence]"
+[ -n "$PR" ] || die "usage: agent-verify.sh <PR#> [--gate NAME=STATE ...] [--post] [--evidence] [--json] [--json-out FILE]"
 
 # --- resolve the PR ------------------------------------------------------- #
 read -r HEAD_SHA PR_URL PR_STATE < <(gh pr view "$PR" \
@@ -114,18 +124,86 @@ DESC="$passed/$total gates passed [route: $ROUTE_NAME]"
 # GitHub commit-status states are: success | failure | pending | error.
 STATE="$overall"
 
-# --- render the plan ------------------------------------------------------ #
-echo "PR #$PR  head=$HEAD_SHA  route=$ROUTE_NAME$ROUTE_CAVEAT"
-echo "status: $CONTEXT = $STATE  ($DESC)"
-for g in "${REQUIRED[@]}"; do printf '  %-20s %s\n' "$g" "${RESULT[$g]}"; done
+# --- resolve the linked issue (best-effort, for the evidence object) ------ #
+# Same "Closes/Fixes/Resolves #N" convention pr_policy.py enforces on the body;
+# this gh CLI version has no closingIssuesReferences JSON field to read instead.
+PR_BODY="$(gh pr view "$PR" --json body --jq '.body // ""' 2>/dev/null || true)"
+ISSUE_NUM="$(printf '%s' "$PR_BODY" | python3 -c '
+import re, sys
+m = re.search(r"(?i)\b(clos|fix|resolv)(e|es|ed)?\s+#(\d+)", sys.stdin.read())
+print(m.group(3) if m else "")
+')"
 
+# --- build the ONE canonical evidence object ------------------------------ #
+# Both --json/--json-out and the human --evidence PR-body block render from this
+# exact object — neither reconstructs gate state independently (see #136).
+GATES_KV=""
+for g in "${REQUIRED[@]}"; do GATES_KV+="$g=${RESULT[$g]};"; done
+EVIDENCE_JSON="$(python3 - "$PR" "$ISSUE_NUM" "$HEAD_SHA" "$ROUTE_NAME" "$STATE" "$GATES_KV" <<'PYEOF'
+import json
+import sys
+
+pr, issue, head_sha, route, aggregate, gates_kv = sys.argv[1:7]
+gates = {}
+required = []
+for pair in gates_kv.split(";"):
+    if not pair:
+        continue
+    name, state = pair.split("=", 1)
+    gates[name] = state
+    required.append(name)
+
+evidence = {
+    "schemaVersion": 1,
+    "pr": int(pr) if pr.isdigit() else pr,
+    "issue": int(issue) if issue.isdigit() else None,
+    "headSha": head_sha,
+    "route": route,
+    "requiredGates": required,
+    "gates": gates,
+    "aggregate": aggregate,
+}
+print(json.dumps(evidence, indent=2))
+PYEOF
+)"
+
+# --- render the plan (suppressed in --json mode so stdout is pure JSON) --- #
+if [ "$JSON" = 0 ]; then
+  echo "PR #$PR  head=$HEAD_SHA  route=$ROUTE_NAME$ROUTE_CAVEAT"
+  echo "status: $CONTEXT = $STATE  ($DESC)"
+  for g in "${REQUIRED[@]}"; do printf '  %-20s %s\n' "$g" "${RESULT[$g]}"; done
+fi
+
+# Renders the human PR-body block FROM $EVIDENCE_JSON (via stdin), not by
+# re-walking REQUIRED/RESULT a second time.
 evidence_block() {
-  printf '<!-- agent-verification:start -->\n'
-  printf '### agent-verification — `%s` for `%s`\n\n' "$STATE" "${HEAD_SHA:0:7}"
-  printf '| gate | result |\n|---|---|\n'
-  for g in "${REQUIRED[@]}"; do printf '| `%s` | %s |\n' "$g" "${RESULT[$g]}"; done
-  printf '\n_%s. Regenerated per head SHA by `tools/agent-verify.sh`._\n' "$DESC"
-  printf '<!-- agent-verification:end -->\n'
+  printf '%s' "$EVIDENCE_JSON" | python3 -c '
+import json
+import sys
+
+ev = json.load(sys.stdin)
+aggregate = ev["aggregate"]
+head7 = ev["headSha"][:7]
+route = ev["route"]
+required = ev["requiredGates"]
+gates = ev["gates"]
+passed = sum(1 for g in required if gates[g] == "pass")
+total = len(required)
+
+out = []
+out.append("<!-- agent-verification:start -->")
+out.append("### agent-verification — `%s` for `%s`" % (aggregate, head7))
+out.append("")
+out.append("| gate | result |")
+out.append("|---|---|")
+for g in required:
+    out.append("| `%s` | %s |" % (g, gates[g]))
+out.append("")
+out.append("_%d/%d gates passed [route: %s]. Regenerated per head SHA by "
+            "`tools/agent-verify.sh`._" % (passed, total, route))
+out.append("<!-- agent-verification:end -->")
+print("\n".join(out))
+'
 }
 
 if [ "$POST" = 1 ]; then
@@ -133,18 +211,20 @@ if [ "$POST" = 1 ]; then
     -f state="$STATE" -f context="$CONTEXT" -f description="$DESC" -f target_url="$PR_URL" \
     --jq '"posted: \(.context) = \(.state)"' || die "failed to post status"
   if [ "$EVIDENCE" = 1 ]; then
-    body="$(gh pr view "$PR" --json body --jq '.body // ""')"
     # Strip any prior block, then append the fresh one. Update the body via the
     # REST API rather than `gh pr edit`, which fails on repos still carrying a
     # projects-classic deprecation (it queries projectCards and errors out).
-    clean="$(printf '%s' "$body" | sed '/<!-- agent-verification:start -->/,/<!-- agent-verification:end -->/d')"
+    clean="$(printf '%s' "$PR_BODY" | sed '/<!-- agent-verification:start -->/,/<!-- agent-verification:end -->/d')"
     newbody="$(printf '%s\n\n%s' "$clean" "$(evidence_block)")"
     gh api -X PATCH "repos/{owner}/{repo}/pulls/$PR" -f body="$newbody" >/dev/null \
       && echo "evidence: PR #$PR body updated"
   fi
-else
+elif [ "$JSON" = 0 ]; then
   echo "(dry run — pass --post to post the commit status; --evidence to update the PR body)"
   [ "$EVIDENCE" = 1 ] && { echo "--- evidence block that would be written ---"; evidence_block; }
 fi
+
+[ -n "$JSON_OUT" ] && printf '%s\n' "$EVIDENCE_JSON" > "$JSON_OUT"
+[ "$JSON" = 1 ] && printf '%s\n' "$EVIDENCE_JSON"
 
 [ "$STATE" = success ] && exit 0 || exit 1


### PR DESCRIPTION
## Linked Issue
Closes #136

## Exact behavioral claim
There is now exactly ONE dynamic verification-evidence authority. `pr-policy` emits
static PR metadata only and no longer claims any gate passed; `tools/agent-verify.sh`
owns dynamic per-gate state and can serialize it as canonical JSON. This prevents the
prior split-brain where `pr_policy.py` hardcoded `ci: pass` for a removed GitHub App /
state machine while `agent-verify.sh` was the real SHA-bound authority.

## Scope
- `pr_policy.py`: `evidence` is now static metadata only — `schemaVersion, issue,
  baseSha, headSha, route, escalated, issueRoute, requiredGates, testsReported,
  prPolicy`. The `gateStates` dict (which hardcoded `ci: pass`) and the App(#65)/state-
  machine(#62) comment are removed. It never marks any gate as passed.
- `agent-verify.sh`: adds `--json` (stdout) and `--json-out FILE` emitting the canonical
  evidence object `{schemaVersion, pr, issue, headSha, route, requiredGates, gates{},
  aggregate}`. The `--evidence` PR-body block now renders from that SAME in-memory object
  instead of re-walking the bash arrays. `ci` is still read from the real `build-and-test`
  check-run; a missing required gate still leaves the aggregate non-success.
- `pr-policy.yml`: comment updated to state pr-policy is static-metadata only.
- Nearby behavior deliberately unchanged: aggregate reuses the script's existing
  overall/state computation; no new schema, no DB/service/App.

## Rules conformance
N/A — orchestration tooling only.

## Tests and evidence
- `python3 -m unittest tests.tooling.test_pr_policy -v` → 5/5 pass (incl. "no gate is ever
  marked pass by pr-policy" and "incomplete body still rejected").
- `tests/tooling/test_agent_verify.sh` → 21/21 pass (success/pending/failure aggregate,
  `--json`/`--json-out` validity + canonical key set, evidence-block parity with `--json`,
  non-required `--gate` rejection).
- `tools/agent-verify.sh 999 --gate scope-warden=pass --json | python3 -m json.tool` → valid JSON.
- `python3 .github/workflows/pr_policy.py` on an incomplete body → exit 1, `prPolicy: fail`.
- No downstream consumer reads the renamed/removed evidence keys (evidence.json is only
  uploaded as an artifact).

## Decisions and tradeoffs
Issue-linking in `agent-verify.sh` uses the same Closes/Fixes/Resolves regex as
`pr_policy.py` because this `gh` (2.45.0) lacks `closingIssuesReferences`.

## Known limitations
`orchestration-metrics.py` still contains a historical (accurate) note that the gate-poster
App was removed — Phase 7 (#141) modernizes metrics; not in scope here.

## Agent provenance
Implemented by a Sonnet worker under the `orchestration-dev` contract; reviewed by the
Opus orchestrator (diff read, tests re-run, downstream key-usage checked) plus deterministic
gates + scope-warden.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `eabb05a`

| gate | result |
|---|---|
| `ci` | pass |
| `scope-warden` | pass |

_2/2 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->