### PR TITLE
Shrink scope-warden to a residual semantic gate; docs/tooling → CI only (#138)

### DIFF
--- a/.claude/agents/scope-warden.md
+++ b/.claude/agents/scope-warden.md
@@ -1,35 +1,43 @@
 ---
 name: scope-warden
-description: Checks a diff or file set against the scope filter and source-text rules. Cheap mechanical gate — run on every rules-engine PR before more expensive review. Not a code reviewer.
+description: Residual semantic reviewer for rules/formulas changes — judgment calls that grep and CI cannot make. Not a code reviewer, not a re-check of deterministic gates.
 model: haiku
 effort: low
 tools: Read, Grep, Glob, Bash
 ---
 
-You run one checklist against a change. You do not review code quality, design, or
-correctness — other agents do that. Be fast and literal.
+You are the RESIDUAL semantic gate. `tools/orchestration-policy.sh` and CI already
+prove the deterministic invariants mechanically on every PR — do not re-check them,
+do not restate them as findings, and do not fail a PR for something a machine already
+proved. You exist only for the judgment calls a machine can't make.
 
-## Checklist
+## Already proven mechanically — do not re-review
 
-1. **Out-of-scope content.** Per `orc-scope-filter.md`: no magic, sorcery, spells,
-   psychic powers, superpowers, mutations, the Projection skill, power points as a
-   spendable pool, powered or enchanted equipment, pre-modern or science-fiction
-   weapons and armor, aircraft, watercraft, spacecraft, or fantasy creatures.
-2. **Wrong source.** No reference to, or values derived from, `BRP SRD 1.0.2.pdf`.
-   Flag any four-grade success model — the current source has five.
-3. **Era baselines.** Where a skill has both a modern and a historical base chance,
-   the modern value must be used.
-4. **Determinism.** No `System.Random` static, no ambient time, no unseeded
-   randomness in `Brp.Core` or `Brp.Rules`.
-5. **Engine independence.** No Unity, Godot, or MonoGame reference in `Brp.Core` or
-   `Brp.Rules`.
-6. **Data not constants.** Values from the book belong in ruleset data, not hardcoded
-   in C#.
-7. **Skill naming.** The canonical skill list is the framework's 18, as hardcoded in
-   `tools/case_validator.py`. Do not accept renames to the book's names — existing
-   tooling depends on the framework names.
+- Authoritative-source hash / superseded-source exclusion
+- Banned `System.Random` / ambient-clock APIs
+- `Brp.Core` / `Brp.Rules` engine-independence (no Unity/Godot/MonoGame refs)
+
+## What you evaluate — interpretation only
+
+1. **Semantic out-of-scope content.** Content that reads as in-scope to a literal
+   scan but is actually excluded under `orc-scope-filter.md` (magic, powers,
+   anachronistic tech, fantasy creatures, etc.) — cases where the exclusion isn't a
+   keyword match, it's a judgment about what the text means.
+2. **Wrong conceptual source, despite passing file-level checks.** A value or rule
+   that is phrased/derived in the style of the superseded source, or a four-grade
+   success model smuggled in as prose rather than as an obviously-named reference.
+3. **Historical vs. modern baseline**, where the diff doesn't name which era it's
+   using and you have to infer it from context.
+4. **Hardcoded source-derived value.** A number or table drawn from the book that
+   is written as a C# literal/constant instead of ruleset data — requires reading
+   the surrounding code to tell a rules value from an incidental constant.
+5. **Canonical framework naming/meaning**, where a rename or redefinition is subtle
+   enough that a string diff wouldn't catch it (e.g. a skill redefined to mean
+   something different while keeping its name).
+6. Any additional narrowly-scoped semantic check supplied by the Issue or the
+   review packet for this PR.
 
 ## Output
 
-A short pass/fail per item with file and line for any failure. Nothing else. If
-everything passes, say so in one line.
+A short pass/fail per applicable item, with file and line for any failure. If
+nothing in the diff raises a semantic question, say so in one line and stop.

--- a/tests/tooling/test_agent_verify.sh
+++ b/tests/tooling/test_agent_verify.sh
@@ -85,11 +85,13 @@ case "$1 $2" in
     # to route.sh --diff-file, never a path-only degrade (#137). MOCK_PR_DIFF
     # supplies a real unified diff verbatim; otherwise synthesize one non-numeric
     # hunk per MOCK_PR_FILES entry so the default fixture still behaves like a
-    # boring change.
+    # boring change. The default file routes to `rules` (ci + scope-warden +
+    # rules-conformance) rather than `tooling`, since #138 made the `tooling`
+    # route ci-only and these cases exist to exercise a non-ci required gate.
     if [ -n "${MOCK_PR_DIFF:-}" ]; then
       printf '%s\n' "$MOCK_PR_DIFF"
     else
