### PR TITLE
Adapt agent-brief architecture-review checklist to issue-floor gates (#186)

### DIFF
--- a/tests/tooling/test_agent_brief.sh
+++ b/tests/tooling/test_agent_brief.sh
@@ -23,7 +23,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT/tools/agent-brief.py"
 
 WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
+trap 'git -C "$ROOT" worktree remove --force "$WORKDIR/wt" >/dev/null 2>&1 || true; rm -rf "$WORKDIR"' EXIT
 
 FAILURES=0
 ok()   { printf 'ok   - %s\n' "$1"; }
@@ -117,6 +117,10 @@ print(json.dumps(body))
       labels)
         if [ "$num" = "5003" ]; then
           emit "{\"labels\":[{\"name\":\"route:formulas\"}]}" "$@"
+        elif [ "$num" = "6001" ]; then
+          # Issue #186 fixture: an issue-level `route:architecture` intent
+          # floor, carried by a docs-only PR with no project/boundary change.
+          emit "{\"labels\":[{\"name\":\"route:architecture\"}]}" "$@"
         else
           emit "{\"labels\":[]}" "$@"
         fi ;;
@@ -245,6 +249,84 @@ if [ -n "$direct_review_route" ]; then
   assert_contains "review packet: predicted route matches tools/route.sh" "$review_route_line" "**$direct_review_route**"
 else
   fail "review packet: predicted route matches tools/route.sh (could not compute direct route)"
+fi
+
+# === ARCHITECTURE-REVIEW CHECKLIST SCOPE (Issue #186 / burn-in F11) ======= #
+# The architecture-review gate lands in the gate set for two structurally
+# different reasons: a path-derived project/boundary change actually in the
+# diff, or an issue-level `route:architecture` intent floor with no such
+# change present. The review packet must name the right scope for each — see
+# tools/agent-brief.py's architecture_review_reason_and_checklist().
+#
+# Real git commits are needed (route.sh classifies actual diffs), so this
+# stands up a disposable secondary worktree, sharing this checkout's object
+# store, and advances its own HEAD independently — the primary worktree
+# under test is never touched.
+WT="$WORKDIR/wt"
+git -C "$ROOT" worktree add -q --detach "$WT" HEAD
+
+base_common="$(git -C "$WT" rev-parse HEAD)"
+
+# --- case (a): docs-only change + issue `route:architecture` floor -> the
+# checklist must be decision-scoped, not the Brp.* layering boilerplate. ---
+mkdir -p "$WT/docs/decisions"
+cat > "$WT/docs/decisions/9999-fixture-test-186.md" <<'EOF'
+# 9999. Fixture decision record for test_agent_brief.sh (Issue #186)
+
+This file exists only to give the architecture-review checklist test a
+docs-only diff to classify. It is committed to a disposable worktree and
+never merged.
+EOF
+git -C "$WT" add docs/decisions/9999-fixture-test-186.md
+git -C "$WT" -c user.email=test@example.invalid -c user.name=test commit -q -m "test fixture: docs-only change for #186"
+head_docs="$(git -C "$WT" rev-parse HEAD)"
+
+# route.sh reads issue labels via `gh`, which must resolve to the mock — run
+# it from within $WT so `HEAD` resolves to this worktree's own HEAD (PATH,
+# with the gh stub, is already exported above).
+direct_docs="$(cd "$WT" && bash tools/route.sh --json --base "$base_common" --issue 6001 2>/dev/null || true)"
+assert_contains "case (a): route.sh reports architecture true (issue floor only)" "$direct_docs" '"architecture":true'
+assert_contains "case (a): route.sh reports issueRaised true off the architecture floor" "$direct_docs" '"issueRaised":true'
+assert_contains "case (a): route.sh reports issueRoute architecture" "$direct_docs" '"issueRoute":"architecture"'
+
+review_docs="$WORKDIR/review_docs.md"
+python3 "$WT/tools/agent-brief.py" review --base "$base_common" --head "$head_docs" --issue 6001 > "$review_docs"
+docs_content="$(cat "$review_docs")"
+assert_contains "case (a): checklist is decision-scoped, not layering boilerplate" "$docs_content" \
+  "no project/boundary change is actually in this diff"
+assert_contains "case (a): checklist tells the reviewer to check decision/boundary soundness" "$docs_content" \
+  "SOUNDNESS of the recorded decision"
+if [[ "$docs_content" == *"architecture-review"*"Brp.Core/Brp.Rules take no game-engine dependency"* ]]; then
+  fail "case (a): checklist must NOT use the Brp.* layering boilerplate"
+else
+  ok "case (a): checklist does not use the Brp.* layering boilerplate"
+fi
+assert_contains "case (a): escalation reason cites the issue-intent floor, not a diff-touched boundary" "$docs_content" \
+  "Issue intent floor \`route:architecture\`"
+
+# --- case (b): a real .csproj / project-reference change -> the checklist
+# must still name the layering / no-game-engine-dependency checks. ---
+git -C "$WT" checkout -q "$base_common"
+printf '  <!-- test fixture #186: benign comment -->\n' >> "$WT/tools/Brp.Cli/Brp.Cli.csproj"
+git -C "$WT" add tools/Brp.Cli/Brp.Cli.csproj
+git -C "$WT" -c user.email=test@example.invalid -c user.name=test commit -q -m "test fixture: project-file change for #186"
+head_csproj="$(git -C "$WT" rev-parse HEAD)"
+
+direct_csproj="$(cd "$WT" && bash tools/route.sh --json --base "$base_common" 2>/dev/null || true)"
+assert_contains "case (b): route.sh reports architecture true (path-derived)" "$direct_csproj" '"architecture":true'
+assert_contains "case (b): route.sh reports issueRaised false (no issue floor involved)" "$direct_csproj" '"issueRaised":false'
+
+review_csproj="$WORKDIR/review_csproj.md"
+python3 "$WT/tools/agent-brief.py" review --base "$base_common" --head "$head_csproj" > "$review_csproj"
+csproj_content="$(cat "$review_csproj")"
+assert_contains "case (b): checklist keeps the Brp.* layering/no-game-engine-dependency check" "$csproj_content" \
+  "Brp.Core/Brp.Rules take no game-engine dependency"
+assert_contains "case (b): escalation reason cites the diff, not an issue floor" "$csproj_content" \
+  "the diff touches project references/layering"
+if [[ "$csproj_content" == *"SOUNDNESS of the recorded decision"* ]]; then
+  fail "case (b): checklist must NOT be decision-scoped for a real project-file change"
+else
+  ok "case (b): checklist is not decision-scoped for a real project-file change"
 fi
 
 echo

