### PR TITLE
Add tools/source-slice.py: deterministic BRP source packets (#140)

### DIFF
--- a/docs/source-handling.md
+++ b/docs/source-handling.md
@@ -41,6 +41,53 @@ This is how the resistance misprint below was confirmed to be a real printing er
 rather than an extraction artifact. Rendering the region at 300 dpi and reading it
 visually is the final check.
 
+## Generating a source packet: `tools/source-slice.py`
+
+Do not re-read and re-transcribe the 303-page PDF by hand every time an agent needs
+an excerpt. `tools/source-slice.py` deterministically slices a page range out of
+`BasicRoleplaying-ORC-Content-Document.pdf` and emits it with a header identifying
+the authoritative filename, its pinned SHA-256, the requested pages, and the
+extraction mode:
+
+```bash
+tools/source-slice.py --pages 130                     # single page, plain text
+tools/source-slice.py --pages 130-132 --layout         # wide/tabular pages
+tools/source-slice.py --pages 130 --bbox                # disputed-cell escalation
+tools/source-slice.py --pages 130 --output /tmp/p130.txt
+```
+
+Before extracting anything, it verifies the PDF against the pinned hash in
+`.github/authoritative-source.sha256` and fails loudly (extracting nothing) if the
+hash does not match. It never accepts an arbitrary `--file` — the source filename is
+hardcoded so the superseded `BRP SRD 1.0.2.pdf` is not reachable through this tool.
+It is a page-slice tool, not a search or indexing system: it does not decide *which*
+pages matter, only extracts the ones it is told.
+
+**Locating the pages.** Two paths, depending on what the Issue says:
+
+- **Issue names exact pages.** The orchestrator runs `source-slice.py` directly and
+  hands the resulting packet to `engine-dev`, `rules-conformance`, and Codex.
+- **Issue names only a section** (e.g. "the Resistance Table" without a page number).
+  `rules-extractor` locates it once and reports back the page range — it does not
+  transcribe the content itself. The orchestrator then generates the packet from
+  that range the same way, so the extraction is deterministic and reviewable.
+
+**Independence rule.** Agents may share the same primary-source excerpt — that is
+the point of generating one packet instead of several independent transcriptions.
+But `codex-conformance` must never be fed `rules-conformance`'s reasoning, notes, or
+conclusions about that excerpt. It gets the same raw packet and re-derives its
+verification independently; that independence is what makes it a useful
+cross-vendor check rather than an echo of the first reviewer.
+
+**Escalation for disputed cells.** Plain mode is the default (see below — `-layout`
+scrambles the single-column body). Wide tables use `--layout`. A disputed cell
+escalates to `--bbox` for glyph coordinates, then to a `pdftoppm`-rendered image
+read visually, exactly as documented for the resistance-table misprint below.
+
+**Packets are ephemeral.** Generate and discard by default; do not commit a source
+packet to the repo unless there is a specific, stated reason to keep it (e.g. it is
+itself the artifact under review for a documentation defect in the extraction).
+
 ## The discipline
 
 **Where the book prints a table, reproduce the whole table as test data.** One case per

--- a/tests/tooling/test_source_slice.sh
+++ b/tests/tooling/test_source_slice.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# tests/tooling/test_source_slice.sh — fixture tests for tools/source-slice.py
+# (Issue #140).
+#
+# Proves: the SHA-256 gate fails extraction loudly on a mismatched pinned hash
+# (without touching the real pinned file), a valid extraction returns a
+# non-empty packet with a correct header, repeated extraction is byte-for-byte
+# deterministic, and --layout/--bbox change both the mode header and the body.
+#
+# The real authoritative PDF is expected to be present in this repo/CI. Tests
+# that require it SKIP gracefully (do not fail the suite) if it or pdftotext
+# is unavailable, so this test never becomes CI-brittle on an environment
+# quirk unrelated to the tool itself. The SHA-gate and header/parsing tests
+# that do not require actually invoking pdftotext still run unconditionally.
+#
+# Run directly:
+#   tests/tooling/test_source_slice.sh
+#
+# Exit: 0 if every case passes (or is skipped), 1 on the first failure.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/source-slice.py"
+PDF="$ROOT/BasicRoleplaying-ORC-Content-Document.pdf"
+PINNED_SHA_FILE="$ROOT/.github/authoritative-source.sha256"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+skip() { printf 'skip - %s\n' "$1"; }
+
+have_pdf() { [ -f "$PDF" ] && command -v pdftotext >/dev/null 2>&1; }
+
+# ---------------------------------------------------------------------------
+# 1. SHA-256 gate: a bad pinned hash must fail extraction, extracting nothing.
+#    Simulated via SOURCE_SLICE_SHA_FILE, never by touching the real pinned
+#    file at $PINNED_SHA_FILE.
+# ---------------------------------------------------------------------------
+BAD_SHA_FILE="$WORKDIR/bad.sha256"
+printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  BasicRoleplaying-ORC-Content-Document.pdf\n' \
+  > "$BAD_SHA_FILE"
+
+set +e
+BAD_OUT="$(SOURCE_SLICE_SHA_FILE="$BAD_SHA_FILE" python3 "$SCRIPT" --pages 5 2>&1)"
+BAD_RC=$?
+set -e
+
+if [ "$BAD_RC" -ne 0 ]; then ok "bad pinned hash: nonzero exit"; else
+  fail "bad pinned hash: expected nonzero exit, got $BAD_RC"
+fi
+if [[ "${BAD_OUT,,}" == *verification* ]]; then
+  ok "bad pinned hash: failure message mentions verification"
+else
+  fail "bad pinned hash: failure message missing verification wording: $BAD_OUT"
+fi
+
+# Also prove the real pinned file was never touched by this run.
+if [ -f "$PINNED_SHA_FILE" ] && git -C "$ROOT" diff --quiet -- .github/authoritative-source.sha256 2>/dev/null; then
+  ok "bad pinned hash test did not modify the real pinned file"
+else
+  ok "bad pinned hash test did not modify the real pinned file (no git context to check; skipping diff check)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Missing pinned-hash file must also fail loudly, not extract.
+# ---------------------------------------------------------------------------
+set +e
+MISSING_OUT="$(SOURCE_SLICE_SHA_FILE="$WORKDIR/does-not-exist.sha256" python3 "$SCRIPT" --pages 5 2>&1)"
+MISSING_RC=$?
+set -e
+if [ "$MISSING_RC" -ne 0 ]; then ok "missing pinned hash file: nonzero exit"; else
+  fail "missing pinned hash file: expected nonzero exit, got $MISSING_RC"
+fi
+
+if ! have_pdf; then
+  skip "real PDF or pdftotext unavailable: skipping extraction/header/determinism/layout/bbox tests"
+else
+  # -------------------------------------------------------------------------
+  # 3. Valid extraction: non-empty packet with correct header.
+  # -------------------------------------------------------------------------
+  PINNED_HASH="$(awk '{print $1; exit}' "$PINNED_SHA_FILE")"
+  OUT1="$(python3 "$SCRIPT" --pages 5)"
+
+  if [ -n "$OUT1" ]; then ok "valid extraction: non-empty output"; else
+    fail "valid extraction: output was empty"
+  fi
+  if [[ "$OUT1" == *"authoritative-file: BasicRoleplaying-ORC-Content-Document.pdf"* ]]; then
+    ok "header: authoritative filename present"
+  else
+    fail "header: authoritative filename missing"
+  fi
+  if [[ "$OUT1" == *"authoritative-sha256: $PINNED_HASH"* ]]; then
+    ok "header: pinned SHA-256 present and matches .github/authoritative-source.sha256"
+  else
+    fail "header: pinned SHA-256 missing or mismatched"
+  fi
+  if [[ "$OUT1" == *"pages: 5"* ]]; then ok "header: requested pages present"; else
+    fail "header: requested pages missing"
+  fi
+  if [[ "$OUT1" == *"mode: plain"* ]]; then ok "header: default mode is plain"; else
+    fail "header: default mode missing/wrong"
+  fi
+
+  # -------------------------------------------------------------------------
+  # 4. Determinism: same pages+mode extracted twice -> identical output.
+  # -------------------------------------------------------------------------
+  OUT2="$(python3 "$SCRIPT" --pages 5)"
+  if [ "$OUT1" = "$OUT2" ]; then ok "determinism: repeated plain extraction is identical"; else
+    fail "determinism: repeated plain extraction differed"
+  fi
+
+  LAYOUT1="$(python3 "$SCRIPT" --pages 130-132 --layout)"
+  LAYOUT2="$(python3 "$SCRIPT" --pages 130-132 --layout)"
+  if [ "$LAYOUT1" = "$LAYOUT2" ]; then ok "determinism: repeated layout extraction is identical"; else
+    fail "determinism: repeated layout extraction differed"
+  fi
+
+  # -------------------------------------------------------------------------
+  # 5. --layout and --bbox change the mode header, and the body differs from
+  #    plain mode (proving the flag actually reached pdftotext).
+  # -------------------------------------------------------------------------
+  if [[ "$LAYOUT1" == *"mode: layout"* ]]; then ok "--layout: mode header updates"; else
+    fail "--layout: mode header did not update"
+  fi
+  if [ "$OUT1" != "$LAYOUT1" ]; then ok "--layout: output differs from plain mode"; else
+    fail "--layout: output identical to plain mode (flag had no effect)"
+  fi
+
+  BBOX1="$(python3 "$SCRIPT" --pages 130 --bbox)"
+  if [[ "$BBOX1" == *"mode: bbox"* ]]; then ok "--bbox: mode header updates"; else
+    fail "--bbox: mode header did not update"
+  fi
+  if [[ "${BBOX1,,}" == *"<doc"* ]]; then ok "--bbox: output contains bbox XML markup"; else
+    fail "--bbox: output missing expected bbox markup"
+  fi
+
+  # -------------------------------------------------------------------------
+  # 6. --output writes to a file instead of stdout.
+  # -------------------------------------------------------------------------
+  OUT_FILE="$WORKDIR/packet.txt"
+  python3 "$SCRIPT" --pages 5 --output "$OUT_FILE" >/dev/null
+  if [ -s "$OUT_FILE" ]; then ok "--output: writes a non-empty file"; else
+    fail "--output: file missing or empty"
+  fi
+  if [ "$(cat "$OUT_FILE")" = "$OUT1" ]; then ok "--output: file content matches stdout content"; else
+    fail "--output: file content differs from stdout content"
+  fi
+fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "test_source_slice.sh: all checks passed"
+  exit 0
+else
+  echo "test_source_slice.sh: $FAILURES check(s) failed"
+  exit 1
+fi

--- a/tools/source-slice.py
+++ b/tools/source-slice.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""source-slice — deterministic page-range extraction from the authoritative BRP source.
+
+Every agent that needs source text should get the same excerpt, generated the same
+way, rather than re-reading and re-transcribing the 303-page PDF independently. This
+tool does exactly one thing: slice a page range out of
+`BasicRoleplaying-ORC-Content-Document.pdf` and emit it with a header identifying
+what it is, so the excerpt is self-describing and reproducible.
+
+It is a page-slice tool, not a search tool. It does not index, search, or reason
+about the document — see `docs/source-handling.md` for how pages are located
+(exact pages named in the Issue, or `rules-extractor` locates a section once and
+reports the range).
+
+    tools/source-slice.py --pages 130
+    tools/source-slice.py --pages 130-132 --layout
+    tools/source-slice.py --pages 130 --bbox
+    tools/source-slice.py --pages 5-9 --output /tmp/packet.txt
+
+The source file is hardcoded. This tool NEVER accepts an arbitrary --file — the
+superseded `BRP SRD 1.0.2.pdf` must never be reachable through this path. Before
+any extraction, the source file is verified against the pinned SHA-256 in
+`.github/authoritative-source.sha256`; a mismatch or missing file fails loudly and
+extracts nothing.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# The one authoritative source. Hardcoded on purpose — see module docstring.
+SOURCE_FILENAME = "BasicRoleplaying-ORC-Content-Document.pdf"
+SOURCE_PATH = ROOT / SOURCE_FILENAME
+
+# Default location of the pinned hash. Overridable via SOURCE_SLICE_SHA_FILE for
+# tests only, so a test can exercise the "pinned hash does not match" failure path
+# without touching the real pinned file. There is no equivalent override for the
+# source file itself.
+DEFAULT_SHA_FILE = ROOT / ".github" / "authoritative-source.sha256"
+
+
+class SourceSliceError(RuntimeError):
+    """Raised for any failure that should abort extraction before it starts."""
+
+
+def _sha_file_path() -> Path:
+    override = os.environ.get("SOURCE_SLICE_SHA_FILE")
+    return Path(override) if override else DEFAULT_SHA_FILE
+
+
+def _sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_pinned_hash(sha_file: Path) -> str:
+    """Parse the first '<hex>  <filename>' line of the pinned-hash file."""
+    if not sha_file.is_file():
+        raise SourceSliceError(f"pinned hash file not found: {sha_file}")
+    text = sha_file.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        m = re.match(r"^([0-9a-fA-F]+)\s+\S*(" + re.escape(SOURCE_FILENAME) + r")?$", line)
+        if m:
+            return m.group(1).lower()
+        # Fall back to "first whitespace-delimited token looks like a hex digest".
+        parts = line.split()
+        if parts and re.match(r"^[0-9a-fA-F]{32,}$", parts[0]):
+            return parts[0].lower()
+    raise SourceSliceError(f"could not parse a hash out of {sha_file}")
+
+
+def verify_source() -> str:
+    """Verify SOURCE_PATH against the pinned hash. Returns the verified hash.
+
+    Raises SourceSliceError (never extracts) on any mismatch or missing file.
+    """
+    if not SOURCE_PATH.is_file():
+        raise SourceSliceError(f"authoritative source not found: {SOURCE_PATH}")
+
+    sha_file = _sha_file_path()
+    pinned = read_pinned_hash(sha_file)
+    actual = _sha256_of(SOURCE_PATH)
+
+    if actual != pinned:
+        raise SourceSliceError(
+            "authoritative source failed SHA-256 verification against "
+            f"{sha_file}\n  pinned:  {pinned}\n  actual:  {actual}\n"
+            "Refusing to extract from an unverified source."
+        )
+    return actual
+
+
+def parse_pages(spec: str) -> tuple[int, int]:
+    spec = spec.strip()
+    m = re.match(r"^(\d+)(?:-(\d+))?$", spec)
+    if not m:
+        raise SourceSliceError(f"invalid --pages value: {spec!r} (want N or A-B)")
+    first = int(m.group(1))
+    last = int(m.group(2)) if m.group(2) else first
+    if first < 1 or last < first:
+        raise SourceSliceError(f"invalid page range: {spec!r}")
+    return first, last
+
+
+def extract_mode(layout: bool, bbox: bool) -> str:
+    if bbox and layout:
+        return "bbox+layout"
+    if bbox:
+        return "bbox"
+    if layout:
+        return "layout"
+    return "plain"
+
+
+def run_pdftotext(first: int, last: int, mode: str) -> str:
+    args = ["pdftotext", "-f", str(first), "-l", str(last)]
+    if mode == "bbox+layout":
+        args.append("-bbox-layout")
+    elif mode == "bbox":
+        args.append("-bbox")
+    elif mode == "layout":
+        args.append("-layout")
+    # "plain" adds nothing: docs/source-handling.md notes -layout scrambles the
+    # single-column body text, so plain mode deliberately omits it.
+    args += [str(SOURCE_PATH), "-"]
+
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, check=False)
+    except FileNotFoundError as e:
+        raise SourceSliceError(f"pdftotext not available: {e}") from e
+
+    if result.returncode != 0:
+        raise SourceSliceError(
+            f"pdftotext failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def build_packet(pages_spec: str, first: int, last: int, mode: str, pinned_hash: str, body: str) -> str:
+    header = (
+        "# BRP source packet\n"
+        f"# authoritative-file: {SOURCE_FILENAME}\n"
+        f"# authoritative-sha256: {pinned_hash}\n"
+        f"# pages: {pages_spec}\n"
+        f"# mode: {mode}\n"
+        "#\n"
+        "# Generated by tools/source-slice.py. Ephemeral by default — see\n"
+        "# docs/source-handling.md before committing a source packet.\n"
+    )
+    return header + body
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="source-slice.py",
+        description="Deterministically slice a page range out of the authoritative BRP source.",
+    )
+    parser.add_argument("--pages", required=True, help="page number 'N' or range 'A-B'")
+    parser.add_argument("--layout", action="store_true", help="preserve column/table layout (pdftotext -layout)")
+    parser.add_argument("--bbox", action="store_true", help="emit bounding-box glyph data (pdftotext -bbox)")
+    parser.add_argument("--output", metavar="FILE", help="write the packet to FILE instead of stdout")
+    args = parser.parse_args(argv)
+
+    try:
+        first, last = parse_pages(args.pages)
+        pinned_hash = verify_source()
+        mode = extract_mode(args.layout, args.bbox)
+        body = run_pdftotext(first, last, mode)
+        packet = build_packet(args.pages, first, last, mode, pinned_hash, body)
+    except SourceSliceError as e:
+        print(f"source-slice: {e}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        Path(args.output).write_text(packet, encoding="utf-8")
+    else:
+        try:
+            sys.stdout.write(packet)
+        except BrokenPipeError:
+            # Downstream consumer (e.g. `| head`) closed early; not our error.
+            try:
+                sys.stdout.close()
+            except Exception:
+                pass
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Linked Issue
Closes #140

## Exact behavioral claim
`tools/source-slice.py` deterministically extracts a page range from the authoritative ORC
Content Document, verifying the file against its pinned SHA-256 before extracting and refusing
to run on a mismatch. This lets the orchestrator hand every model the SAME primary-source
excerpt instead of each model re-searching the 303-page PDF.

## Scope
- `tools/source-slice.py` (new, executable): `--pages N|A-B`, `--layout`, `--bbox`, `--output FILE`.
  Backend is poppler `pdftotext` (installed locally and in CI). The authoritative filename is
  HARDCODED — there is no `--file` flag, so the forbidden `BRP SRD 1.0.2.pdf` can never be targeted.
  Every packet is headed with authoritative filename + pinned SHA-256 + requested pages + mode,
  and the body is deterministic (no timestamps).
- `docs/source-handling.md` (extended): source-packet workflow (exact-pages vs section-only via
  `rules-extractor`), the Codex independence rule (shared excerpt, NOT shared reasoning), and the
  ephemeral-by-default note.

## Rules conformance
N/A — this is extraction tooling; it does not interpret the rules.

## Tests and evidence
- `tests/tooling/test_source_slice.sh` (new): SHA-gate FAILS extraction on a wrong pinned hash
  (via `SOURCE_SLICE_SHA_FILE` override — never touches the real pinned file) and on a missing
  pinned file; header correctness; plain + layout determinism; `--layout`/`--bbox` change mode+body;
  `--output`. Gracefully skips extraction checks if the PDF/`pdftotext` are absent.
- Full suite green: `test_route.sh`, `test_agent_verify.sh`, `test_pr_policy` (5/5),
  `test_agent_brief.sh`, `test_source_slice.sh`, `orchestration-policy.sh`.
- Orchestrator re-verified independently: real page-1 header shows the pinned SHA; `--pages 30-31`
  identical across two runs; a valid-format wrong hash → "Refusing to extract from an unverified
  source", exit 1, no packet.

## Decisions and tradeoffs
No Python PDF library is importable and the repo is stdlib-only, so the tool shells out to poppler
rather than adding a pip dependency. A `BrokenPipeError` guard was added so `| head`-style truncation
of large `--bbox` output does not error.

## Known limitations
Disputed-cell escalation beyond `--bbox` (rendering a page image via `pdftoppm` for visual/manual
verification) is documented as the next escalation step but left to the operator, per "do not
overbuild a semantic PDF system".

## Agent provenance
Implemented by the `orchestration-dev` (Sonnet) agent; reviewed by the Opus orchestrator (tool
exercised directly: extraction, determinism, SHA-mismatch refusal, no-SRD-path; full suite re-run).
Route: tooling → CI only.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `6aea62c`

| gate | result |
|---|---|
| `ci` | pass |

_1/1 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->