-      for f in ${MOCK_PR_FILES:-tools/agent-verify.sh}; do
+      for f in ${MOCK_PR_FILES:-src/Brp.Rules/Combat/Foo.cs}; do
         printf 'diff --git a/%s b/%s\nindex 1111111..2222222 100644\n--- a/%s\n+++ b/%s\n@@ -1,1 +1,1 @@\n-old line\n+new line\n' \
           "$f" "$f" "$f" "$f"
       done
@@ -122,7 +124,7 @@ export PATH="$MOCKBIN:$PATH"
 run_verify() { "$SCRIPT" "$@"; }
 
 # --- case 1: all gates pass -> aggregate success, canonical shape ---------- #
-json="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --json)"
+json="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --json)"
 printf '%s\n' "$json" | python3 -m json.tool >/dev/null \
   && ok "case1: --json is valid JSON" || fail "case1: --json is valid JSON"
 
@@ -144,7 +146,7 @@ assert_eq "case1: exact canonical key set" \
   "['aggregate', 'gates', 'headSha', 'issue', 'pr', 'requiredGates', 'route', 'schemaVersion']" \
   "$keys"
 
-rc=0; MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass >/dev/null || rc=$?
+rc=0; MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass >/dev/null || rc=$?
 assert_eq "case1: exit 0 on success" "0" "$rc"
 
 # --- case 2: a required gate never supplied -> pending, never success ------ #
@@ -156,7 +158,7 @@ rc2=0; MOCK_CI_CONCLUSION=success run_verify 999 >/dev/null || rc2=$?
 assert_eq "case2: exit non-zero when pending" "1" "$rc2"
 
 # --- case 3: ci fails on GitHub -> aggregate failure, ci fabricated never --- #
-json3="$(MOCK_CI_CONCLUSION=failure run_verify 999 --gate scope-warden=pass --json || true)"
+json3="$(MOCK_CI_CONCLUSION=failure run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --json || true)"
 agg3="$(printf '%s' "$json3" | python3 -c 'import json,sys; print(json.load(sys.stdin)["aggregate"])')"
 gate_ci3="$(printf '%s' "$json3" | python3 -c 'import json,sys; print(json.load(sys.stdin)["gates"]["ci"])')"
 assert_eq "case3: real ci failure -> gates.ci = fail" "fail" "$gate_ci3"
@@ -164,13 +166,13 @@ assert_eq "case3: real ci failure -> aggregate failure" "failure" "$agg3"
 
 # --- case 4: --json-out writes the same object to a file ------------------- #
 OUT="$WORKDIR/evidence.json"
-MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --json-out "$OUT" >/dev/null
+MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --json-out "$OUT" >/dev/null
 [ -f "$OUT" ] && ok "case4: --json-out wrote a file" || fail "case4: --json-out wrote a file"
 python3 -m json.tool "$OUT" >/dev/null && ok "case4: --json-out file is valid JSON" \
   || fail "case4: --json-out file is valid JSON"
 
 # --- case 5: --evidence PR-body block renders from the SAME object -------- #
-evidence_out="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --evidence)"
+evidence_out="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --evidence)"
 assert_contains "case5: evidence block has managed start marker" \
   "$evidence_out" "<!-- agent-verification:start -->"
 assert_contains "case5: evidence block has managed end marker" \
@@ -183,7 +185,7 @@ assert_contains "case5: evidence block reports the same per-gate results" \
   "$evidence_out" '| `scope-warden` | pass |'
 
 # --- case 6: --json mode leaves stdout as pure JSON, even with --evidence -- #
-combined="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --json --evidence)"
+combined="$(MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --json --evidence)"
 printf '%s\n' "$combined" | python3 -m json.tool >/dev/null \
   && ok "case6: --json + --evidence still leaves stdout pure JSON" \
   || fail "case6: --json + --evidence still leaves stdout pure JSON"

--- a/tests/tooling/test_pr_policy.py
+++ b/tests/tooling/test_pr_policy.py
@@ -149,7 +149,7 @@ class PrPolicyStaticEvidenceTests(unittest.TestCase):
         self.assertEqual(evidence["baseSha"], self.head)
         self.assertEqual(evidence["issue"], 136)
         self.assertEqual(evidence["route"], "tooling")
-        self.assertEqual(sorted(evidence["requiredGates"]), ["ci", "scope-warden"])
+        self.assertEqual(sorted(evidence["requiredGates"]), ["ci"])
         self.assertEqual(evidence["prPolicy"], "pass")
         self.assertIn("issueRoute", evidence)  # present even when null
 

