### PR TITLE
Make route.sh the single route authority for external patches (#137)

### DIFF
--- a/.github/workflows/pr_policy.py
+++ b/.github/workflows/pr_policy.py
@@ -77,10 +77,21 @@ def is_empty(header: str, content: str) -> bool:
     return False
 
 
-def run_route(base: str | None) -> dict:
+def parse_linked_issue(body: str) -> int | None:
+    m = re.search(r"\b(clos|fix|resolv)(e|es|ed)?\s+#(\d+)", body, re.I)
+    return int(m.group(3)) if m else None
+
+
+def run_route(base: str | None, issue: int | None = None) -> dict:
     cmd = [str(ROOT / "tools" / "route.sh"), "--json"]
     if base:
         cmd += ["--base", base]
+    if issue:
+        # Propagate the linked Issue's route:* label as the asymmetric intent
+        # floor — route.sh (the one route authority) may only RAISE the route
+        # this implies, never lower what the diff itself shows. Best-effort:
+        # route.sh degrades gracefully (no floor applied) if `gh` has no access.
+        cmd += ["--issue", str(issue)]
     try:
         out = subprocess.check_output(cmd, cwd=ROOT, text=True, stderr=subprocess.DEVNULL)
         return json.loads(out.strip().splitlines()[-1])
@@ -104,8 +115,7 @@ def validate(body: str, route: dict, files: list[str]) -> tuple[list[str], dict]
     violations: list[str] = []
 
     # Linked issue.
-    m = re.search(r"\b(clos|fix|resolv)(e|es|ed)?\s+#(\d+)", body, re.I)
-    issue = int(m.group(3)) if m else None
+    issue = parse_linked_issue(body)
     if issue is None:
         violations.append("Linked Issue missing — body has no `Closes #<n>` / `Fixes #<n>`.")
 
@@ -164,7 +174,11 @@ def main() -> int:
         print("no PR body available (pass --body-file or run in a pull_request event)", file=sys.stderr)
         return 2
 
-    route = run_route(base)
+    # Only a genuinely linked Issue (Closes/Fixes/Resolves #N) is a route-intent
+    # source — the PR's own number is not an Issue and must never be passed to
+    # `gh issue view`.
+    linked_issue = parse_linked_issue(body)
+    route = run_route(base, linked_issue)
     files = changed_files(base, head)
     violations, meta = validate(body, route, files)
 

--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -12,6 +12,14 @@ this — the `gates-satisfied` aggregator and the gate-poster App — was remove
 #90/#91; the "required gates" below are the reviewers a change *conceptually* needs,
 no longer an automated check.
 
+`tools/route.sh` is the **one route authority** (#137): it is the only place that
+parses a diff for content escalation, composes architecture, and applies the
+issue-intent floor. Every consumer that needs to classify a change it did not
+generate locally — `agent-verify.sh` when the working tree isn't the PR head,
+`pr_policy.py` once it knows the linked Issue, `agent-brief.py`'s review packet —
+calls this script (via `--diff-file` for an externally captured patch) rather than
+approximating any of this itself.
+
 ## How a route is derived
 
 1. **Path baseline (simple, deterministic).** [`.github/route-map`](../../.github/route-map)
@@ -78,6 +86,12 @@ tools/route.sh src/Brp.Data/damage-ruleset.json
 # Raise the route to a linked issue's declared intent (never lowers it)
 tools/route.sh --base origin/main --issue 112
 tools/route.sh --issue-route formulas src/SomeLoader.cs
+
+# Classify a patch that wasn't generated in this checkout — e.g. a PR's actual
+# diff, fetched with `gh pr diff` while HEAD is somewhere else entirely. Content
+# escalation, architecture composition, and --issue all work exactly as above.
+gh pr diff 137 > /tmp/pr137.diff
+tools/route.sh --diff-file /tmp/pr137.diff --issue 137
 
 # Machine-readable, for the orchestrator / state machine
 tools/route.sh --json --base origin/main

--- a/tests/tooling/test_agent_verify.sh
+++ b/tests/tooling/test_agent_verify.sh
@@ -81,7 +81,19 @@ case "$1 $2" in
       *) echo "mock gh: unhandled pr view --json $jsonf" >&2; exit 1 ;;
     esac ;;
   "pr diff")
