### PR TITLE
Task packet honors the Issue route:* floor (#169)

### DIFF
--- a/tests/tooling/test_agent_brief.sh
+++ b/tests/tooling/test_agent_brief.sh
@@ -97,13 +97,29 @@ Make the widget reproducible.
 print(json.dumps(body))
 ')"
           emit "{\"title\":\"Widget packet test\",\"body\":$body_json,\"labels\":[],\"number\":5001,\"url\":\"https://example.invalid/issues/5001\"}" "$@"
+        elif [ "$num" = "5003" ]; then
+          # No "Likely files" / "Workspace" section at all (mirrors #112): the
+          # task packet's route prediction must still honor the issue's
+          # `route:formulas` floor via `--issue`, not fall back to "?" and not
+          # fall back to the local checkout's dirty-worktree diff.
+          body_json="$(python3 -c '
+import json
+body = """## Outcome
+Add a numeric table with no named files."""
+print(json.dumps(body))
+')"
+          emit "{\"title\":\"Floor packet test\",\"body\":$body_json,\"labels\":[{\"name\":\"route:formulas\"}],\"number\":5003,\"url\":\"https://example.invalid/issues/5003\"}" "$@"
         else
           echo "mock gh: unhandled issue view $num" >&2; exit 1
         fi ;;
       state,title)
         emit "{\"state\":\"OPEN\",\"title\":\"Dependency fixture issue\"}" "$@" ;;
       labels)
-        emit "{\"labels\":[]}" "$@" ;;
+        if [ "$num" = "5003" ]; then
+          emit "{\"labels\":[{\"name\":\"route:formulas\"}]}" "$@"
+        else
+          emit "{\"labels\":[]}" "$@"
+        fi ;;
       *) echo "mock gh: unhandled issue view --json $jsonf" >&2; exit 1 ;;
     esac ;;
   *) echo "mock gh: unhandled args: $*" >&2; exit 1 ;;
@@ -164,6 +180,19 @@ assert_contains "task packet: explicit exclusion carried through" "$content" "gi
 route_line="$(grep '^- route:' "$task1")"
 direct_route="$(bash "$ROOT/tools/route.sh" --json tools/agent-brief.py | python3 -c 'import json,sys; print(json.load(sys.stdin)["route"])')"
 assert_contains "task packet: predicted route matches tools/route.sh" "$route_line" "**$direct_route**"
+
+# --- task packet honors the Issue's route:* floor (Issue #169) -------------- #
+# #5003 carries `route:formulas` and names no likely files at all — the
+# predicted route must still be raised to (at least) "formulas" by the
+# issue-intent floor, matching `tools/route.sh --issue 5003` directly, not
+# left at "?" and not derived from this checkout's local working-tree diff.
+task3="$WORKDIR/task3.md"
+python3 "$SCRIPT" task 5003 > "$task3"
+floor_route_line="$(grep '^- route:' "$task3")"
+direct_floor_route="$(bash "$ROOT/tools/route.sh" --json --issue 5003 | python3 -c 'import json,sys; print(json.load(sys.stdin)["route"])')"
+assert_eq "task packet: issue route:* floor resolves to formulas" "formulas" "$direct_floor_route"
+assert_contains "task packet: predicted route honors issue route:* floor" "$floor_route_line" "**$direct_floor_route**"
+assert_contains "task packet: predicted gates honor issue route:* floor" "$floor_route_line" "codex-conformance"
 
 # === REVIEW PACKET =========================================================== #
 # Use two real commits from this checkout's own history so no `gh pr view` is

--- a/tools/agent-brief.py
+++ b/tools/agent-brief.py
@@ -191,16 +191,32 @@ def route_for(files: list[str], base: str | None = None, issue: int | None = Non
     # escalation, and (via --issue) the issue-intent floor the same way for
     # every consumer — the review packet must never approximate this itself.
     cmd = ["bash", str(ROOT / "tools" / "route.sh"), "--json"]
+    empty_diff = None
     if base:
         cmd += ["--base", base]
-    else:
+    elif files:
         cmd += files
+    elif issue:
+        # No known files and no base ref: route.sh's "neither" fallback reads
+        # the local working tree's `git diff HEAD`, which has nothing to do
+        # with a not-yet-started Issue and would make the prediction depend on
+        # whatever happens to be dirty in this checkout. Feed it an explicit
+        # empty diff instead, so the path baseline stays "tooling" and only
+        # the Issue's `route:*` floor (still applied independently of the
+        # file list) can raise it.
+        import tempfile
+        empty_diff = tempfile.NamedTemporaryFile(mode="w", suffix=".diff", delete=False)
+        empty_diff.close()
+        cmd += ["--diff-file", empty_diff.name]
     if issue:
         cmd += ["--issue", str(issue)]
     try:
         return json.loads(sh(cmd).strip().splitlines()[-1])
     except Exception:
         return {"route": "unknown", "gates": []}
+    finally:
+        if empty_diff:
+            Path(empty_diff.name).unlink(missing_ok=True)
 
 
 def render(schema: str, lines: list[str]) -> str:
@@ -226,7 +242,7 @@ def cmd_task(num: int) -> None:
 
     files_text = first_of(sec, "likely files or subsystem", "workspace", "likely files")
     ws_lines, derived = workspace(files_text, body)
-    route = route_for(derived) if derived else {"route": "?", "gates": []}
+    route = route_for(derived, issue=num)
 
     src = first_of(sec, "rules source")
     focus = f"{d['title']} {labels} {src}"


### PR DESCRIPTION
## Linked Issue

Closes #169

## Exact behavioral claim

`tools/agent-brief.py task <n>` now threads the Issue number into `route_for`, so a task packet's predicted route and required gates honor the Issue's `route:*` intent floor (via `tools/route.sh --issue`) — even when the Issue names no likely files. Previously `cmd_task` called `route_for(derived)` with no Issue and printed `route: ? → gates: —` for an Issue like #112; it now predicts `formulas → ci, scope-warden, rules-conformance, codex-conformance`, matching what PR-time verification will apply. This closes a briefing-quality gap where the implementer was told a cheaper route than the Issue declared.

## Scope

`tools/agent-brief.py`: `cmd_task` now passes `issue=num`; `route_for` gained an explicit empty-diff fallback so that when an Issue names no files and there is no base ref, the path baseline stays `tooling` and only the Issue floor can raise it — rather than `route.sh` silently reading the orchestrator's local working-tree diff. No change to `route.sh` or the floor semantics; `cmd_review` was already correct and is untouched.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_agent_brief.sh` → all 42 checks passed. Added fixture Issue #5003 (`route:formulas`, no likely-files section, mirroring #112) asserting the predicted route/gates equal `tools/route.sh --issue 5003` (formulas, incl. codex-conformance). Also confirmed `python3 tools/agent-brief.py task 112` now prints route formulas in its REQUIRED GATES section.

## Decisions and tradeoffs

The naive "pass issue=num only when files exist" would have left #112 at `route: ?`; passing an empty file list straight through would have made the prediction depend on the checkout's dirty diff. The empty-`--diff-file` fallback makes the floor apply deterministically using only the existing `route.sh` interface.

## Known limitations

None.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
