### PR TITLE
Source-packet citation sanity: --expect anchor in source-slice (#188)

### DIFF
--- a/docs/source-handling.md
+++ b/docs/source-handling.md
@@ -63,6 +63,23 @@ hardcoded so the superseded `BRP SRD 1.0.2.pdf` is not reachable through this to
 It is a page-slice tool, not a search or indexing system: it does not decide *which*
 pages matter, only extracts the ones it is told.
 
+**Citation sanity check: `--expect <regex>`.** A wrong or truncated page range (e.g.
+citing "p.14" for a table that starts on p.15) slices real-but-irrelevant text
+without complaint — that is how the first #112 source packet omitted the entire
+Hit-Points-by-Location table and Codex silently verified 0 of 45 cells against it
+(burn-in finding F5(b)). When a packet is being built for a conformance gate,
+assert on an anchor from the cited table so a bad range is caught at packet-build
+time instead of discovered later by a reviewer manually re-reading the excerpt:
+
+```bash
+tools/source-slice.py --pages 14-16 --expect "Hit Points by Location"
+```
+
+`--expect` is opt-in and repeatable; it exits non-zero and names any missing
+anchor. It is still a presence check on the range already chosen, not a way to
+locate the range — it does not search the document for the anchor, it only
+confirms the anchor is in the text this invocation already sliced.
+
 **Locating the pages.** Two paths, depending on what the Issue says:
 
 - **Issue names exact pages.** The orchestrator runs `source-slice.py` directly and

--- a/tests/tooling/test_source_slice.sh
+++ b/tests/tooling/test_source_slice.sh
@@ -148,6 +148,51 @@ else
   if [ "$(cat "$OUT_FILE")" = "$OUT1" ]; then ok "--output: file content matches stdout content"; else
     fail "--output: file content differs from stdout content"
   fi
+
+  # -------------------------------------------------------------------------
+  # 7. --expect: anchor present passes; anchor absent fails loudly (Issue #188).
+  # -------------------------------------------------------------------------
+  # Pick a word we know is on page 5 from the already-fetched OUT1 body (skip the
+  # header lines, which always start with '#').
+  ANCHOR_WORD="$(printf '%s\n' "$OUT1" | grep -v '^#' | grep -oE '[A-Za-z]{5,}' | head -n1 || true)"
+
+  if [ -n "$ANCHOR_WORD" ]; then
+    set +e
+    EXPECT_OK_OUT="$(python3 "$SCRIPT" --pages 5 --expect "$ANCHOR_WORD" 2>&1)"
+    EXPECT_OK_RC=$?
+    set -e
+    if [ "$EXPECT_OK_RC" -eq 0 ]; then ok "--expect: present anchor exits zero"; else
+      fail "--expect: present anchor '$ANCHOR_WORD' unexpectedly failed (rc=$EXPECT_OK_RC): $EXPECT_OK_OUT"
+    fi
+    if [ "$EXPECT_OK_OUT" = "$OUT1" ]; then
+      ok "--expect: present anchor does not change packet output"
+    else
+      fail "--expect: present anchor changed packet output"
+    fi
+  else
+    skip "--expect present-anchor case: could not find a stable word on page 5"
+  fi
+
+  set +e
+  EXPECT_MISSING_OUT="$(python3 "$SCRIPT" --pages 5 --expect "ZzQqXxNoSuchAnchorInThisDocument999" 2>&1)"
+  EXPECT_MISSING_RC=$?
+  set -e
+  if [ "$EXPECT_MISSING_RC" -ne 0 ]; then ok "--expect: absent anchor exits nonzero"; else
+    fail "--expect: absent anchor expected nonzero exit, got $EXPECT_MISSING_RC"
+  fi
+  if [[ "$EXPECT_MISSING_OUT" == *"ZzQqXxNoSuchAnchorInThisDocument999"* ]]; then
+    ok "--expect: failure message names the missing anchor"
+  else
+    fail "--expect: failure message did not name the missing anchor: $EXPECT_MISSING_OUT"
+  fi
+
+  # No --expect at all: behavior must be unchanged (already covered by OUT1/OUT2
+  # above, which never pass --expect).
+  if [ "$OUT1" = "$OUT2" ]; then
+    ok "--expect: omitting the flag leaves existing behavior unchanged"
+  else
+    fail "--expect: omitting the flag changed existing behavior"
+  fi
 fi
 
 echo

--- a/tools/source-slice.py
+++ b/tools/source-slice.py
@@ -16,6 +16,14 @@ reports the range).
     tools/source-slice.py --pages 130-132 --layout
     tools/source-slice.py --pages 130 --bbox
     tools/source-slice.py --pages 5-9 --output /tmp/packet.txt