-    printf '%s\n' "${MOCK_PR_FILES:-tools/agent-verify.sh}" ;;
+    # agent-verify.sh now fetches the FULL patch (no --name-only) and hands it
+    # to route.sh --diff-file, never a path-only degrade (#137). MOCK_PR_DIFF
+    # supplies a real unified diff verbatim; otherwise synthesize one non-numeric
+    # hunk per MOCK_PR_FILES entry so the default fixture still behaves like a
+    # boring change.
+    if [ -n "${MOCK_PR_DIFF:-}" ]; then
+      printf '%s\n' "$MOCK_PR_DIFF"
+    else
+      for f in ${MOCK_PR_FILES:-tools/agent-verify.sh}; do
+        printf 'diff --git a/%s b/%s\nindex 1111111..2222222 100644\n--- a/%s\n+++ b/%s\n@@ -1,1 +1,1 @@\n-old line\n+new line\n' \
+          "$f" "$f" "$f" "$f"
+      done
+    fi ;;
   *)
     case "$1" in
       api)
@@ -179,6 +191,35 @@ printf '%s\n' "$combined" | python3 -m json.tool >/dev/null \
 # --- case 7: an unrequired --gate is rejected (unchanged prior behaviour) -- #
 rc7=0; run_verify 999 --gate bogus-gate=pass >/dev/null 2>&1 || rc7=$?
 assert_eq "case7: --gate for a non-required gate is rejected" "2" "$rc7"
+
+# --- case 8: off-PR-head route is NOT path-only degraded (#137) ------------ #
+# The local checkout here is never at MOCK_HEAD_SHA, so agent-verify.sh always
+# takes the "not on PR head" branch. Feed it a numeric-threshold change to a
+# rules file through the gh pr diff mock and confirm content escalation still
+# fires — i.e. the required gate set is `formulas`'s (codex-conformance
+# included), never degraded to the path-only `rules` set.
+NUMERIC_DIFF='diff --git a/src/Brp.Rules/Combat/RangeBands.cs b/src/Brp.Rules/Combat/RangeBands.cs
+index 1111111..2222222 100644
+--- a/src/Brp.Rules/Combat/RangeBands.cs
++++ b/src/Brp.Rules/Combat/RangeBands.cs
+@@ -1,3 +1,3 @@
+ switch (r) {
+-    Range.Short => 15,
++    Range.Short => 20,
+ }'
+json8="$(MOCK_PR_DIFF="$NUMERIC_DIFF" run_verify 999 \
+  --gate scope-warden=pass --gate rules-conformance=pass --gate codex-conformance=pass --json)"
+route8="$(printf '%s' "$json8" | python3 -c 'import json,sys; print(json.load(sys.stdin)["route"])')"
+assert_eq "case8: off-head numeric change still content-escalates to formulas" "formulas" "$route8"
+required8="$(printf '%s' "$json8" | python3 -c 'import json,sys; print(sorted(json.load(sys.stdin)["requiredGates"]))')"
+assert_eq "case8: formulas required-gate set (not the path-only rules set)" \
+  "['ci', 'codex-conformance', 'rules-conformance', 'scope-warden']" "$required8"
+
+# Same patch, classified directly by route.sh (the same authority), must agree.
+DIFFFILE="$WORKDIR/numeric.diff"
+printf '%s\n' "$NUMERIC_DIFF" > "$DIFFFILE"
+route8_direct="$("$ROOT/tools/route.sh" --json --diff-file "$DIFFFILE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["route"])')"
+assert_eq "case8: agrees with tools/route.sh --diff-file on the identical patch" "$route8_direct" "$route8"
 
 echo
 if [ "$FAILURES" -eq 0 ]; then

