### PR TITLE
Make packet-first dispatch mandatory; reproducible packet hashes (#139)

### DIFF
--- a/.claude/agents/case-author.md
+++ b/.claude/agents/case-author.md
@@ -9,6 +9,17 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 You author and repair case data. Read `cases/SCHEMA.md` first, and `cases/overpass.yaml`
 as the reference implementation.
 
+## Packet-first
+
+A generated TASK packet (`tools/agent-brief.py task <issue>`) is your starting
+context. Read the named files and their necessary one-hop neighbors — do not
+conduct an open-ended repository survey. If more than five broad discovery
+operations (repo-wide grep/glob/history searches) appear necessary, stop and
+return `BRIEF DEFICIENCY` describing what the packet failed to provide. Normal
+reads, edits, targeted validator runs, and inspection of explicitly named files
+do not count as broad discovery. If no working TASK packet was provided, that is
+a process error — say so rather than reconstructing the context by hand.
+
 ## The rules that are machine-enforced
 
 `tools/case_validator.py` is the authority. Run it on every case you touch and act on

--- a/.claude/agents/design-critic.md
+++ b/.claude/agents/design-critic.md
@@ -10,6 +10,18 @@ You review design work the way `design-review-notes.md` reviews the framework: f
 the places where the design stops being an adaptation and becomes an original game,
 because that is where it is thinnest.
 
+## Packet-first, read-only
+
+Start from the generated packet for the work under review — a REVIEW packet
+(`tools/agent-brief.py review <pr>`) for a PR, or a TASK packet
+(`tools/agent-brief.py task <issue>`) for a phase-gate document review — and read
+the named document plus its necessary one-hop neighbors (cited precedents,
+directly linked ADRs). Do not conduct an open-ended repository survey; more than
+five broad discovery operations means stop and return `BRIEF DEFICIENCY`. If no
+working packet was provided, that is a process error — say so rather than
+reconstructing the context yourself. You are read-only: findings only, never
+`Write`/`Edit` the document you are critiquing.
+
 ## Method
 
 - Say plainly what is strong before what is weak, and be specific about both.

--- a/.claude/agents/engine-dev.md
+++ b/.claude/agents/engine-dev.md
@@ -6,8 +6,8 @@ effort: medium
 tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 
-You implement exactly one Issue. Read `AGENTS.md` first, then the Issue. Do not read
-the whole repository.
+You implement exactly one Issue. Read `AGENTS.md` first, then the Issue and its task
+packet. Do not read the whole repository.
 
 ## Boundaries
 
@@ -16,6 +16,19 @@ the whole repository.
 - If the Issue turns out to require an unsettled design decision, stop and say so.
   Do not decide it yourself.
 - If it seems to require out-of-scope content, stop and ask.
+
+## Packet-first
+
+A generated TASK packet (`tools/agent-brief.py task <issue>`) is your starting
+context: the Issue, its exact outcome, acceptance criteria, exclusions, likely
+files, predicted route, and required gates. Read the named files and their
+necessary one-hop neighbors — do not conduct an open-ended repository survey. If
+more than five broad discovery operations (repo-wide grep/glob/history searches)
+appear necessary, stop and return `BRIEF DEFICIENCY` describing what the packet
+failed to provide. Normal reads, edits, targeted compilation/tests, and inspection
+of explicitly named files do not count as broad discovery. If no working TASK
+packet was provided at all, that is a process error — say so rather than
+reconstructing the context by hand.
 
 ## Non-negotiable invariants
 

--- a/.claude/agents/orchestration-dev.md
+++ b/.claude/agents/orchestration-dev.md
@@ -31,11 +31,16 @@ writing routine Bash, Python, YAML, or docs.
 
 ## Packet-first
 
-A generated TASK packet is your starting context: the Issue, the exact outcome,
-acceptance criteria, exclusions, likely files, predicted route, and required gates.
-Read the named files and their necessary one-hop neighbors. Do not conduct an
-open-ended repository survey. If a working TASK packet was not provided, treat that as
-a process error and say so rather than reconstructing the whole context by hand.
+A generated TASK packet (`tools/agent-brief.py task <issue>`) is your starting
+context: the Issue, the exact outcome, acceptance criteria, exclusions, likely
+files, predicted route, and required gates. Read the named files and their
+necessary one-hop neighbors. Do not conduct an open-ended repository survey. If
+more than five broad discovery operations (repo-wide grep/glob/history searches)
+appear necessary, stop and return `BRIEF DEFICIENCY` describing what the packet
+failed to provide. Normal reads, edits, targeted compilation/tests, and inspection
+of explicitly named files do not count as broad discovery. If a working TASK
+packet was not provided at all, treat that as a process error and say so rather
+than reconstructing the whole context by hand.
 
 ## Non-negotiable invariants
 

--- a/.claude/agents/rules-conformance.md
+++ b/.claude/agents/rules-conformance.md
@@ -10,6 +10,18 @@ You verify that the engine matches the book. Your default assumption is that it 
 not. A finding you cannot demonstrate with a specific row, value, or worked example
 is not a finding — discard it rather than reporting a suspicion.
 
+## Packet-first, read-only
+
+A generated REVIEW packet (`tools/agent-brief.py review <pr>`) is your starting
+context — it carries the exact base/head SHA, the changed-file list, and the full
+`git diff -U1` already assembled. Use that diff; do not re-derive your own with a
+repo-wide search. If no working REVIEW packet was provided, that is a process
+error — stop and say so rather than assembling the diff yourself. Read the named
+files and their necessary one-hop neighbors (e.g. the printed table's surrounding
+section). If more than five broad discovery operations appear necessary, stop and
+return `BRIEF DEFICIENCY`. You are a verification agent: read-only tools only,
+never `Write`/`Edit` on the engine you are checking.
+
 ## Why this role exists at high effort
 
 This project's most expensive failure mode is a plausible-looking formula derived

--- a/.claude/agents/rules-extractor.md
+++ b/.claude/agents/rules-extractor.md
@@ -9,6 +9,17 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 You transcribe rules data from the source book into ruleset JSON. You are a careful
 copyist, not a designer.
 
+## Packet-first
+
+A generated TASK packet (`tools/agent-brief.py task <issue>`) is your starting
+context. Read the named files and their necessary one-hop neighbors — do not
+conduct an open-ended repository survey. If more than five broad discovery
+operations (repo-wide grep/glob/history searches) appear necessary, stop and
+return `BRIEF DEFICIENCY` describing what the packet failed to provide. Normal
+reads, edits, and inspection of explicitly named files do not count as broad
+discovery. If no working TASK packet was provided, that is a process error — say
+so rather than reconstructing the context by hand.
+
 ## Source
 
 `BasicRoleplaying-ORC-Content-Document.pdf`. Extract with `pdftotext` (no `-layout`;

--- a/.claude/agents/scope-warden.md
+++ b/.claude/agents/scope-warden.md
@@ -11,6 +11,16 @@ prove the deterministic invariants mechanically on every PR — do not re-check 
 do not restate them as findings, and do not fail a PR for something a machine already
 proved. You exist only for the judgment calls a machine can't make.
 
+## Packet-first, read-only
+
+A generated REVIEW packet (`tools/agent-brief.py review <pr>`) is your starting
+context — it already carries the exact base/head SHA, changed-file list, and full
+`git diff -U1`. Use that diff; do not assemble your own with a repo-wide search.
+If no working REVIEW packet was provided, that is a process error — stop and say
+so. Read the named files and their necessary one-hop neighbors only; more than
+five broad discovery operations means stop and return `BRIEF DEFICIENCY`. You are
+read-only: never `Write`/`Edit` the diff you are reviewing.
+
 ## Already proven mechanically — do not re-review
 
 - Authoritative-source hash / superseded-source exclusion

--- a/docs/orchestration/agent-brief.md
+++ b/docs/orchestration/agent-brief.md
@@ -5,6 +5,16 @@ repo already knows, so the agent spends its token budget reasoning about the
 problem instead of rediscovering it. On #9 that rediscovery was ~40k of ~52k
 tokens ([`docs/agent-team.md`](../agent-team.md), "Briefing agents efficiently").
 
+**Packet-first is mandatory.** Every implementation and review agent role
+(`.claude/agents/*.md`) treats a missing packet as a process error, not something to
+work around by re-deriving context itself. A missing TASK packet before
+implementation, or a missing REVIEW packet before review, means stop and say so.
+Agent roles also carry a broad-discovery budget: named files and their necessary
+one-hop neighbors are normal reads; more than five broad repo-wide discovery
+operations (grep/glob/history searches) means the packet was deficient, and the
+agent should stop and return `BRIEF DEFICIENCY` rather than quietly widening its
+own search.
+
 ## Task packet — before implementation
 
 ```bash
@@ -13,7 +23,8 @@ tools/agent-brief.py task 52
 
 Emits, as markdown ready to paste into an implementer prompt:
 
-- **TASK** — outcome, acceptance criteria, explicit exclusions (parsed from the Issue).
+- **TASK** — outcome, acceptance criteria, explicit exclusions (parsed from the Issue;
+  a stable placeholder when the Issue states none).
 - **AUTHORITY** — `AGENTS.md`, the scope filter, source-handling, plus the ADRs whose
   titles best match the Issue title/labels/rules-source (foundational ADRs 0001–0003
   always included), and the cited rules source.
@@ -21,7 +32,9 @@ Emits, as markdown ready to paste into an implementer prompt:
 - **WORKSPACE** — files/modules named in the Issue (and `Brp.X.Y` module tokens in the
   body) mapped to `src/…` directories and their neighbouring `tests/…` dirs.
 - **REQUIRED GATES** — the route predicted from those paths via `tools/route.sh`.
-- **DO NOT REVISIT** — the matched ADRs as locked decisions, plus any rejected approaches.
+- **DO NOT REVISIT** — the matched ADRs as locked decisions.
+- **KNOWN DEAD ENDS** — rejected approaches recorded on the Issue, or a stable
+  placeholder when none are recorded.
 
 ## Review packet — before review
 
@@ -32,12 +45,34 @@ tools/agent-brief.py review --base <ref> --head <ref> --issue 74
 
 Emits:
 
-- **RANGE / CHANGED FILES** — base…head and the file list.
+- **PR / ISSUE** — the PR number, the linked Issue, and a reference to that Issue's
+  own task packet (`tools/agent-brief.py task <issue>`) when one applies.
+- **RANGE / CHANGED FILES** — the exact base and head commit SHAs and the file list.
+- **AUTHORITY** — the same authority documents and matched ADRs as the task packet,
+  derived from the PR title and changed files.
 - **IMPLEMENTER CLAIM** — the PR's "Exact behavioral claim" (to verify, not assume).
 - **REQUIRED REVIEW** — the route (via `tools/route.sh`) turned into a per-gate review
   checklist: what `scope-warden` / `rules-conformance` / `codex-conformance` /
   `architecture-review` must each check.
+- **ESCALATION REASON** — why the route is what it is (content escalation, an
+  issue-intent floor, an architecture addition, or none).
 - **DIFF** — `git diff -U1` for the range.
+
+## Reproducible packet hash
+
+Every packet ends with a footer:
+
+```
+---
+packet-schema: task-packet/1
+packet-version: 1
+packet-sha256: <hex>
+```
+
+The hash covers only the packet's semantic content — never a timestamp or other
+wall-clock value — so running the same command twice against identical repo/issue/PR
+state reproduces the identical `packet-sha256`. This is what lets a consumer treat
+two packets as "the same brief" without re-diffing the markdown.
 
 ## Notes
 

--- a/tests/tooling/test_agent_brief.sh
+++ b/tests/tooling/test_agent_brief.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# tests/tooling/test_agent_brief.sh — fixture tests for tools/agent-brief.py's
+# packet-first dispatch contract (Issue #139).
+#
+# Proves: a TASK packet and a REVIEW packet are each generated in one command;
+# every packet ends with a reproducible packet-sha256 (no timestamp or other
+# nondeterministic value hashed in — two runs against identical state produce
+# the identical hash); the packet contains its required sections; and the
+# packet's predicted route agrees with tools/route.sh, the one route authority.
+#
+# No network `gh` access is assumed (CI has none) — `gh` is stubbed with a
+# fixture script, same pattern as tests/tooling/test_agent_verify.sh. `git`
+# operations run against this real checkout's own history, so no mocking of
+# git is needed.
+#
+# Run directly:
+#   tests/tooling/test_agent_brief.sh
+#
+# Exit: 0 if every case passes, 1 on the first failure.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/agent-brief.py"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then ok "$desc"; else
+    fail "$desc (expected [$expected], got [$actual])"
+  fi
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then ok "$desc"; else
+    fail "$desc (expected to find [$needle])"
+  fi
+}
+
+# --- fixture `gh` stub ------------------------------------------------------ #
+# Answers exactly the gh subcommands agent-brief.py's task packet issues:
+# `issue view <n> --json title,body,labels,number,url` for the issue itself,
+# `issue view <n> --json state,title` for a referenced dependency, and
+# `issue view <n> --json labels --jq ...` (issued by tools/route.sh --issue).
+MOCKBIN="$WORKDIR/bin"
+mkdir -p "$MOCKBIN"
+cat > "$MOCKBIN/gh" <<'MOCKGH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+find_flag_value() {
+  local flag="$1"; shift; local args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    if [ "${args[$i]}" = "$flag" ]; then printf '%s' "${args[$((i + 1))]}"; return 0; fi
+  done
+  return 1
+}
+
+emit() {
+  local body="$1"; shift; local jqf
+  if jqf="$(find_flag_value --jq "$@")"; then printf '%s' "$body" | jq -r "$jqf"
+  else printf '%s\n' "$body"; fi
+}
+
+case "$1 $2" in
+  "issue view")
+    num="$3"
+    jsonf="$(find_flag_value --json "$@" || true)"
+    case "$jsonf" in
+      title,body,labels,number,url)
+        if [ "$num" = "5001" ]; then
+          body_json="$(python3 -c '
+import json
+body = """## Outcome
+Make the widget reproducible.
+
+## Acceptance Criteria
+- widget is deterministic
+
+## Out of Scope
+- do not touch the gizmo
+
+## Dependencies
+#5002
+
+## Workspace
+`tools/agent-brief.py` is the file to change.
+
+## Known Dead Ends
+- tried a global counter, rejected: not reproducible"""
+print(json.dumps(body))
+')"
+          emit "{\"title\":\"Widget packet test\",\"body\":$body_json,\"labels\":[],\"number\":5001,\"url\":\"https://example.invalid/issues/5001\"}" "$@"
+        else
+          echo "mock gh: unhandled issue view $num" >&2; exit 1
+        fi ;;
+      state,title)
+        emit "{\"state\":\"OPEN\",\"title\":\"Dependency fixture issue\"}" "$@" ;;
+      labels)
+        emit "{\"labels\":[]}" "$@" ;;
+      *) echo "mock gh: unhandled issue view --json $jsonf" >&2; exit 1 ;;
+    esac ;;
+  *) echo "mock gh: unhandled args: $*" >&2; exit 1 ;;
+esac
+MOCKGH
+chmod +x "$MOCKBIN/gh"
+export PATH="$MOCKBIN:$PATH"
+
+# === TASK PACKET ============================================================ #
+
+task1="$WORKDIR/task1.md"
+task2="$WORKDIR/task2.md"
+python3 "$SCRIPT" task 5001 > "$task1"
+python3 "$SCRIPT" task 5001 > "$task2"
+
+ok "task packet: generated in one command"
+
+diff -q "$task1" "$task2" >/dev/null \
+  && ok "task packet: byte-identical across two runs" \
+  || fail "task packet: byte-identical across two runs"
+
+hash1="$(grep '^packet-sha256:' "$task1" | awk '{print $2}')"
+hash2="$(grep '^packet-sha256:' "$task2" | awk '{print $2}')"
+[ -n "$hash1" ] && ok "task packet: packet-sha256 present" || fail "task packet: packet-sha256 present"
+assert_eq "task packet: packet-sha256 reproducible across runs" "$hash1" "$hash2"
+assert_eq "task packet: packet-sha256 is 64 hex chars" "64" "${#hash1}"
+
+grep -q '^packet-version: 1$' "$task1" \
+  && ok "task packet: packet-version footer present" \
+  || fail "task packet: packet-version footer present"
+grep -q '^packet-schema: task-packet/1$' "$task1" \
+  && ok "task packet: packet-schema marker present" \
+  || fail "task packet: packet-schema marker present"
+
+for section in \
+  "# TASK BRIEF" \
+  "<https://example.invalid/issues/5001>" \
+  "**Outcome.**" \
+  "**Acceptance criteria.**" \
+  "**Explicitly out of scope.**" \
+  "## AUTHORITY" \
+  "## DEPENDENCIES" \
+  "## WORKSPACE" \
+  "## REQUIRED GATES" \
+  "## DO NOT REVISIT" \
+  "## KNOWN DEAD ENDS" \
+  ; do
+  content="$(cat "$task1")"
+  assert_contains "task packet: contains section [$section]" "$content" "$section"
+done
+
+content="$(cat "$task1")"
+assert_contains "task packet: dependency state resolved" "$content" "Dependency fixture issue"
+assert_contains "task packet: known dead end carried through" "$content" "global counter"
+assert_contains "task packet: explicit exclusion carried through" "$content" "gizmo"
+
+# --- task packet route matches tools/route.sh directly ---------------------- #
+route_line="$(grep '^- route:' "$task1")"
+direct_route="$(bash "$ROOT/tools/route.sh" --json tools/agent-brief.py | python3 -c 'import json,sys; print(json.load(sys.stdin)["route"])')"
+assert_contains "task packet: predicted route matches tools/route.sh" "$route_line" "**$direct_route**"
+
+# === REVIEW PACKET =========================================================== #
+# Use two real commits from this checkout's own history so no `gh pr view` is
+# needed (an explicit --base/--head range skips it entirely).
+BASE_SHA="$(git -C "$ROOT" rev-parse HEAD~2)"
+HEAD_SHA="$(git -C "$ROOT" rev-parse HEAD)"
+
+review1="$WORKDIR/review1.md"
+review2="$WORKDIR/review2.md"
+python3 "$SCRIPT" review --base "$BASE_SHA" --head "$HEAD_SHA" --issue 5001 > "$review1"
+python3 "$SCRIPT" review --base "$BASE_SHA" --head "$HEAD_SHA" --issue 5001 > "$review2"
+
+ok "review packet: generated in one command"
+
+diff -q "$review1" "$review2" >/dev/null \
+  && ok "review packet: byte-identical across two runs" \
+  || fail "review packet: byte-identical across two runs"
+
+rhash1="$(grep '^packet-sha256:' "$review1" | awk '{print $2}')"
+rhash2="$(grep '^packet-sha256:' "$review2" | awk '{print $2}')"
+assert_eq "review packet: packet-sha256 reproducible across runs" "$rhash1" "$rhash2"
+assert_eq "review packet: packet-sha256 is 64 hex chars" "64" "${#rhash1}"
+
+grep -q '^packet-schema: review-packet/1$' "$review1" \
+  && ok "review packet: packet-schema marker present" \
+  || fail "review packet: packet-schema marker present"
+
+rcontent="$(cat "$review1")"
+for section in \
+  "# REVIEW BRIEF" \
+  "## PR" \
+  "## ISSUE" \
+  "## RANGE" \
+  "$BASE_SHA" \
+  "$HEAD_SHA" \
+  "## CHANGED FILES" \
+  "## AUTHORITY" \
+  "## IMPLEMENTER CLAIM" \
+  "## REQUIRED REVIEW" \
+  "## ESCALATION REASON" \
+  "## DIFF" \
+  ; do
+  assert_contains "review packet: contains section [$section]" "$rcontent" "$section"
+done
+assert_contains "review packet: source-packet reference present" "$rcontent" "agent-brief.py task 5001"
+
+review_route_line="$(grep '^## REQUIRED REVIEW' "$review1")"
+direct_review_route="$(bash "$ROOT/tools/route.sh" --json --base "$BASE_SHA" --issue 5001 | python3 -c 'import json,sys; print(json.load(sys.stdin)["route"])' 2>/dev/null || true)"
+if [ -n "$direct_review_route" ]; then
+  assert_contains "review packet: predicted route matches tools/route.sh" "$review_route_line" "**$direct_review_route**"
+else
+  fail "review packet: predicted route matches tools/route.sh (could not compute direct route)"
+fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "test_agent_brief.sh: all checks passed"
+  exit 0
+else
+  echo "test_agent_brief.sh: $FAILURES check(s) failed"
+  exit 1
+fi

--- a/tools/agent-brief.py
+++ b/tools/agent-brief.py
@@ -16,6 +16,7 @@ to be pasted directly into an agent prompt.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -24,6 +25,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DECISIONS = ROOT / "docs" / "decisions"
+
+# Packet schema/hash version. Bump this whenever a section is added, removed, or
+# reordered in a way that changes what a consumer can rely on being present —
+# NOT on every cosmetic wording change. The hash footer this stamps is
+# reproducible: it covers only the packet's semantic content, never a
+# timestamp or other wall-clock value (there is deliberately none in this
+# file), so two runs against identical repo/issue/PR state produce the same
+# packet-sha256.
+PACKET_VERSION = 1
 
 # Foundational authority that applies to essentially all engine work.
 ALWAYS_AUTHORITY = ["AGENTS.md", "orc-scope-filter.md", "docs/source-handling.md"]
@@ -193,6 +203,20 @@ def route_for(files: list[str], base: str | None = None, issue: int | None = Non
         return {"route": "unknown", "gates": []}
 
 
+def render(schema: str, lines: list[str]) -> str:
+    """Join packet lines and append a deterministic version/hash footer.
+
+    The hash covers exactly the rendered body (schema line included) — no
+    timestamp, hostname, or other nondeterministic value is ever part of it,
+    so re-running the same command against the same repo/issue/PR state
+    reproduces the identical `packet-sha256`.
+    """
+    body = "\n".join(lines).rstrip() + "\n"
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    footer = f"\n---\npacket-schema: {schema}/{PACKET_VERSION}\npacket-version: {PACKET_VERSION}\npacket-sha256: {digest}\n"
+    return body + footer
+
+
 def cmd_task(num: int) -> None:
     d = gh_json(["issue", "view", str(num), "--json", "title,body,labels,number,url"])
     body = d.get("body") or ""
@@ -220,8 +244,7 @@ def cmd_task(num: int) -> None:
     if acc:
         p.append(f"\n**Acceptance criteria.**\n{acc}")
     excl = first_of(sec, "out of scope", "exclusions")
-    if excl:
-        p.append(f"\n**Explicitly out of scope.**\n{excl}")
+    p.append(f"\n**Explicitly out of scope.**\n{excl or '(none stated in the issue body)'}")
 
     p.append("\n## AUTHORITY (read these, in this order)")
     for f in ALWAYS_AUTHORITY:
@@ -243,11 +266,12 @@ def cmd_task(num: int) -> None:
     p.append("\n## DO NOT REVISIT (locked decisions)")
     for a in adr_pick:
         p.append(f"- {adrs[a][0]} (`{adrs[a][1].name}`)")
-    dead = first_of(sec, "known dead ends", "dead ends")
-    if dead:
-        p.append(f"- Rejected approaches: {dead}")
 
-    print("\n".join(p))
+    p.append("\n## KNOWN DEAD ENDS")
+    dead = first_of(sec, "known dead ends", "dead ends")
+    p.append(dead if dead else "(none recorded in the issue; if you hit one, note it in the PR for the next agent.)")
+
+    sys.stdout.write(render("task-packet", p))
 
 
 def cmd_review(args: argparse.Namespace) -> None:
@@ -269,34 +293,74 @@ def cmd_review(args: argparse.Namespace) -> None:
     diff = sh(["git", "diff", "-U1", f"{base}...{head}"])
     route = route_for(names, base=base, issue=issue)
 
-    claim = first_of(split_sections(body), "exact behavioral claim", "behavioral claim") or "(none stated)"
+    sec = split_sections(body)
+    claim = first_of(sec, "exact behavioral claim", "behavioral claim") or "(none stated)"
+
+    focus = f"{title} {sec.get('rules source', '')}"
+    adrs = adr_titles()
+    adr_pick = relevant_adrs(focus) if title != "(explicit range)" else list(ALWAYS_ADRS)
+
+    reasons = []
+    if route.get("escalated"):
+        reasons.append("content escalation: the diff touches a numeric table/threshold, "
+                        "so `rules` was promoted to `formulas`")
+    if route.get("issueRaised"):
+        reasons.append(f"issue-intent floor: Issue #{issue} carries `route:{route.get('issueRoute')}`, "
+                        "which raises (never lowers) the route")
+    if route.get("architecture"):
+        reasons.append("architecture review added: the diff touches project references/layering")
+    escalation_reason = "; ".join(reasons) if reasons else "none — plain path-based route, no escalation"
 
     p = []
     p.append(f"# REVIEW BRIEF — {title}")
-    if issue:
-        p.append(f"Closes/related Issue: #{issue}")
+    p.append(f"\n## PR")
+    if args.pr is not None:
+        p.append(f"- PR: #{args.pr}")
+    else:
+        p.append("- PR: (explicit range, no PR)")
     if url:
-        p.append(f"<{url}>")
-    p.append(f"\n## RANGE\n- base `{base[:12]}`\n- head `{head[:12]}`")
+        p.append(f"- <{url}>")
+
+    p.append("\n## ISSUE")
+    if issue:
+        p.append(f"- Closes/related: #{issue}")
+        p.append(f"- Source task packet: `tools/agent-brief.py task {issue}`")
+    else:
+        p.append("- (none referenced — no `Closes #<n>` found; not applicable)")
+
+    p.append(f"\n## RANGE\n- base `{base}`\n- head `{head}`")
 
     p.append("\n## CHANGED FILES")
     p.extend([f"- `{f}`" for f in names] or ["- (none)"])
+
+    p.append("\n## AUTHORITY (read these, in this order)")
+    for f in ALWAYS_AUTHORITY:
+        p.append(f"- `{f}`")
+    for a in adr_pick:
+        if a in adrs:
+            p.append(f"- `docs/decisions/{adrs[a][1].name}` — {adrs[a][0]}")
 
     p.append("\n## IMPLEMENTER CLAIM (verify — do not assume true)")
     p.append(claim)
 
     p.append(f"\n## REQUIRED REVIEW — route **{route.get('route')}**"
              + (" (content-escalated)" if route.get("escalated") else ""))
+    p.append("Checklist — every listed gate must return a verdict before this PR can merge:")
     for g in route.get("gates", []):
         if g in GATE_REVIEW:
-            p.append(f"- **{g}** — {GATE_REVIEW[g]}")
+            p.append(f"- [ ] **{g}** — {GATE_REVIEW[g]}")
+        else:
+            p.append(f"- [ ] **{g}**")
+
+    p.append("\n## ESCALATION REASON")
+    p.append(escalation_reason)
 
     p.append("\n## DIFF (`git diff -U1`)")
     p.append("```diff")
     p.append(diff.rstrip())
     p.append("```")
 
-    print("\n".join(p))
+    sys.stdout.write(render("review-packet", p))
 
 
 def main() -> int:


### PR DESCRIPTION
## Linked Issue
Closes #139

## Exact behavioral claim
Dispatch is now packet-first: `agent-brief.py` emits complete task and review packets, each
sealed with a reproducible `packet-sha256`, and every Claude agent role now treats a missing
packet as a process error and is capped by a broad-discovery budget. No agent should begin a
job by rediscovering what/why/where/which-Issue — GitHub and deterministic tooling already
know that. This attacks the measured failure mode (tens of thousands of tokens spent locating
context instead of reasoning).

## Scope
- `tools/agent-brief.py`: added `PACKET_VERSION` + `render()` which appends a deterministic
  footer (`packet-schema`, `packet-version`, `packet-sha256`) hashing ONLY the rendered body —
  no timestamp/wall-clock is ever hashed, so identical repo/issue/PR state → identical hash.
  Task packet now always emits "Explicitly out of scope" and "Known dead ends". Review packet
  gained explicit `## PR`, `## ISSUE` (with source-task-packet reference), `## AUTHORITY`,
  untruncated base/head SHAs, a checklist `## REQUIRED REVIEW`, and `## ESCALATION REASON`
  derived from `route.sh`. Route for both packet types still comes from the one route authority.
- `.claude/agents/*.md` (all 7): added the broad-discovery budget (>5 broad ops → stop, return
  `BRIEF DEFICIENCY`) and packet-required contract. Review agents (rules-conformance, scope-warden,
  design-critic) additionally: use the packet's `-U1` diff rather than assembling their own, and
  state read-only explicitly.
- `docs/orchestration/agent-brief.md`: documents the new sections, mandatory-packet contract, and hash footer.

## Rules conformance
N/A.

## Tests and evidence
- `tests/tooling/test_agent_brief.sh` (new): task & review packets each in one command; **packet-sha256
  reproducible byte-for-byte across two runs**; all required sections present; packet route == `route.sh`.
- Full suite green: `test_route.sh`, `test_agent_verify.sh`, `test_pr_policy` (5/5), `test_agent_brief.sh`,
  `orchestration-policy.sh` PASS.
- Verified independently by the orchestrator: `agent-brief.py task 139` run twice → identical sha256
  (`20ad29…`); `review 148` emits all sections + hash footer.

## Decisions and tradeoffs
Existing `task`/`review` CLI is unchanged (same subcommands/flags); only output content was extended.

## Known limitations
Recording each job's packet hash in the ledger lands with Phase 7 (#141), which adds the
`prompt_hash`/`packet_type`/`discovery_calls` columns.

## Agent provenance
Implemented by the `orchestration-dev` (Sonnet) agent; reviewed by the Opus orchestrator
(reproducible-hash property re-verified, review packet exercised, all role contracts checked,
full suite re-run). Route: tooling → CI only.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `ea9401b`

| gate | result |
|---|---|
| `ci` | pass |

_1/1 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->