### PR TITLE
Extend setup-project.sh schema for Layer 5, new routes, orchestration-dev (#173)

### DIFF
--- a/tools/setup-project.sh
+++ b/tools/setup-project.sh
@@ -39,11 +39,17 @@ mkfield() { # name  datatype  [comma,options]
 # merged -> Done). We do NOT add a custom "Stage" field — a second workflow field
 # the automations would not touch. Verification Route mirrors tools/route.sh;
 # Agent Role mirrors the roster.
-mkfield "Layer"                       SINGLE_SELECT "L0,L1,L2,L3,L4,Orchestration"
+#
+# NOTE: field-create only runs when the field does not already exist (see
+# mkfield above), so re-running this script against an already-provisioned
+# board will NOT add these new options to an existing single-select field.
+# Add missing options to an existing board's fields via the API or the
+# project UI directly.
+mkfield "Layer"                       SINGLE_SELECT "L0,L1,L2,L3,L4,L5,Orchestration"
 mkfield "Subsystem"                   TEXT
 mkfield "Risk"                        SINGLE_SELECT "low,medium,high"
-mkfield "Verification Route"          SINGLE_SELECT "docs,tooling,rules,formulas,architecture"
-mkfield "Agent Role"                  SINGLE_SELECT "engine-dev,case-author,scope-warden,rules-conformance,design-critic,rules-extractor,codex"
+mkfield "Verification Route"          SINGLE_SELECT "docs,tooling,presentation,scenario,gameplay,rules,formulas,architecture"
+mkfield "Agent Role"                  SINGLE_SELECT "engine-dev,case-author,scope-warden,rules-conformance,design-critic,rules-extractor,orchestration-dev,codex"
 mkfield "Source-Conformance Required" SINGLE_SELECT "yes,no"
 
 echo "adding items:"


### PR DESCRIPTION
## Linked Issue

Closes #173

## Exact behavioral claim

`tools/setup-project.sh` now provisions Project-v2 fields whose option lists match the current orchestration ontology: **Layer** includes `L5`; **Verification Route** includes `presentation,scenario,gameplay` (alongside the original five); **Agent Role** includes `orchestration-dev`. A fresh board provisioned by this script can now represent Layer 5 work and the orchestration-dev role.

## Scope

`tools/setup-project.sh` only — three `mkfield` option lists extended, plus a comment noting that `field-create` is skipped for already-existing fields, so an already-provisioned board must have the new options added via API/UI separately (no migration logic added, per the Issue's out-of-scope note). No new fields, no renames.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash -n tools/setup-project.sh` → syntax OK. Cross-checked every option string against source: Route options match the `tools/route.sh` route set (`docs,tooling,presentation,scenario,gameplay,rules,formulas,architecture`); Role options match `.claude/agents/*.md` filenames plus the pre-existing non-file `codex` value; `L5` added per the Issue.

## Decisions and tradeoffs

Kept `codex` in the Agent Role list (it has no agent file but is a real reviewer identity) rather than dropping it. Ordered the new routes to mirror `route.sh` precedence for readability.

## Known limitations

Does not migrate an already-created board's existing single-select options — documented in-script as a manual API/UI step.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