+    tools/source-slice.py --pages 130 --expect "Hit Points by Location"
+
+`--expect <regex>` (repeatable) is an opt-in sanity check on the already-chosen
+page range, not a search feature: it does not decide which pages to slice, it
+only asserts that a regex the caller already expects to be present actually
+appears in the sliced body text. If any given pattern is missing, the tool
+exits non-zero and names the missing anchor instead of silently handing back a
+packet that does not cover what it claims to. See `docs/source-handling.md`.
 
 The source file is hardcoded. This tool NEVER accepts an arbitrary --file — the
 superseded `BRP SRD 1.0.2.pdf` must never be reachable through this path. Before
@@ -149,6 +157,29 @@ def run_pdftotext(first: int, last: int, mode: str) -> str:
     return result.stdout
 
 
+def check_expected_anchors(body: str, patterns: list[str]) -> None:
+    """Raise SourceSliceError naming any --expect pattern absent from body.
+
+    This is a presence check on the already-sliced text, not a search: it does
+    not locate pages or sections, it only confirms the page range the caller
+    already chose actually contains what they expect it to.
+    """
+    missing = []
+    for pattern in patterns:
+        try:
+            found = re.search(pattern, body) is not None
+        except re.error as e:
+            raise SourceSliceError(f"invalid --expect regex {pattern!r}: {e}") from e
+        if not found:
+            missing.append(pattern)
+    if missing:
+        joined = "\n  - ".join(missing)
+        raise SourceSliceError(
+            "sliced text is missing expected anchor(s) — the page range may be "
+            f"wrong or truncated:\n  - {joined}"
+        )
+
+
 def build_packet(pages_spec: str, first: int, last: int, mode: str, pinned_hash: str, body: str) -> str:
     header = (
         "# BRP source packet\n"
@@ -172,6 +203,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--layout", action="store_true", help="preserve column/table layout (pdftotext -layout)")
     parser.add_argument("--bbox", action="store_true", help="emit bounding-box glyph data (pdftotext -bbox)")
     parser.add_argument("--output", metavar="FILE", help="write the packet to FILE instead of stdout")
+    parser.add_argument(
+        "--expect",
+        metavar="REGEX",
+        action="append",
+        default=[],
+        help="regex that must be present in the sliced text (repeatable); "
+        "fails loudly if any are absent (opt-in citation sanity check)",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -179,6 +218,8 @@ def main(argv: list[str] | None = None) -> int:
         pinned_hash = verify_source()
         mode = extract_mode(args.layout, args.bbox)
         body = run_pdftotext(first, last, mode)
+        if args.expect:
+            check_expected_anchors(body, args.expect)
         packet = build_packet(args.pages, first, last, mode, pinned_hash, body)
     except SourceSliceError as e:
         print(f"source-slice: {e}", file=sys.stderr)


### PR DESCRIPTION
## Linked Issue

Closes #188

## Exact behavioral claim

A source packet can now assert it captured the cited material: `tools/source-slice.py --expect <regex>` (repeatable) exits non-zero and names any missing anchor after slicing, so a truncated/wrong page citation is caught at build time instead of reaching a conformance gate with a silent coverage gap (burn-in F5b). Behavior without `--expect` is unchanged.

## Scope

tools/source-slice.py (opt-in `--expect`), tests/tooling/test_source_slice.sh, docs/source-handling.md. source-slice stays a page-slicer — no search/indexing added.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_source_slice.sh` → all 21 checks pass, including anchor-present (pass), anchor-absent (non-zero, names the anchor), and a no-`--expect` regression check.

## Decisions and tradeoffs

Kept the change tightly scoped to the named files; no ADR added and the decisions index untouched (deliberate, to avoid the F8/F9 collision class while several sibling PRs are in flight).

## Known limitations

None beyond what the linked Issue states.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