--- a/tests/tooling/test_agent_brief.sh
+++ b/tests/tooling/test_agent_brief.sh
@@ -293,7 +293,7 @@ review_docs="$WORKDIR/review_docs.md"
 python3 "$WT/tools/agent-brief.py" review --base "$base_common" --head "$head_docs" --issue 6001 > "$review_docs"
 docs_content="$(cat "$review_docs")"
 assert_contains "case (a): checklist is decision-scoped, not layering boilerplate" "$docs_content" \
-  "no project/boundary change is actually in this diff"
+  "No project/boundary change is actually in this diff"
 assert_contains "case (a): checklist tells the reviewer to check decision/boundary soundness" "$docs_content" \
   "SOUNDNESS of the recorded decision"
 if [[ "$docs_content" == *"architecture-review"*"Brp.Core/Brp.Rules take no game-engine dependency"* ]]; then

--- a/tools/agent-brief.py
+++ b/tools/agent-brief.py
@@ -51,6 +51,51 @@ GATE_REVIEW = {
                            "Brp.Core/Brp.Rules take no game-engine dependency.",
 }
 
+# The architecture-review gate lands in the gate set for two structurally
+# different reasons, per tools/route.sh (the one route authority):
+#   1. a path-derived project/boundary change actually present in the diff (a
+#      changed .csproj, project reference, or similar) — `architecture: true`.
+#   2. an issue-level `route:architecture` intent floor with NO such change in
+#      the diff. route.sh only reports `issueRaised: true` off the
+#      `route:architecture` floor when it had to add the gate itself (the
+#      path-derived `arch` flag was 0 before applying the floor) — see
+#      route.sh's "Issue-intent floor" comment. So `architecture && issueRaised
+#      && issueRoute == "architecture"` means the gate exists ONLY because of
+#      the issue floor, not because of anything in the diff.
+# These need different reasons/checklists (F11 burn-in finding): the layering
+# boilerplate is nonsensical for, e.g., a docs-only ADR that merely records a
+# decision.
+ARCH_REVIEW_LAYERING = (
+    "Review the new subsystem boundary and project references: layering holds, "
+    "Brp.Core/Brp.Rules take no game-engine dependency."
+)
+ARCH_REVIEW_DECISION_SCOPED = (
+    "No project/boundary change is actually in this diff — this gate is present only "
+    "because the Issue carries a `route:architecture` intent floor. Review the "
+    "SOUNDNESS of the recorded decision or boundary the change makes (is it correct, "
+    "consistent with prior decisions, and adequately justified) — do NOT check "
+    "`Brp.*` layering or project references, which this diff does not touch."
+)
+
+
+def architecture_review_reason_and_checklist(route: dict) -> tuple[str, str] | None:
+    """Return (reason, checklist text) for the architecture-review gate, or
+    None if the gate is not present in `route`'s gate set. Distinguishes WHY
+    the gate is present — see the comment above ARCH_REVIEW_LAYERING."""
+    if not route.get("architecture"):
+        return None
+    issue_floor_only = bool(route.get("issueRaised")) and route.get("issueRoute") == "architecture"
+    if issue_floor_only:
+        return (
+            "architecture review added: Issue intent floor `route:architecture` — "
+            "no project/boundary change in the diff",
+            ARCH_REVIEW_DECISION_SCOPED,
+        )
+    return (
+        "architecture review added: the diff touches project references/layering",
+        ARCH_REVIEW_LAYERING,
+    )
+
 
 def sh(cmd: list[str], check: bool = True) -> str:
     r = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
