### PR TITLE
Log agent-team telemetry for Phases 5-6 (#149)

### DIFF
--- a/docs/agent-team-ledger/jobs.csv
+++ b/docs/agent-team-ledger/jobs.csv
@@ -11,3 +11,5 @@ orch,136,146,2,2026-08-31,verify,scope-warden,haiku,low,NI,NI,11628,NI,NI,NI,1,1
 orch,137,147,1,2026-08-31,build,orchestration-dev,sonnet,medium,NI,NI,99675,NI,NI,NI,58,435380,NI,NI,NI,NI,NI,NI,NI,NI,NI,NI,route.sh single authority: --diff-file external-patch classification; 4 consumers unified; 9 acceptance tests
 orch,137,147,2,2026-08-31,verify,scope-warden,haiku,low,NI,NI,13395,NI,NI,NI,1,17095,NI,NI,NI,NI,NI,NI,NI,NI,NI,NI,tooling-route scope check: all pass
 orch,138,148,1,2026-08-31,build,orchestration-dev,sonnet,medium,NI,NI,67104,NI,NI,NI,40,234198,NI,NI,NI,NI,NI,NI,NI,NI,NI,NI,scope-warden residual semantic gate; docs/tooling route -> ci only; labels updated
+orch,139,151,1,2026-08-31,build,orchestration-dev,sonnet,medium,NI,NI,82233,NI,NI,NI,49,331876,NI,NI,NI,NI,NI,NI,NI,NI,NI,NI,packet-first mandatory; reproducible packet-sha256; broad-discovery budget + packet-required in all 7 roles
+orch,140,152,1,2026-08-31,build,orchestration-dev,sonnet,medium,NI,NI,58442,NI,NI,NI,36,248417,NI,NI,NI,NI,NI,NI,NI,NI,NI,NI,source-slice.py: deterministic ORC page extraction w/ SHA gate; poppler backend; source-handling.md


### PR DESCRIPTION
## Linked Issue
Closes #149

## Exact behavioral claim
Persists the two subagent-job telemetry rows for merged PRs #151 and #152 to `main` before Phase 7 (#141) migrates the ledger schema, so no old-schema rows are left uncommitted during the migration.

## Scope
`docs/agent-team-ledger/jobs.csv`: +2 orchestration-dev build rows. Data only.

## Rules conformance
N/A.

## Tests and evidence
`git diff` shows only two appended rows; header/column order unchanged; unmeasured fields are `NI`.

## Decisions and tradeoffs
Committed now (not folded into Phase 7) so the schema migration starts from a fully-committed ledger.

## Known limitations
None.

## Agent provenance
Logged by the Opus orchestrator.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).