--- a/tests/tooling/test_route.sh
+++ b/tests/tooling/test_route.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# tests/tooling/test_route.sh — fixture tests for tools/route.sh, the one route
+# authority (Issue #137).
+#
+# Proves route.sh classifies a change identically whether it derives the diff
+# itself (--base / working tree) or is handed an externally captured patch
+# (--diff-file) — the shape agent-verify.sh, pr_policy.py, and agent-brief.py
+# now all call through rather than approximating classification themselves.
+#
+# No network access is available in this environment (or in CI without a PAT),
+# so `gh` is stubbed for the two cases that need an issue's route:* label.
+#
+# Run directly:
+#   tests/tooling/test_route.sh
+#
+# Exit: 0 if every case passes, 1 on the first failure.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/route.sh"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then ok "$desc"; else
+    fail "$desc (expected [$expected], got [$actual])"
+  fi
+}
+
+route_of()     { printf '%s' "$1" | python3 -c 'import json,sys; print(json.load(sys.stdin)["route"])'; }
+escalated_of() { printf '%s' "$1" | python3 -c 'import json,sys; print(json.load(sys.stdin)["escalated"])'; }
+arch_of()      { printf '%s' "$1" | python3 -c 'import json,sys; print(json.load(sys.stdin)["architecture"])'; }
+gates_of()     { printf '%s' "$1" | python3 -c 'import json,sys; print(sorted(json.load(sys.stdin)["gates"]))'; }
+
+# --- case 1: ordinary docs file -> docs ------------------------------------ #
+j1="$("$SCRIPT" --json -- README.md)"
+assert_eq "case1: docs file -> docs" "docs" "$(route_of "$j1")"
+
+# --- case 2: ordinary tooling file -> tooling ------------------------------ #
+j2="$("$SCRIPT" --json -- tools/some-script.sh)"
+assert_eq "case2: tooling file -> tooling" "tooling" "$(route_of "$j2")"
+
+# --- case 3: ordinary BRP C# implementation -> rules ----------------------- #
+j3="$("$SCRIPT" --json -- src/Brp.Rules/Combat/RangeBands.cs)"
+assert_eq "case3: BRP C# impl -> rules" "rules" "$(route_of "$j3")"
+
+# --- case 4: ruleset JSON -> formulas --------------------------------------- #
+j4="$("$SCRIPT" --json -- src/Brp.Data/damage-ruleset.json)"
+assert_eq "case4: ruleset JSON -> formulas" "formulas" "$(route_of "$j4")"
+
+# --- fixture diffs ----------------------------------------------------------- #
+NUMERIC_DIFF="$WORKDIR/numeric.diff"
+cat > "$NUMERIC_DIFF" <<'EOF'
+diff --git a/src/Brp.Rules/Combat/RangeBands.cs b/src/Brp.Rules/Combat/RangeBands.cs
+index 1111111..2222222 100644
+--- a/src/Brp.Rules/Combat/RangeBands.cs
++++ b/src/Brp.Rules/Combat/RangeBands.cs
+@@ -1,4 +1,4 @@
+ switch (r) {
+-    Range.Short => 15,
++    Range.Short => 20,
+ }
+EOF
+
+BORING_DIFF="$WORKDIR/boring.diff"
+cat > "$BORING_DIFF" <<'EOF'
+diff --git a/tools/some-script.sh b/tools/some-script.sh
+index 1111111..2222222 100644
+--- a/tools/some-script.sh
++++ b/tools/some-script.sh
+@@ -1,2 +1,2 @@
+-echo hi
++echo hello
+EOF
+
+# --- case 5: C# numeric-threshold change -> formulas via content escalation  #
+j5="$("$SCRIPT" --json --diff-file "$NUMERIC_DIFF")"
+assert_eq "case5: numeric threshold change -> formulas" "formulas" "$(route_of "$j5")"
+assert_eq "case5: content-escalated flag set" "True" "$(escalated_of "$j5")"
+
+# --- fixture `gh` stub for --issue label lookups ---------------------------- #
+MOCKBIN="$WORKDIR/bin"
+mkdir -p "$MOCKBIN"
+cat > "$MOCKBIN/gh" <<'MOCKGH'
+#!/usr/bin/env bash
+set -euo pipefail
+# route.sh calls: gh issue view <N> --json labels --jq '...route:* labels...'
+if [ "$1 $2" = "issue view" ]; then
+  printf '%s\n' "${MOCK_ROUTE_LABELS:-}"
+  exit 0
+fi
+echo "mock gh: unhandled args: $*" >&2
+exit 1
+MOCKGH
+chmod +x "$MOCKBIN/gh"
+
+# --- case 6: issue label route:formulas raises a boring diff -> formulas --- #
+j6_base="$("$SCRIPT" --json --diff-file "$BORING_DIFF")"
+assert_eq "case6 sanity: the boring diff alone is tooling" "tooling" "$(route_of "$j6_base")"
+j6="$(PATH="$MOCKBIN:$PATH" MOCK_ROUTE_LABELS="formulas" "$SCRIPT" --json --diff-file "$BORING_DIFF" --issue 999)"
+assert_eq "case6: issue label route:formulas raises a boring diff -> formulas" "formulas" "$(route_of "$j6")"
+
+# --- case 7: issue label route:docs CANNOT lower an actual formulas diff --- #
+j7="$(PATH="$MOCKBIN:$PATH" MOCK_ROUTE_LABELS="docs" "$SCRIPT" --json --diff-file "$NUMERIC_DIFF" --issue 999)"
+assert_eq "case7: route:docs cannot lower a real formulas diff" "formulas" "$(route_of "$j7")"
+
+# --- case 8: architecture composes with another route ----------------------- #
+j8="$("$SCRIPT" --json -- src/Brp.Rules/Combat/RangeBands.cs Directory.Build.props)"
+assert_eq "case8: base route unaffected by the architecture file" "rules" "$(route_of "$j8")"
+assert_eq "case8: architecture flag set" "True" "$(arch_of "$j8")"
+assert_eq "case8: gate set composes (architecture-review added, rules gates kept)" \
+  "['architecture-review', 'ci', 'rules-conformance', 'scope-warden']" "$(gates_of "$j8")"
+
+# --- case 9: route derivation away from the PR branch == on the PR branch -- #
+# Build a throwaway git repo that stands in for "the PR branch", carrying its
+# own copy of route.sh and .github/route-map so `--base` classification is
+# self-contained. Classify it there (on-branch), then capture the identical
+# patch to a file and classify THAT from this real checkout instead — which is
+# a different git repository, on a different branch entirely (away from the
+# PR branch) — and confirm the two agree exactly.
+PRREPO="$WORKDIR/pr-repo"
+mkdir -p "$PRREPO/tools" "$PRREPO/.github" "$PRREPO/src/Brp.Rules/Combat"
+cp "$SCRIPT" "$PRREPO/tools/route.sh"
+cp "$ROOT/.github/route-map" "$PRREPO/.github/route-map"
+git -C "$PRREPO" init -q -b main
+git -C "$PRREPO" config user.email "test@example.invalid"
+git -C "$PRREPO" config user.name "test"
+cat > "$PRREPO/src/Brp.Rules/Combat/Foo.cs" <<'EOF'
+public static int Threshold(int x) => x switch
+{
+    1 => 5,
+    _ => 0,
+};
+EOF
+git -C "$PRREPO" add -A
+git -C "$PRREPO" commit -q -m base
+sed -i 's/1 => 5,/1 => 9,/' "$PRREPO/src/Brp.Rules/Combat/Foo.cs"
+git -C "$PRREPO" commit -aq -m "pr change"
+
+ON_BRANCH_JSON="$(cd "$PRREPO" && ./tools/route.sh --json --base HEAD~1)"
+git -C "$PRREPO" diff HEAD~1...HEAD > "$WORKDIR/captured.diff"
+OFF_BRANCH_JSON="$("$SCRIPT" --json --diff-file "$WORKDIR/captured.diff")"
+
+assert_eq "case9: off-branch route == on-branch route" \
+  "$(route_of "$ON_BRANCH_JSON")" "$(route_of "$OFF_BRANCH_JSON")"
+assert_eq "case9: off-branch route is formulas (content-escalated)" \
+  "formulas" "$(route_of "$OFF_BRANCH_JSON")"
+assert_eq "case9: off-branch escalated flag == on-branch" \
+  "$(escalated_of "$ON_BRANCH_JSON")" "$(escalated_of "$OFF_BRANCH_JSON")"
+assert_eq "case9: off-branch gate set == on-branch gate set" \
+  "$(gates_of "$ON_BRANCH_JSON")" "$(gates_of "$OFF_BRANCH_JSON")"
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "test_route.sh: all checks passed"
+  exit 0
+else
+  echo "test_route.sh: $FAILURES check(s) failed"
+  exit 1
+fi

