### PR TITLE
Fix test_orchestration_metrics case1b to allow real job telemetry (#156)

### DIFF
--- a/tests/tooling/test_orchestration_metrics.sh
+++ b/tests/tooling/test_orchestration_metrics.sh
@@ -57,16 +57,28 @@ PYEOF
 assert_eq "case1: every jobs.csv data row matches the header field count" "OK" "$csv_check"
 
 ni_check="$(python3 - "$JOBS_CSV" <<'PYEOF'
-import csv, sys
+import csv, re, sys
 path = sys.argv[1]
 with open(path, newline="") as f:
     rows = list(csv.DictReader(f))
-bad = [r.get("issue") for r in rows
-       if r.get("packet_type") != "NI" or r.get("prompt_hash") != "NI" or r.get("discovery_calls") != "NI"]
-print("OK" if not bad else "NOT_NI:" + ",".join(str(b) for b in bad))
+HEX64 = re.compile(r"\A[0-9a-f]{64}\Z")
+def ok(r):
+    # Each new column is either NI (unmeasured) or a well-formed value — never
+    # fabricated garbage. This catches migration/schema corruption while still
+    # allowing real job telemetry to populate the columns (their whole purpose).
+    pt, ph, dc = r.get("packet_type"), r.get("prompt_hash"), r.get("discovery_calls")
+    if pt not in ("NI", "task", "review"):
+        return False
+    if ph != "NI" and not HEX64.match(ph or ""):
+        return False
+    if dc != "NI" and not (dc or "").isdigit():
+        return False
+    return True
+bad = [r.get("issue") for r in rows if not ok(r)]
+print("OK" if not bad else "MALFORMED:" + ",".join(str(b) for b in bad))
 PYEOF
 )"
-assert_eq "case1b: every pre-#141 jobs.csv row has NI (never fabricated) in the 3 new columns" "OK" "$ni_check"
+assert_eq "case1b: every jobs.csv row has NI or a well-formed value in the 3 new columns (no fabrication)" "OK" "$ni_check"
 
 # --- case 2: ledger-log.sh accepts and round-trips the 3 new job fields ---- #
 WORK_LEDGER="$WORKDIR/ledger"


### PR DESCRIPTION
## Linked Issue
Closes #156

## Exact behavioral claim
`case1b` no longer fails when the new `packet_type`/`prompt_hash`/`discovery_calls` columns
(added in #141) actually hold data. It now validates each value is `NI` OR well-formed —
still catching migration/schema corruption, but permitting the real telemetry the columns exist for.

## Scope
- `tests/tooling/test_orchestration_metrics.sh` case1b: replaced "every row must be `NI`" with a
  well-formedness check — `packet_type` ∈ {task, review, NI}; `prompt_hash` is 64-hex or `NI`;
  `discovery_calls` is a non-negative integer or `NI`. case1 (field-count consistency) is unchanged.

## Rules conformance
N/A.

## Tests and evidence
- `bash tests/tooling/test_orchestration_metrics.sh` → all checks pass, including with a live
  `packet_type=task` row present in `jobs.csv` (the case that previously failed).
- Verified the check still REJECTS a malformed `packet_type` (e.g. `bogus`).

## Decisions and tradeoffs
Kept the test reading the live ledger (consistent with case1) rather than switching to a frozen
fixture; the well-formedness invariant is robust to the ledger growing.

## Known limitations
None.

## Agent provenance
Found by the Opus orchestrator while verifying Phase 8 (#142); fixed directly (a ~10-line test
assertion). Route: tooling → CI only.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).