### PR TITLE
Harden route.sh content-escalation + fail closed on malformed diff (#162, #164)

### DIFF
--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -107,6 +107,9 @@ explicit keeps the decision deterministic:
 | numeric array / indexer | `[ -?N` | `[ 1, 3, 6 ]` |
 | threshold comparison | `>= <= > <` followed by `-?N` | `roll <= skill / 5` |
 | number in a list | `, -?N` | `Steps(1, 2, 4, 8)` |
+| plain / const assignment (also `==`, `!=`) | `= -?N` | `public const int MaximumRoll = 99;` |
+| numeric return | `return -?N` | `return baseDamage * 3;` |
+| arithmetic on a number | `* / %` followed by `-?N` | `baseDamage * 3` |
 
 The match is intentionally line-level and slightly over-inclusive: a false escalation
 costs one extra (independent) verification pass; a false *de*-escalation would let a

--- a/tests/tooling/test_route.sh
+++ b/tests/tooling/test_route.sh
@@ -194,6 +194,97 @@ assert_eq "case9: off-branch escalated flag == on-branch" \
 assert_eq "case9: off-branch gate set == on-branch gate set" \
   "$(gates_of "$ON_BRANCH_JSON")" "$(gates_of "$OFF_BRANCH_JSON")"
 
+# --- Defect #162: escalation must also catch numeric shapes beyond the ------ #
+# original set (plain assignment, numeric return, arithmetic) -------------- #
+ASSIGN_DIFF="$WORKDIR/assign.diff"
+cat > "$ASSIGN_DIFF" <<'EOF'
+diff --git a/src/Brp.Rules/Combat/Limits.cs b/src/Brp.Rules/Combat/Limits.cs
+index 1111111..2222222 100644
+--- a/src/Brp.Rules/Combat/Limits.cs
++++ b/src/Brp.Rules/Combat/Limits.cs
+@@ -1,2 +1,2 @@
+-    public const int MaximumRoll = 100;
++    public const int MaximumRoll = 99;
+EOF
+j15="$("$SCRIPT" --json --diff-file "$ASSIGN_DIFF")"
+assert_eq "case15: plain const assignment to a number -> formulas" "formulas" "$(route_of "$j15")"
+assert_eq "case15: content-escalated flag set" "True" "$(escalated_of "$j15")"
+
+FIELD_INIT_DIFF="$WORKDIR/field-init.diff"
+cat > "$FIELD_INIT_DIFF" <<'EOF'
+diff --git a/src/Brp.Rules/Combat/Dice.cs b/src/Brp.Rules/Combat/Dice.cs
+index 1111111..2222222 100644
+--- a/src/Brp.Rules/Combat/Dice.cs
++++ b/src/Brp.Rules/Combat/Dice.cs
+@@ -1,2 +1,2 @@
+-    int GainDieSides = 6;
++    int GainDieSides = 4;
+EOF
+j16="$("$SCRIPT" --json --diff-file "$FIELD_INIT_DIFF")"
+assert_eq "case16: field init numeric change -> formulas" "formulas" "$(route_of "$j16")"
+
+RETURN_DIFF="$WORKDIR/return.diff"
+cat > "$RETURN_DIFF" <<'EOF'
+diff --git a/src/Brp.Rules/Combat/Damage.cs b/src/Brp.Rules/Combat/Damage.cs
+index 1111111..2222222 100644
+--- a/src/Brp.Rules/Combat/Damage.cs
++++ b/src/Brp.Rules/Combat/Damage.cs
+@@ -1,2 +1,2 @@
+-        return baseDamage * 2;
++        return baseDamage * 3;
+EOF
+j17="$("$SCRIPT" --json --diff-file "$RETURN_DIFF")"
+assert_eq "case17: bare numeric return with arithmetic -> formulas" "formulas" "$(route_of "$j17")"
+
+# --- guard: a rules .cs change with NO numeric literal edit must NOT --------- #
+# over-escalate to formulas (renaming a method / editing a comment) --------- #
+NO_NUMERIC_DIFF="$WORKDIR/no-numeric.diff"
+cat > "$NO_NUMERIC_DIFF" <<'EOF'
+diff --git a/src/Brp.Rules/Combat/Damage.cs b/src/Brp.Rules/Combat/Damage.cs
+index 1111111..2222222 100644
+--- a/src/Brp.Rules/Combat/Damage.cs
++++ b/src/Brp.Rules/Combat/Damage.cs
+@@ -1,2 +1,2 @@
+-    public void Recalculate() {
++    public void RecomputeDamage() {
+         // adjust for cover
+EOF
+j18="$("$SCRIPT" --json --diff-file "$NO_NUMERIC_DIFF")"
+assert_eq "case18: rules change with no numeric edit stays -> rules (no over-escalation)" \
+  "rules" "$(route_of "$j18")"
+assert_eq "case18: escalated flag is False for a non-numeric rules change" \
+  "False" "$(escalated_of "$j18")"
+
+# --- Defect #164: fail CLOSED on a non-empty, header-less (unparseable) ----- #
+# diff instead of silently defaulting to tooling with zero files ------------ #
+HEADERLESS_DIFF="$WORKDIR/headerless.diff"
+cat > "$HEADERLESS_DIFF" <<'EOF'
+--- a/tools/some-script.sh
++++ b/tools/some-script.sh
+@@ -1,2 +1,2 @@
+-echo hi
++echo hello
+EOF
+if "$SCRIPT" --json --diff-file "$HEADERLESS_DIFF" >/dev/null 2>"$WORKDIR/headerless.err"; then
+  fail "case19: header-less non-empty diff must fail closed (exit non-zero), but it exited 0"
+else
+  ok "case19: header-less non-empty diff fails closed (non-zero exit)"
+fi
+if [ -s "$WORKDIR/headerless.err" ]; then
+  ok "case19b: header-less diff failure prints an error to stderr"
+else
+  fail "case19b: header-less diff failure printed nothing to stderr"
+fi
+
+# --- sanity: a genuinely empty diff file is NOT an error (no changes) ------- #
+EMPTY_DIFF="$WORKDIR/empty.diff"
+: > "$EMPTY_DIFF"
+if "$SCRIPT" --json --diff-file "$EMPTY_DIFF" >/dev/null 2>"$WORKDIR/empty.err"; then
+  ok "case20: an empty diff file is not an error"
+else
+  fail "case20: an empty diff file incorrectly failed closed"
+fi
+
 echo
 if [ "$FAILURES" -eq 0 ]; then
   echo "test_route.sh: all checks passed"

--- a/tools/route.sh
+++ b/tools/route.sh
@@ -123,6 +123,15 @@ diff_hunks_for_files_in_file() {
 if [ ${#FILES[@]} -eq 0 ]; then
   if [ -n "$DIFF_FILE" ]; then
     mapfile -t FILES < <(files_from_diff_file "$DIFF_FILE")
+    # Fail CLOSED: a non-empty diff that yields zero recognizable file paths
+    # (e.g. a `diff --git` header-less patch, such as `git diff --no-prefix`
+    # output) is unparseable, not "no changes" — do not silently fall through
+    # to the tooling/no-files default. A legitimately empty diff file (no
+    # changes at all) is not an error.
+    if [ ${#FILES[@]} -eq 0 ] && [ -s "$DIFF_FILE" ]; then
+      echo "--diff-file: non-empty diff yielded no recognizable file paths (missing 'diff --git a/... b/...' headers?): $DIFF_FILE" >&2
+      exit 2
+    fi
   elif [ -n "$BASE" ]; then
     mapfile -t FILES < <(git -C "$ROOT" diff --name-only "$BASE"...HEAD)
   else
@@ -201,7 +210,7 @@ if [ "$base" = "rules" ]; then
     else
       d="$(git -C "$ROOT" diff --unified=0 HEAD -- "${rf[@]}" 2>/dev/null || true)"
     fi
-    if printf '%s' "$d" | grep -Eq '^[+-][^+-].*(=>[[:space:]]*-?[0-9]|:[[:space:]]*-?[0-9]+|\[[[:space:]]*-?[0-9]|(>=|<=|>|<)[[:space:]]*-?[0-9]|,[[:space:]]*-?[0-9]+)'; then
+    if printf '%s' "$d" | grep -Eq '^[+-][^+-].*(=>[[:space:]]*-?[0-9]|:[[:space:]]*-?[0-9]+|\[[[:space:]]*-?[0-9]|(>=|<=|>|<)[[:space:]]*-?[0-9]|,[[:space:]]*-?[0-9]+|=[[:space:]]*-?[0-9]|return[[:space:]]+-?[0-9]|[*/%][[:space:]]*-?[0-9])'; then
       base="formulas"; escalated=1
     fi
   fi


### PR DESCRIPTION
## Linked Issue
Closes #162
Closes #164

## Exact behavioral claim
Fixes two `route.sh --diff-file` classification defects found by the post-remediation adversarial
audit. (#162, MAJOR) A source-derived numeric change written as plain assignment / bare return /
arithmetic now correctly escalates `rules → formulas`, so it gets the independent `codex-conformance`
cross-check instead of silently losing it — restoring the documented "when in doubt, escalate"
property. (#164, MINOR) A non-empty diff that yields no recognizable file paths now fails CLOSED.

## Scope
- `tools/route.sh`: escalation regex (rules-base block only) gains three alternatives —
  `=[[:space:]]*-?[0-9]` (plain/const assignment), `return[[:space:]]+-?[0-9]` (numeric return),
  `[*/%][[:space:]]*-?[0-9]` (arithmetic) — keeping all existing shapes. And: if `--diff-file` is
  non-empty but zero files are extracted, error to stderr and `exit 2` (a legitimately empty diff
  still succeeds).
- `docs/orchestration/routing.md`: escalation-patterns table updated with the new shapes.
- Nearby behavior deliberately unchanged: escalation stays scoped to the `rules` base (never affects
  docs/tooling/gameplay/scenario/presentation); a rules `.cs` change with NO numeric edit stays `rules`.

## Rules conformance
N/A — routing tooling. This change makes MORE rules-engine numeric changes get Codex, not fewer.

## Tests and evidence
- `tests/tooling/test_route.sh` cases 15–20: plain const `= 99`, field init, bare `return … * N`,
  arithmetic → `formulas`/escalated; a no-numeric-edit rules change → `rules`/not-escalated
  (over-escalation guard); header-less non-empty diff → non-zero exit; empty diff → not an error.
- Orchestrator re-verified the ORIGINAL audit reproduction (`const int MaximumRoll = 100 → 99`) now
  yields `route: formulas, escalated: True, gates: [...codex-conformance]`, and the no-numeric guard
  stays `rules`. Full tooling suite green (37/37 route cases; agent_verify/agent_brief/source_slice/
  orchestration_metrics/codex_agent/pr_policy/orchestration-policy all pass) — existing rules/formulas
  cases unaffected by the widening.

## Decisions and tradeoffs
Over-escalation is explicitly acceptable per routing.md ("when in doubt, escalate"), so the widening
does not try to exclude e.g. loop counters (which already escalate via the comparison arm). Verified it
does not escalate a numeric-free rules change.

## Known limitations
None. Remaining audit follow-ups (#163 stale doc paragraph, #161 gitignore `.codex`) are separate.

## Agent provenance
Found by the independent `design-critic` (Opus) audit; reproduced by the Opus orchestrator; fixed by the
`orchestration-dev` (Sonnet) agent; re-verified by the orchestrator (reproduction + guard + fail-closed +
full suite). Route: tooling → CI only.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `dedc43e`

| gate | result |
|---|---|
| `ci` | pass |

_1/1 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->