--- a/tools/agent-brief.py
+++ b/tools/agent-brief.py
@@ -176,12 +176,17 @@ def workspace(files_text: str, body: str) -> tuple[list[str], list[str]]:
     return lines, derived
 
 
-def route_for(files: list[str], base: str | None = None) -> dict:
+def route_for(files: list[str], base: str | None = None, issue: int | None = None) -> dict:
+    # route.sh is the one route authority: derives changed paths, content
+    # escalation, and (via --issue) the issue-intent floor the same way for
+    # every consumer — the review packet must never approximate this itself.
     cmd = ["bash", str(ROOT / "tools" / "route.sh"), "--json"]
     if base:
         cmd += ["--base", base]
     else:
         cmd += files
+    if issue:
+        cmd += ["--issue", str(issue)]
     try:
         return json.loads(sh(cmd).strip().splitlines()[-1])
     except Exception:
@@ -262,7 +267,7 @@ def cmd_review(args: argparse.Namespace) -> None:
 
     names = [f for f in sh(["git", "diff", "--name-only", f"{base}...{head}"]).splitlines() if f]
     diff = sh(["git", "diff", "-U1", f"{base}...{head}"])
-    route = route_for(names, base=base)
+    route = route_for(names, base=base, issue=issue)
 
     claim = first_of(split_sections(body), "exact behavioral claim", "behavioral claim") or "(none stated)"
 