@@ -316,15 +361,17 @@ def cmd_review(args: argparse.Namespace) -> None:
     adrs = adr_titles()
     adr_pick = relevant_adrs(focus) if title != "(explicit range)" else list(ALWAYS_ADRS)
 
+    arch_review = architecture_review_reason_and_checklist(route)
+
     reasons = []
     if route.get("escalated"):
         reasons.append("content escalation: the diff touches a numeric table/threshold, "
                         "so `rules` was promoted to `formulas`")
-    if route.get("issueRaised"):
+    if route.get("issueRaised") and route.get("issueRoute") != "architecture":
         reasons.append(f"issue-intent floor: Issue #{issue} carries `route:{route.get('issueRoute')}`, "
                         "which raises (never lowers) the route")
-    if route.get("architecture"):
-        reasons.append("architecture review added: the diff touches project references/layering")
+    if arch_review:
+        reasons.append(arch_review[0])
     escalation_reason = "; ".join(reasons) if reasons else "none — plain path-based route, no escalation"
 
     p = []
@@ -363,7 +410,9 @@ def cmd_review(args: argparse.Namespace) -> None:
              + (" (content-escalated)" if route.get("escalated") else ""))
     p.append("Checklist — every listed gate must return a verdict before this PR can merge:")
     for g in route.get("gates", []):
-        if g in GATE_REVIEW:
+        if g == "architecture-review" and arch_review:
+            p.append(f"- [ ] **{g}** — {arch_review[1]}")
+        elif g in GATE_REVIEW:
             p.append(f"- [ ] **{g}** — {GATE_REVIEW[g]}")
         else:
             p.append(f"- [ ] **{g}**")


### PR DESCRIPTION
## Linked Issue

Closes #186

## Exact behavioral claim

The `agent-brief.py` review packet now tailors its `architecture-review` reason and checklist to *why* the gate is required: a path-derived project/boundary change (`.csproj`/references) still gets the `Brp.*` layering / no-game-engine-dependency checklist, while a gate pulled in only by an issue-level `route:architecture` floor gets a decision/boundary-soundness checklist instead of the misleading layering boilerplate (burn-in F11).

## Scope

tools/agent-brief.py (new `architecture_review_reason_and_checklist(route)` keying off route.sh `--json` `architecture`/`issueRaised`/`issueRoute`), tests/tooling/test_agent_brief.sh. No change to route.sh.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_agent_brief.sh` → all 53 checks pass, including a docs-only + `route:architecture`-floor case (decision-scoped) and a `.csproj` case (layering).

## Decisions and tradeoffs

Kept the change tightly scoped to the named files; no ADR added and the decisions index untouched (deliberate, to avoid the F8/F9 collision class while several sibling PRs are in flight).

## Known limitations

None beyond what the linked Issue states.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
