### PR TITLE
Add Layer 5 route taxonomy: gameplay / scenario / presentation (#143)

### DIFF
--- a/.github/route-map
+++ b/.github/route-map
@@ -1,7 +1,7 @@
 # NoiRPG route map — maps a changed path to a coarse verification route.
 #
 # Format:  <glob>  <route>        (one rule per line; "#" starts a comment)
-# Routes:  docs | tooling | rules | formulas | architecture
+# Routes:  docs | tooling | presentation | scenario | gameplay | rules | formulas | architecture
 # Matching: CODEOWNERS-style — LAST matching rule wins for a given file.
 # Globs:   *  matches within one path segment; **  matches across segments;
 #          **/ matches zero or more leading directories.
@@ -37,6 +37,31 @@ src/Brp.Rules/**           rules
 # (Last matching rule wins, so the .json rule must come after the catch-all.)
 src/Brp.Data/**            rules
 src/Brp.Data/**/*.json     formulas
+
+# Layer 5 — the noir game layer on top of BRP. Explicit routes so this content
+# does not fall through to the `tooling` catch-all once it starts landing (most
+# of these paths do not exist yet; see docs/orchestration/routing.md).
+#
+# `gameplay` — original Noir mechanics (design-led, NOT BRP source-conformance).
+# Gate set is `ci` only: settled gameplay implementation relies on CI +
+# deterministic tests + layer/scope enforcement + the prior accepted design
+# decision that authorized it. `design-critic` belongs at design/phase gates,
+# not on every routine gameplay PR.
+src/Noir.Rules/**          gameplay
+
+# `scenario` — authored case/scenario content and the engine that loads it.
+# Gate set is `ci` only: tools/case_validator.py is the deterministic enforcer
+# of schema, the Three Doors rule, junction budget, and canonical skills.
+# `case-author` is a content-producing role, not a second reviewer — no Opus
+# review on ordinary case YAML.
+cases/**                   scenario
+src/Noir.Scenario/**       scenario
+
+# `presentation` — game engine / client / presentation code. An explicit route
+# instead of the `tooling` catch-all, even though these paths do not exist yet.
+# Gate set is `ci` only.
+src/Noir.Game/**           presentation
+src/Noir.Client/**         presentation
 
 # Architecture — project boundaries and references (last, so they win for these
 # files even under src/**). Adds architecture-review on top of normal gates.

--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -90,6 +90,28 @@ a Sonnet worker can. Do not route routine implementation to Opus.
 not a failure — deciding it inside an implementation PR is how decisions get buried
 where no later agent will find them.
 
+**`needs-design` is a scheduler stop, not a suggestion.** `tools/ready-issues.sh`
+treats `needs-design` as a human gate, the same as `blocked`: an unresolved
+original-design Issue must never be converted into implementation work — Sonnet or
+otherwise — merely because its dependencies have closed. Route/gate derivation (below)
+tells verification what a *settled* Layer 5 change will need; it is not permission to
+treat an unsettled one as ready.
+
+**Layer 5 (`gameplay`/`scenario`/`presentation`) is design-led, not source-conformance.**
+`tools/route.sh` gives the noir game layer on top of BRP its own routes —
+`gameplay` (original mechanics, `src/Noir.Rules/**`), `scenario` (authored case
+content and its schema engine, `cases/**` and `src/Noir.Scenario/**`), and
+`presentation` (game engine / client code, `src/Noir.Game/**` /
+`src/Noir.Client/**`) — each with a `ci`-only gate set. None of them is checked
+against a printed BRP table, so none of them gets `rules-conformance` or
+`codex-conformance`; instead each relies on a deterministic, code-level gate:
+CI plus the layer's own tests for `gameplay`, and `tools/case_validator.py` (schema,
+the Three Doors rule, junction budget, canonical skills) for `scenario`. `design-critic`
+sits at the design/phase gate where a mechanic is *decided*, not on every routine PR
+that implements an already-settled one, and `case-author` is a content-producing role
+— it is not paired with an Opus review on ordinary case YAML. See
+[`docs/orchestration/routing.md`](orchestration/routing.md) for the full route table.
+
 **Verification agents get read-only tools.** An agent that can edit what it is checking
 will eventually make the check pass instead of making the code right.
 

--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -25,8 +25,9 @@ approximating any of this itself.
 1. **Path baseline (simple, deterministic).** [`.github/route-map`](../../.github/route-map)
    maps each changed path to a coarse route, CODEOWNERS-style — the *last* matching
    rule wins for a given file. Across all changed files, the highest-precedence
-   route is taken (`docs` < `tooling` < `rules` < `formulas`), and any file that
-   maps to `architecture` adds an architecture review on top.
+   route is taken (`docs` < `tooling` < `presentation` < `scenario` < `gameplay` <
+   `rules` < `formulas`), and any file that maps to `architecture` adds an
+   architecture review on top.
 2. **Content escalation (precise, where it matters).** A `rules` change is promoted
    to `formulas` when the diff actually touches numeric tables or thresholds — so the
    expensive independent cross-check fires when a *value* could be wrong, not merely
@@ -42,8 +43,11 @@ approximating any of this itself.
 
 | Route | What triggers it | Required gates |
 |---|---|---|
-| `docs` | `*.md`, `docs/**` | `ci`, `scope-warden` |
-| `tooling` | `.github/**`, `tools/**`, `*.sln`, `global.json`, anything unmatched | `ci`, `scope-warden` |
+| `docs` | `*.md`, `docs/**` | `ci` |
+| `tooling` | `.github/**`, `tools/**`, `*.sln`, `global.json`, anything unmatched | `ci` |
+| `presentation` | `src/Noir.Game/**`, `src/Noir.Client/**` (game engine / client / presentation code — Layer 5) | `ci` |
+| `scenario` | `cases/**`, `src/Noir.Scenario/**` (authored case content and the case-schema engine — Layer 5) | `ci` |
+| `gameplay` | `src/Noir.Rules/**` (original Noir mechanics — Layer 5) | `ci` |
 | `rules` | `src/Brp.Core/**`, `src/Brp.Rules/**`, `src/Brp.Data/**/*.cs` (loaders/models — ordinary implementation) | `ci`, `scope-warden`, `rules-conformance` |
 | `formulas` | `src/Brp.Data/**/*.json` (printed numeric tables), **or** a `rules` change whose diff touches numeric tables/thresholds | `ci`, `scope-warden`, `rules-conformance`, `codex-conformance` |
 | `architecture` | `**/*.csproj`, `Directory.Build.props` (project boundaries/refs) | *(above, per the other files)* **+** `architecture-review` |
@@ -52,6 +56,43 @@ approximating any of this itself.
 else applies — it adds `architecture-review` (dispatched to the `design-critic`
 agent) without removing the normal gates. Escalation only ever *raises* the gate
 set, never lowers it.
+
+### `gameplay`, `scenario`, `presentation` — design-led, not BRP source-conformance
+
+These three routes exist so Layer 5 — the noir game layer on top of BRP — gets an
+explicit classification instead of falling through to the `tooling` catch-all once it
+starts landing. Their gate set is `ci` only, deliberately: none of them is checked
+against a printed source table, so none of them needs `rules-conformance` or
+`codex-conformance`, and none of them gets a semantic AI reviewer on every routine PR.
+
+- **`gameplay`** is original Noir mechanics — not BRP, so there is no source table to
+  conform to. A settled `gameplay` change relies on CI, deterministic tests, and
+  layer/scope enforcement, plus the prior accepted design decision that authorized the
+  mechanic in the first place. `design-critic` (Opus, phase-gate design review) belongs
+  at design/phase gates — the point where the mechanic is *decided* — not on every
+  routine implementation PR that merely builds what was already decided.
+- **`scenario`** is authored case/scenario content. Its correctness is machine-checked
+  by [`tools/case_validator.py`](../../tools/case_validator.py) — schema, the Three
+  Doors rule, the junction budget, canonical skill names, and load/parse validity — all
+  deterministic. `case-author` (Sonnet, see [`agent-team.md`](../agent-team.md)) is a
+  content-producing role, not a second reviewer; it does not get paired with an Opus
+  review on ordinary case YAML.
+- **`presentation`** is game engine / client / presentation code. It gets its own route
+  rather than the generic `tooling` catch-all so its gate set is legible on its own
+  terms, even though none of `src/Noir.Game/**` or `src/Noir.Client/**` exists yet —
+  this route is added ahead of the code, not in response to it.
+
+A `**/*.csproj` or `Directory.Build.props` change under any of these paths still
+composes `architecture-review` on top, exactly as it does for `rules`/`formulas` —
+the architecture rules are last in `.github/route-map`, so they still win for those
+files.
+
+None of this authorizes Layer 5 implementation. `needs-design` remains a scheduler
+stop (`tools/ready-issues.sh` treats it as a human gate alongside `blocked`): an
+unresolved original-design Issue must not be picked up for implementation merely
+because its dependencies have closed. The route taxonomy tells verification which
+gates a Layer 5 change will need *once it is settled and ready* — it does not settle
+the design itself.
 
 ## Content-escalation patterns
 
@@ -108,10 +149,11 @@ content. So editing a loader no longer triggers the expensive Codex route.
 ## Labels
 
 The derived route can be surfaced on issues/PRs as a `route:*` label
-(`route:docs`, `route:tooling`, `route:rules`, `route:formulas`,
-`route:architecture`) so the route is visible without running the tool. These were
-applied automatically by the now-removed `route-gates` workflow; apply them by hand
-(or from a new workflow) if you want them.
+(`route:docs`, `route:tooling`, `route:presentation`, `route:scenario`,
+`route:gameplay`, `route:rules`, `route:formulas`, `route:architecture`) so the route
+is visible without running the tool. These were applied automatically by the
+now-removed `route-gates` workflow; apply them by hand (or from a new workflow) if
+you want them.
 
 A `route:*` label on an **issue** is also an *input*, not just a readout: it declares
 the change's intended risk, and `tools/route.sh --issue <n>` reads it as the

--- a/tests/tooling/test_route.sh
+++ b/tests/tooling/test_route.sh
@@ -58,6 +58,36 @@ assert_eq "case3: BRP C# impl -> rules" "rules" "$(route_of "$j3")"
 j4="$("$SCRIPT" --json -- src/Brp.Data/damage-ruleset.json)"
 assert_eq "case4: ruleset JSON -> formulas" "formulas" "$(route_of "$j4")"
 
+# --- Layer 5 route taxonomy (Issue #143) ------------------------------------- #
+# gameplay — original Noir mechanics, design-led, NOT auto BRP conformance.
+j10="$("$SCRIPT" --json -- src/Noir.Rules/Foo.cs)"
+assert_eq "case10: original Noir mechanics -> gameplay" "gameplay" "$(route_of "$j10")"
+assert_eq "case10: gameplay gate set is ci-only (no design-critic on routine PRs)" \
+  "['ci']" "$(gates_of "$j10")"
+
+# scenario — authored case content, machine-enforced by case_validator.py.
+j11="$("$SCRIPT" --json -- cases/case01.yaml)"
+assert_eq "case11: authored case YAML -> scenario" "scenario" "$(route_of "$j11")"
+assert_eq "case11: scenario gate set is ci-only (case-author is not a second reviewer)" \
+  "['ci']" "$(gates_of "$j11")"
+
+j12="$("$SCRIPT" --json -- src/Noir.Scenario/Model.cs)"
+assert_eq "case12: case-schema engine -> scenario" "scenario" "$(route_of "$j12")"
+assert_eq "case12: scenario engine gate set is ci-only" "['ci']" "$(gates_of "$j12")"
+
+# presentation — game/client/presentation code, an explicit route instead of
+# falling through to the tooling catch-all.
+j13="$("$SCRIPT" --json -- src/Noir.Game/Ui.cs)"
+assert_eq "case13: game/client code -> presentation" "presentation" "$(route_of "$j13")"
+assert_eq "case13: presentation gate set is ci-only" "['ci']" "$(gates_of "$j13")"
+
+# architecture still composes on top of a gameplay-routed .csproj change.
+j14="$("$SCRIPT" --json -- src/Noir.Rules/Foo.cs src/Noir.Rules/Noir.Rules.csproj)"
+assert_eq "case14: base route unaffected by the architecture file" "gameplay" "$(route_of "$j14")"
+assert_eq "case14: architecture flag set for a .csproj under src/Noir.Rules" "True" "$(arch_of "$j14")"
+assert_eq "case14: gate set composes (architecture-review added, gameplay gates kept)" \
+  "['architecture-review', 'ci']" "$(gates_of "$j14")"
+
 # --- fixture diffs ----------------------------------------------------------- #
 NUMERIC_DIFF="$WORKDIR/numeric.diff"
 cat > "$NUMERIC_DIFF" <<'EOF'
@@ -113,6 +143,10 @@ assert_eq "case6: issue label route:formulas raises a boring diff -> formulas" "
 # --- case 7: issue label route:docs CANNOT lower an actual formulas diff --- #
 j7="$(PATH="$MOCKBIN:$PATH" MOCK_ROUTE_LABELS="docs" "$SCRIPT" --json --diff-file "$NUMERIC_DIFF" --issue 999)"
 assert_eq "case7: route:docs cannot lower a real formulas diff" "formulas" "$(route_of "$j7")"
+
+# --- case 7b: issue label route:gameplay CANNOT lower a real formulas diff -- #
+j7b="$(PATH="$MOCKBIN:$PATH" MOCK_ROUTE_LABELS="gameplay" "$SCRIPT" --json --diff-file "$NUMERIC_DIFF" --issue 999)"
+assert_eq "case7b: route:gameplay cannot lower a real formulas diff" "formulas" "$(route_of "$j7b")"
 
 # --- case 8: architecture composes with another route ----------------------- #
 j8="$("$SCRIPT" --json -- src/Brp.Rules/Combat/RangeBands.cs Directory.Build.props)"

--- a/tools/route.sh
+++ b/tools/route.sh
@@ -56,7 +56,7 @@ done
 # route but never lower it. The diff sees only filenames; an issue's `route:*`
 # label carries the author's knowledge that a change is riskier than it looks.
 # `--issue N` reads that label; `--issue-route R` supplies it directly.
-iprec() { case "$1" in docs) echo 1 ;; tooling) echo 2 ;; rules) echo 3 ;; formulas) echo 4 ;; architecture) echo 5 ;; *) echo 0 ;; esac; }
+iprec() { case "$1" in docs) echo 1 ;; tooling) echo 2 ;; presentation) echo 3 ;; scenario) echo 4 ;; gameplay) echo 5 ;; rules) echo 6 ;; formulas) echo 7 ;; architecture) echo 8 ;; *) echo 0 ;; esac; }
 if [ -n "$ISSUE_NUM" ] && [ -z "$ISSUE_ROUTE" ]; then
   # Take the highest-precedence route:* label if the issue carries more than one.
   while IFS= read -r r; do
@@ -67,8 +67,8 @@ if [ -n "$ISSUE_NUM" ] && [ -z "$ISSUE_ROUTE" ]; then
              2>/dev/null || true)
 fi
 case "${ISSUE_ROUTE:-}" in
-  ""|docs|tooling|rules|formulas|architecture) ;;
-  *) echo "invalid --issue-route: $ISSUE_ROUTE (docs|tooling|rules|formulas|architecture)" >&2; exit 2 ;;
+  ""|docs|tooling|presentation|scenario|gameplay|rules|formulas|architecture) ;;
+  *) echo "invalid --issue-route: $ISSUE_ROUTE (docs|tooling|presentation|scenario|gameplay|rules|formulas|architecture)" >&2; exit 2 ;;
 esac
 
 [ -n "$DIFF_FILE" ] && [ -n "$BASE" ] && { echo "--diff-file and --base are mutually exclusive" >&2; exit 2; }
@@ -171,7 +171,7 @@ route_for_file() {
   printf '%s' "$matched"
 }
 
-prec() { case "$1" in docs) echo 1 ;; tooling) echo 2 ;; rules) echo 3 ;; formulas) echo 4 ;; *) echo 0 ;; esac; }
+prec() { case "$1" in docs) echo 1 ;; tooling) echo 2 ;; presentation) echo 3 ;; scenario) echo 4 ;; gameplay) echo 5 ;; rules) echo 6 ;; formulas) echo 7 ;; *) echo 0 ;; esac; }
 
 base="tooling"; basep=0; arch=0
 for f in "${FILES[@]}"; do
@@ -220,7 +220,7 @@ if [ -n "$ISSUE_ROUTE" ]; then
 fi
 
 case "$base" in
-  docs | tooling) gates="ci" ;;
+  docs | tooling | presentation | scenario | gameplay) gates="ci" ;;
   rules)          gates="ci scope-warden rules-conformance" ;;
   formulas)       gates="ci scope-warden rules-conformance codex-conformance" ;;
 esac


### PR DESCRIPTION
## Linked Issue
Closes #143

## Exact behavioral claim
Explicit deterministic routes now exist for the (not-yet-written) Layer 5 game layer, so future
`Noir.*` code and authored cases will NOT fall through to the `tooling` catch-all and be
under-classified. All three new routes are CI-only — design-led gameplay and machine-validated
scenario content do not buy a semantic AI reviewer on routine PRs. This is route-taxonomy design
ONLY; no Layer 5 mechanics were implemented.

## Scope
- New routes (gate set `ci` only): `gameplay` (`src/Noir.Rules/**`), `scenario`
  (`cases/**`, `src/Noir.Scenario/**`), `presentation` (`src/Noir.Game/**`, `src/Noir.Client/**`).
- `.github/route-map`: new path rules added ABOVE the architecture rules, which stay last so
  `**/*.csproj` / `Directory.Build.props` still compose `architecture-review` on top of any base.
- `tools/route.sh`: `iprec()`/`prec()`/`--issue-route` validation extended to
  docs<tooling<presentation<scenario<gameplay<rules<formulas<architecture — preserving the
  existing relative order and the asymmetric floor (a `route:gameplay/scenario/presentation`
  label can raise a boring diff but can NEVER lower an actual rules/formulas/architecture diff).
- `docs/orchestration/routing.md`, `docs/agent-team.md`: document the new routes, their gate sets,
  the design-vs-conformance rationale (why `design-critic`/Codex don't sit on routine gameplay/
  scenario PRs), and that `needs-design` remains a scheduler stop (unchanged in `ready-issues.sh`).
- Incidental: corrected two stale rows in routing.md's gate table (docs/tooling said
  "ci, scope-warden"; the code has been `ci` since #138) — same table being edited here.

## Rules conformance
N/A — routing metadata only, no rules/mechanics.

## Tests and evidence
- `tests/tooling/test_route.sh` (new cases): Noir.Rules→gameplay, cases/→scenario,
  Noir.Scenario→scenario, Noir.Game/Client→presentation, each gate set `['ci']`, csproj under
  Noir.Rules composes architecture, and `--issue-route gameplay` on a `formulas` diff stays formulas.
- Full tooling suite green (route, agent_verify, agent_brief, source_slice, orchestration_metrics,
  codex_agent, pr_policy, orchestration-policy).
- Orchestrator re-verified every new path→route/gate mapping and the asymmetric floor directly.
- Labels `route:gameplay`/`route:scenario`/`route:presentation` created.

## Decisions and tradeoffs
`presentation` is a distinct route (not folded into gameplay) so eventual client/UI code is
classified explicitly. A lone `.csproj` still reports base `tooling (+architecture)` — pre-existing
behavior for any project file; architecture-review is what the composition guarantees.

## Known limitations
The mapped `src/Noir.*` and `cases/**` paths mostly do not exist yet — this is intentional preflight
so the classifier is ready before Layer 5 code lands. Wiring `case_validator.py` into CI for the
scenario route is a separate future concern.

## Agent provenance
Implemented by the `orchestration-dev` (Sonnet) agent; reviewed by the Opus orchestrator (every new
mapping + asymmetric floor re-verified, full suite re-run, labels created). Route: tooling → CI only.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `bfcf142`

| gate | result |
|---|---|
| `ci` | pass |

_1/1 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->