--- a/tools/agent-verify.sh
+++ b/tools/agent-verify.sh
@@ -65,23 +65,41 @@ read -r HEAD_SHA PR_URL PR_STATE < <(gh pr view "$PR" \
   || die "cannot read PR #$PR"
 [ -n "$HEAD_SHA" ] || die "PR #$PR has no head SHA"
 
+# --- resolve the linked issue (best-effort; used both for the route's issue-
+# intent floor and for the evidence object) -------------------------------- #
+# Same "Closes/Fixes/Resolves #N" convention pr_policy.py enforces on the body;
+# this gh CLI version has no closingIssuesReferences JSON field to read instead.
+PR_BODY="$(gh pr view "$PR" --json body --jq '.body // ""' 2>/dev/null || true)"
+ISSUE_NUM="$(printf '%s' "$PR_BODY" | python3 -c '
+import re, sys
+m = re.search(r"(?i)\b(clos|fix|resolv)(e|es|ed)?\s+#(\d+)", sys.stdin.read())
+print(m.group(3) if m else "")
+')"
+
 # --- derive the required gate set from the route -------------------------- #
-# The route must reflect the PR's OWN diff, not whatever is checked out. When the
-# working tree is on the PR head we use route.sh --base (full, incl. the numeric
-# content-escalation); otherwise we degrade to GitHub's changed-file list, which
-# is path-only — the rules->formulas content escalation cannot be seen — and say so.
+# The route must reflect the PR's OWN diff, not whatever is checked out. When
+# the working tree is on the PR head we use route.sh --base (full, incl. the
+# numeric content-escalation). Otherwise we fetch the actual PR patch with
+# `gh pr diff` and classify THAT through route.sh --diff-file — the same
+# content-escalation and issue-intent logic route.sh applies to a local diff,
+# never a path-only degrade (see #137: route.sh is the one route authority).
 git -C "$ROOT" rev-parse --verify --quiet "$BASE" >/dev/null 2>&1 \
   || git -C "$ROOT" fetch -q origin "${BASE#origin/}" 2>/dev/null || true
 LOCAL_HEAD="$(git -C "$ROOT" rev-parse --quiet --verify HEAD 2>/dev/null || echo none)"
-ROUTE_CAVEAT=""
+PR_DIFF_FILE=""
+cleanup_diff_file() { [ -n "$PR_DIFF_FILE" ] && rm -f "$PR_DIFF_FILE"; }
+trap cleanup_diff_file EXIT
+ROUTE_ARGS=(--json)
 if [ "$LOCAL_HEAD" = "$HEAD_SHA" ]; then
-  ROUTE_JSON="$(cd "$ROOT" && tools/route.sh --json --base "$BASE" 2>/dev/null || echo '{}')"
+  ROUTE_ARGS+=(--base "$BASE")
 else
-  mapfile -t PR_FILES < <(gh pr diff "$PR" --name-only 2>/dev/null || true)
-  [ "${#PR_FILES[@]}" -gt 0 ] || die "cannot list PR #$PR changed files (and HEAD is not the PR head)"
-  ROUTE_JSON="$(cd "$ROOT" && tools/route.sh --json "${PR_FILES[@]}" 2>/dev/null || echo '{}')"
-  ROUTE_CAVEAT=" (path-only: check out the PR head for content-escalation)"
+  PR_DIFF_FILE="$(mktemp)"
+  gh pr diff "$PR" > "$PR_DIFF_FILE" 2>/dev/null || die "cannot fetch PR #$PR diff (and HEAD is not the PR head)"
+  [ -s "$PR_DIFF_FILE" ] || die "PR #$PR diff is empty (and HEAD is not the PR head)"
+  ROUTE_ARGS+=(--diff-file "$PR_DIFF_FILE")
 fi
+[ -n "$ISSUE_NUM" ] && ROUTE_ARGS+=(--issue "$ISSUE_NUM")
+ROUTE_JSON="$(cd "$ROOT" && tools/route.sh "${ROUTE_ARGS[@]}" 2>/dev/null || echo '{}')"
 mapfile -t REQUIRED < <(printf '%s' "$ROUTE_JSON" | \
   python3 -c 'import sys,json;print("\n".join(json.load(sys.stdin).get("gates",[])))' 2>/dev/null || true)
 ROUTE_NAME="$(printf '%s' "$ROUTE_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("route","?"))' 2>/dev/null || echo '?')"