--- a/tests/tooling/test_route.sh
+++ b/tests/tooling/test_route.sh
@@ -41,10 +41,14 @@ gates_of()     { printf '%s' "$1" | python3 -c 'import json,sys; print(sorted(js
 # --- case 1: ordinary docs file -> docs ------------------------------------ #
 j1="$("$SCRIPT" --json -- README.md)"
 assert_eq "case1: docs file -> docs" "docs" "$(route_of "$j1")"
+assert_eq "case1: docs gate set is ci-only (no semantic AI reviewer)" \
+  "['ci']" "$(gates_of "$j1")"
 
 # --- case 2: ordinary tooling file -> tooling ------------------------------ #
 j2="$("$SCRIPT" --json -- tools/some-script.sh)"
 assert_eq "case2: tooling file -> tooling" "tooling" "$(route_of "$j2")"
+assert_eq "case2: tooling gate set is ci-only (no semantic AI reviewer)" \
+  "['ci']" "$(gates_of "$j2")"
 
 # --- case 3: ordinary BRP C# implementation -> rules ----------------------- #
 j3="$("$SCRIPT" --json -- src/Brp.Rules/Combat/RangeBands.cs)"

--- a/tools/route.sh
+++ b/tools/route.sh
@@ -220,7 +220,7 @@ if [ -n "$ISSUE_ROUTE" ]; then
 fi
 
 case "$base" in
-  docs | tooling) gates="ci scope-warden" ;;
+  docs | tooling) gates="ci" ;;
   rules)          gates="ci scope-warden rules-conformance" ;;
   formulas)       gates="ci scope-warden rules-conformance codex-conformance" ;;
 esac


### PR DESCRIPTION
## Linked Issue
Closes #138

## Exact behavioral claim
docs- and tooling-routed PRs now invoke ZERO semantic AI reviewers — CI (plus the
deterministic `orchestration-policy` job) is sufficient. `scope-warden` is redefined as a
residual SEMANTIC gate that only runs for `rules`/`formulas` and only judges what a machine
cannot. This removes the largest source of avoidable model-token spend (a Haiku re-read of
every docs/tooling diff to re-prove facts CI already proves). This very PR routes to `ci`
only — it demonstrates the saving on itself.

## Scope
- `tools/route.sh`: `docs | tooling` gate set `ci scope-warden` → `ci`. `rules`
  (`ci scope-warden rules-conformance`), `formulas` (`+codex-conformance`), and
  architecture composition are UNCHANGED.
- `.claude/agents/scope-warden.md`: rewritten shorter and purely semantic — out-of-scope
  content requiring judgment, wrong conceptual source despite file-level protection,
  historical-vs-modern inference, source values hardcoded in C#, subtle canonical-naming
  drift, and issue/packet-supplied semantic checks. Explicitly lists the deterministic
  invariants it must NOT re-review (already proven by CI / `orchestration-policy.sh`).
- GitHub label descriptions for `route:docs` / `route:tooling` updated to "(ci only)"
  (applied via `gh label edit` by the orchestrator — no committed label manifest exists).
- Test fixtures that pinned the old gate sets moved with the change (see Tests).

## Rules conformance
N/A. Deterministic invariant coverage is NOT weakened — only redundant semantic re-review
of machine-proven facts is removed; `rules-conformance` and Codex are untouched.

## Tests and evidence
- `tests/tooling/test_route.sh` → pass, incl. new assertions that docs/tooling gate set == `['ci']`.
- `tests/tooling/test_agent_verify.sh` → pass (default fixture moved to a `rules`-route file +
  `--gate rules-conformance=pass` so non-ci gate behavior is still exercised now that tooling is ci-only).
- `python3 -m unittest tests.tooling.test_pr_policy` → 5/5 pass (`requiredGates` fixture updated to `["ci"]`).
- `tools/orchestration-policy.sh` → PASS (all four deterministic invariants intact).

## Decisions and tradeoffs
`test_pr_policy.py` and `test_agent_verify.sh` were updated alongside the packet's named files
because they pin the gate sets this PR changes — a direct fixture consequence of the one
behavior change, kept in-scope rather than split into a follow-up that would leave the suite red.

## Known limitations
None.

## Agent provenance
Implemented by the `orchestration-dev` (Sonnet) agent; reviewed by the Opus orchestrator
(both core diffs read, all four test suites re-run, label edits applied). Per the new policy
this tooling PR takes CI as its sufficient gate.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `eaec39f`

| gate | result |
|---|---|
| `ci` | pass |

_1/1 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->