### PR TITLE
Check Codex availability via CODEX_BIN, not which codex (#187)

### DIFF
--- a/docs/orchestration/agent-verification.md
+++ b/docs/orchestration/agent-verification.md
@@ -7,6 +7,10 @@ aggregator, that derivation was *computed and then ignored*: the model-driven ga
 posted nothing on a PR, so GitHub could only gate on `build-and-test`, `pr-policy`,
 and `orchestration-policy`.
 
+Codex presence (needed for the `codex-conformance` gate) is checked via
+`CODEX_BIN` — run `tools/codex-agent.sh --check` (or `preflight`) — never via
+`which codex`, which does not find it (see burn-in finding F5(a)).
+
 [`tools/agent-verify.sh`](../../tools/agent-verify.sh) closes that loop without
 rebuilding the App fan-out. The **local orchestrator** runs the route's gates for the
 PR head SHA and posts a single `agent-verification` **commit status** — success only

--- a/tests/tooling/test_codex_agent.sh
+++ b/tests/tooling/test_codex_agent.sh
@@ -10,6 +10,9 @@
 #   - `review` includes the REVIEW packet content
 #   - `simcheck` takes --packet and includes its content
 #   - a prompt-sha256 is always printed
+#   - `--check` / `preflight` report Codex availability via CODEX_BIN (never
+#     `which codex`): exit 0 when present, non-zero with a clear message when
+#     absent, honoring a CODEX_BIN override
 #
 # Run directly:
 #   tests/tooling/test_codex_agent.sh
@@ -133,6 +136,38 @@ OUT="$(DRY_RUN=1 CODEX_BIN="$WORKDIR/no-such-codex-binary" "$SCRIPT" simcheck --
 set -e
 [ "$RC" -eq 0 ] && ok "DRY_RUN succeeds even with a nonexistent CODEX_BIN (never invoked)" || \
   fail "DRY_RUN should succeed without a real codex binary (rc=$RC): $OUT"
+
+# ---------------------------------------------------------------------------
+# 7. --check / preflight: reports availability via CODEX_BIN, never `which`.
+# ---------------------------------------------------------------------------
+STUB_CODEX="$WORKDIR/stub-codex"
+cat > "$STUB_CODEX" <<'EOF'
+#!/usr/bin/env bash
+echo "stub codex"
+EOF
+chmod +x "$STUB_CODEX"
+
+set +e
+OUT="$(CODEX_BIN="$STUB_CODEX" "$SCRIPT" --check 2>&1)"; RC=$?
+set -e
+[ "$RC" -eq 0 ] && ok "--check: present CODEX_BIN -> exit 0" || fail "--check: present CODEX_BIN should exit 0 (rc=$RC): $OUT"
+assert_contains "--check: present CODEX_BIN reports the path" "$OUT" "$STUB_CODEX"
+
+set +e
+OUT="$(CODEX_BIN="$STUB_CODEX" "$SCRIPT" preflight 2>&1)"; RC=$?
+set -e
+[ "$RC" -eq 0 ] && ok "preflight: present CODEX_BIN -> exit 0" || fail "preflight: present CODEX_BIN should exit 0 (rc=$RC): $OUT"
+
+set +e
+OUT="$(CODEX_BIN=/nonexistent "$SCRIPT" --check 2>&1)"; RC=$?
+set -e
+[ "$RC" -ne 0 ] && ok "--check: absent CODEX_BIN -> nonzero exit" || fail "--check: absent CODEX_BIN should fail (rc=$RC): $OUT"
+assert_contains "--check: absent CODEX_BIN reports a clear message" "$OUT" "/nonexistent"
+
+set +e
+OUT="$(CODEX_BIN=/nonexistent "$SCRIPT" preflight 2>&1)"; RC=$?
+set -e
+[ "$RC" -ne 0 ] && ok "preflight: absent CODEX_BIN -> nonzero exit" || fail "preflight: absent CODEX_BIN should fail (rc=$RC): $OUT"
 
 echo
 if [ "$FAILURES" -eq 0 ]; then

--- a/tools/codex-agent.sh
+++ b/tools/codex-agent.sh
@@ -19,6 +19,10 @@
 #   tools/codex-agent.sh conformance --review-packet FILE --source-packet FILE
 #   tools/codex-agent.sh review      --review-packet FILE
 #   tools/codex-agent.sh simcheck    --packet FILE
+#   tools/codex-agent.sh --check
+#   tools/codex-agent.sh preflight
+#     # report whether Codex is available at CODEX_BIN (never `which codex`);
+#     # exit 0 if present, non-zero with a clear message if absent
 #   DRY_RUN=1 tools/codex-agent.sh conformance --review-packet R --source-packet S
 #     # print the composed command + prompt, invoke nothing
 #
@@ -38,6 +42,21 @@ CODEX_BIN="${CODEX_BIN:-/usr/lib/chatgpt/resources/codex}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 ROLE="${1:-}"
 shift || true
+
+# --check / preflight: report Codex availability by testing the CODEX_BIN
+# path directly. Do NOT use `which codex` or `command -v codex` — the binary
+# is not installed under that name on PATH; only CODEX_BIN is authoritative.
+case "$ROLE" in
+  --check|preflight)
+    if [[ -x "$CODEX_BIN" ]]; then
+      echo "codex-agent: codex available at $CODEX_BIN"
+      exit 0
+    else
+      echo "codex-agent: codex not found at $CODEX_BIN (set CODEX_BIN to override)" >&2
+      exit 1
+    fi
+    ;;
+esac
 
 REVIEW_PACKET=""
 SOURCE_PACKET=""


### PR DESCRIPTION
## Linked Issue

Closes #187

## Exact behavioral claim

Codex availability is now checked via a `tools/codex-agent.sh --check` / `preflight` subcommand that tests `[ -x "$CODEX_BIN" ]` (honoring the `CODEX_BIN` override), instead of the misleading `which codex` — which reports "not installed" because the binary is not on `PATH` under that name (burn-in F5a).

## Scope

tools/codex-agent.sh (new `--check`/`preflight`), tests/tooling/test_codex_agent.sh, and a one-line note in docs/orchestration/agent-verification.md. No change to ledger/metrics tooling.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tools/codex-agent.sh --check` → available at CODEX_BIN (exit 0); `CODEX_BIN=/nonexistent … --check` → clear message (exit 1); `bash tests/tooling/test_codex_agent.sh` → all 32 checks pass.

## Decisions and tradeoffs

Kept the change tightly scoped to the named files; no ADR added and the decisions index untouched (deliberate, to avoid the F8/F9 collision class while several sibling PRs are in flight).

## Known limitations

None beyond what the linked Issue states.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