@@ -124,16 +142,6 @@ DESC="$passed/$total gates passed [route: $ROUTE_NAME]"
 # GitHub commit-status states are: success | failure | pending | error.
 STATE="$overall"
 
-# --- resolve the linked issue (best-effort, for the evidence object) ------ #
-# Same "Closes/Fixes/Resolves #N" convention pr_policy.py enforces on the body;
-# this gh CLI version has no closingIssuesReferences JSON field to read instead.
-PR_BODY="$(gh pr view "$PR" --json body --jq '.body // ""' 2>/dev/null || true)"
-ISSUE_NUM="$(printf '%s' "$PR_BODY" | python3 -c '
-import re, sys
-m = re.search(r"(?i)\b(clos|fix|resolv)(e|es|ed)?\s+#(\d+)", sys.stdin.read())
-print(m.group(3) if m else "")
-')"
-
 # --- build the ONE canonical evidence object ------------------------------ #
 # Both --json/--json-out and the human --evidence PR-body block render from this
 # exact object — neither reconstructs gate state independently (see #136).
@@ -169,7 +177,7 @@ PYEOF
 
 # --- render the plan (suppressed in --json mode so stdout is pure JSON) --- #
 if [ "$JSON" = 0 ]; then
-  echo "PR #$PR  head=$HEAD_SHA  route=$ROUTE_NAME$ROUTE_CAVEAT"
+  echo "PR #$PR  head=$HEAD_SHA  route=$ROUTE_NAME"
   echo "status: $CONTEXT = $STATE  ($DESC)"
   for g in "${REQUIRED[@]}"; do printf '  %-20s %s\n' "$g" "${RESULT[$g]}"; done
 fi

--- a/tools/route.sh
+++ b/tools/route.sh
@@ -8,10 +8,18 @@
 # touches numeric tables / thresholds.
 #
 # Usage:
-#   tools/route.sh [--base <ref>] [--json] [file ...]
+#   tools/route.sh [--base <ref> | --diff-file <path>] [--json] [--issue <n>] [file ...]
 #
 # File selection (first that applies):
 #   explicit [file ...]   classify exactly those paths
