### PR TITLE
Post-audit cleanup: gitignore .codex mirror; fix stale off-branch doc (#161, #163)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ __pycache__/
 # OS
 .DS_Store
 Thumbs.db
+
+# Auto-generated Codex role mirror (external tool derives it from .claude/agents/;
+# the repo tracks tools/codex-agent.sh instead — see #142/#161).
+.codex/

--- a/docs/orchestration/agent-verification.md
+++ b/docs/orchestration/agent-verification.md
@@ -46,9 +46,10 @@ tools/agent-verify.sh <PR#> \
   posted on incomplete evidence**.
 - Default is a dry run. `--post` posts the status; `--evidence` also writes a managed
   `<!-- agent-verification -->` block into the PR body for humans.
-- Run it with the PR branch checked out. From another branch it degrades to a
-  path-only route (GitHub's changed-file list) and says so — the `rules → formulas`
-  content-escalation can't be seen without the diff.
+- Works from any branch. When the working tree is on the PR head it routes from the
+  local diff (`route.sh --base`); otherwise it fetches the full PR patch with
+  `gh pr diff` and classifies it via `route.sh --diff-file`, so the `rules → formulas`
+  content-escalation is applied either way — never a path-only degrade (see #137).
 
 ## Making it required (burned in, then flipped)
 


### PR DESCRIPTION
## Linked Issue
Closes #161
Closes #163

## Exact behavioral claim
Two trivial cleanups from the adversarial audit: the externally auto-generated `.codex/agents/`
mirror can no longer be accidentally re-committed, and the agent-verification doc no longer describes
superseded off-branch behavior.

## Scope
- `.gitignore`: add `.codex/` — an external tool regenerates it from `.claude/agents/`, and #142
  removed the tracked copies; ignoring it keeps the auto-generated mirror out of git permanently.
- `docs/orchestration/agent-verification.md`: the off-branch paragraph said agent-verify "degrades to
  a path-only route" — that is pre-#137. Corrected to describe the actual `gh pr diff` + `--diff-file`
  routing, so content-escalation applies from any branch.

## Rules conformance
N/A.

## Tests and evidence
- `git check-ignore .codex/agents/scope-warden.toml` → ignored.
- `git status` no longer lists `.codex/`; no tracked files changed under `.codex/`.
- Doc paragraph now matches `agent-verify.sh` (verified against #137 behavior and test_agent_verify case8/9).

## Decisions and tradeoffs
Two one-line cleanups from the same audit bundled into one PR; both keep the repo honest/clean, no code behavior change.

## Known limitations
None. This closes the last of the adversarial-audit follow-ups.

## Agent provenance
Found by the `design-critic` audit; applied directly by the Opus orchestrator (trivial). Route: tooling → CI only.

## Checklist
- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `aa7436f`

| gate | result |
|---|---|
| `ci` | pass |

_1/1 gates passed [route: tooling]. Regenerated per head SHA by `tools/agent-verify.sh`._
<!-- agent-verification:end -->