+#   --diff-file <path>    a unified diff (e.g. `gh pr diff` or `git diff` output,
+#                          not necessarily generated in this checkout) — content
+#                          escalation is read from the patch itself, so route
+#                          derivation away from the diff's own branch is identical
+#                          to running on it. This is the ONE route authority: other
+#                          tools that need to classify a patch they didn't generate
+#                          locally (agent-verify.sh, pr_policy.py, agent-brief.py)
+#                          call this, they do not reimplement classification.
 #   --base <ref>          git diff --name-only <ref>...HEAD
 #   (neither)             git diff --name-only HEAD   (working tree + staged)
 #
@@ -27,6 +35,7 @@ MAP="$ROOT/.github/route-map"
 
 JSON=0
 BASE=""
+DIFF_FILE=""       # classify a patch that isn't necessarily the local checkout's diff
 ISSUE_ROUTE=""     # an explicit intent floor, e.g. --issue-route formulas
 ISSUE_NUM=""       # or --issue N, from which we read the issue's route:* label
 FILES=()
@@ -34,6 +43,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --json)        JSON=1; shift ;;
     --base)        BASE="${2:-}"; shift 2 ;;
+    --diff-file)   DIFF_FILE="${2:-}"; shift 2 ;;
     --issue-route) ISSUE_ROUTE="${2:-}"; shift 2 ;;
     --issue)       ISSUE_NUM="${2:-}"; shift 2 ;;
     --)     shift; while [ $# -gt 0 ]; do FILES+=("$1"); shift; done ;;
@@ -61,8 +71,59 @@ case "${ISSUE_ROUTE:-}" in
   *) echo "invalid --issue-route: $ISSUE_ROUTE (docs|tooling|rules|formulas|architecture)" >&2; exit 2 ;;
 esac
 
+[ -n "$DIFF_FILE" ] && [ -n "$BASE" ] && { echo "--diff-file and --base are mutually exclusive" >&2; exit 2; }
+[ -n "$DIFF_FILE" ] && [ ! -f "$DIFF_FILE" ] && { echo "diff file not found: $DIFF_FILE" >&2; exit 2; }
+
+# Parse a unified diff (git diff / gh pr diff format) for the paths it touches.
+# Uses the `diff --git a/X b/Y` header, which names both sides regardless of
+# add/delete/rename, so it does not depend on --- / +++ (which go /dev/null on
+# add or delete). Reports the "b" (current/new) path, falling back to "a".
+files_from_diff_file() {
+  awk '
+    /^diff --git a\// {
+      line = $0
+      sub(/^diff --git a\//, "", line)
+      idx = index(line, " b/")
+      if (idx > 0) {
+        apath = substr(line, 1, idx - 1)
+        bpath = substr(line, idx + 3)
+        print (bpath != "" ? bpath : apath)
+      }
+    }
+  ' "$1"
+}
+
+# Extract only the hunks for the given paths out of a unified diff file, so
+# content escalation can be evaluated against an externally supplied patch the
+# exact same way it is against a local `git diff`.
+diff_hunks_for_files_in_file() {
+  local diff_file="$1"; shift
+  local wanted; wanted="$(printf '%s\n' "$@")"
+  awk -v wanted="$wanted" '
+    BEGIN {
+      n = split(wanted, arr, "\n")
+      for (i = 1; i <= n; i++) if (arr[i] != "") want[arr[i]] = 1
+    }
+    /^diff --git a\// {
+      line = $0
+      sub(/^diff --git a\//, "", line)
+      idx = index(line, " b/")
+      keep = 0
+      if (idx > 0) {
+        apath = substr(line, 1, idx - 1)
+        bpath = substr(line, idx + 3)
+        if ((apath in want) || (bpath in want)) keep = 1
+      }
+      next
+    }
+    { if (keep) print }
+  ' "$diff_file"
+}
+
 if [ ${#FILES[@]} -eq 0 ]; then
-  if [ -n "$BASE" ]; then
+  if [ -n "$DIFF_FILE" ]; then
+    mapfile -t FILES < <(files_from_diff_file "$DIFF_FILE")
+  elif [ -n "$BASE" ]; then
     mapfile -t FILES < <(git -C "$ROOT" diff --name-only "$BASE"...HEAD)
   else
     mapfile -t FILES < <(git -C "$ROOT" diff --name-only HEAD)
@@ -133,7 +194,9 @@ if [ "$base" = "rules" ]; then
     { [ "$r" = "rules" ] || [ "$r" = "formulas" ]; } && rf+=("$f")
   done
   if [ ${#rf[@]} -gt 0 ]; then
-    if [ -n "$BASE" ]; then
+    if [ -n "$DIFF_FILE" ]; then
+      d="$(diff_hunks_for_files_in_file "$DIFF_FILE" "${rf[@]}")"
+    elif [ -n "$BASE" ]; then
       d="$(git -C "$ROOT" diff --unified=0 "$BASE"...HEAD -- "${rf[@]}" 2>/dev/null || true)"
     else
       d="$(git -C "$ROOT" diff --unified=0 HEAD -- "${rf[@]}" 2>/dev/null || true)"


### PR DESCRIPTION
## Linked Issue
Closes #137

## Exact behavioral claim
`tools/route.sh` is now the ONE route authority: it can classify a unified diff it did
not generate locally (`--diff-file`), reading content escalation from the patch itself.
`agent-verify.sh`, `pr_policy.py`, and `agent-brief.py` now all route through it, so a
numeric C# change can no longer evade `formulas`/Codex routing just because the PR head
isn't the local checkout. Route derivation is identical from local branch, PR patch,
review packet, and verification.

## Scope
- `route.sh`: adds `--diff-file <path>` (mutually exclusive with `--base`). Parses paths
  from `diff --git a/X b/Y` headers (robust to add/delete/rename) and evaluates the
  existing content-escalation grep against the patch's own hunks — no second classifier.
  Existing `--base`/`--json`/`--issue`/`[file ...]` interface unchanged.
- `agent-verify.sh`: when NOT on the PR head, fetches the full `gh pr diff <PR>` patch and
  routes it via `--diff-file --issue`, instead of degrading to a path-only filename list.
- `pr_policy.py`: resolves the linked Issue and passes `--issue` to `route.sh` so issue
  intent (`route:*`) is applied as a floor (only a genuine linked Issue, never the PR's own number).
- `agent-brief.py`: review-packet route now passes `--issue` through the same engine.
- `docs/orchestration/routing.md`: documents `--diff-file` and the one-authority framing.

## Rules conformance
N/A — orchestration tooling only.

## Tests and evidence
- `tests/tooling/test_route.sh` (new): all 9 required acceptance cases pass — docs/tooling/
  rules/formulas classification, C# numeric→formulas content escalation, `route:formulas`
  raises a boring diff, `route:docs` cannot lower a formulas diff (asymmetric rule),
  architecture composition, and **off-branch `--diff-file` route == on-branch `--base` route**.
- `tests/tooling/test_agent_verify.sh`: 24 assertions pass (added case 8 — off-PR-head route
  is no longer path-degraded and agrees with `route.sh --diff-file`).
- `python3 -m unittest tests.tooling.test_pr_policy` → 5/5 pass; `orchestration-policy.sh` → PASS.

## Decisions and tradeoffs
An externally supplied patch carries context lines a local `--unified=0` diff omits; within
the rules→formulas escalation this can only ever ESCALATE (the safe, asymmetric direction),
never under-route. Confirmed equal to the on-branch result on the tested formulas case.

## Known limitations
`--issue` propagation needs `gh` access to the linked Issue's labels; `route.sh` already
degrades gracefully (no floor, not a hard failure) when `gh` is unreachable — unchanged here.

## Agent provenance
Implemented by the `orchestration-dev` (Sonnet) agent; reviewed by the Opus orchestrator
(diff read incl. the awk hunk-parser, all tests re-run) plus deterministic gates + scope-warden.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `9e3d290`

| gate | result |
|---|---|
| `ci` | pass |
| `scope-warden` | pass |

_2/2 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->