### PR TITLE
Deterministic decision-index drift guard (#189)

### DIFF
--- a/tests/tooling/test_adr_index_check.sh
+++ b/tests/tooling/test_adr_index_check.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# tests/tooling/test_adr_index_check.sh — fixture tests for
+# tools/adr-index-check.sh (Issue #189).
+#
+# Proves the deterministic decision-index drift guard fails on a duplicate
+# ADR number, a numbering gap, an index row with no matching file, and an
+# ADR file with no index row — and passes on a clean index. Also proves it
+# passes against the real docs/decisions/ on this branch.
+#
+# Run directly:
+#   tests/tooling/test_adr_index_check.sh
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/adr-index-check.sh"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+
+# ---------------------------------------------------------------------------
+# Helper: build a fixture decisions dir from a heredoc README body plus a
+# list of filenames to create (each gets minimal placeholder content).
+# ---------------------------------------------------------------------------
+make_fixture() {
+  local name="$1"; shift
+  local dir="$WORKDIR/$name"
+  mkdir -p "$dir"
+  cat > "$dir/README.md"
+  for f in "$@"; do
+    printf '# %s\n\nStub decision record.\n' "$f" > "$dir/$f"
+  done
+  printf '%s' "$dir"
+}
+
+run_check() {
+  local dir="$1"
+  set +e
+  OUT="$("$SCRIPT" "$dir" 2>&1)"
+  RC=$?
+  set -e
+}
+
+# ---------------------------------------------------------------------------
+# 1. Clean index (contiguous, 1:1) — must PASS.
+# ---------------------------------------------------------------------------
+CLEAN_DIR="$(make_fixture clean \
+  0001-first.md 0002-second.md 0003-third.md <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+| [0002](0002-second.md) | Second | Accepted |
+| [0003](0003-third.md) | Third | Accepted |
+EOF
+)"
+run_check "$CLEAN_DIR"
+if [ "$RC" -eq 0 ]; then ok "clean index: passes"; else fail "clean index: expected pass, got FAIL: $OUT"; fi
+
+# ---------------------------------------------------------------------------
+# 2. Duplicate ADR number in the index — must FAIL.
+# ---------------------------------------------------------------------------
+DUP_DIR="$(make_fixture duplicate \
+  0001-first.md 0002-second.md <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+| [0002](0002-second.md) | Second | Accepted |
+| [0002](0002-second.md) | Second (again) | Accepted |
+EOF
+)"
+run_check "$DUP_DIR"
+if [ "$RC" -ne 0 ]; then ok "duplicate ADR number: fails"; else fail "duplicate ADR number: expected FAIL, got pass"; fi
+if [[ "${OUT,,}" == *duplicate* ]]; then ok "duplicate ADR number: message mentions duplicate"; else fail "duplicate ADR number: message missing 'duplicate': $OUT"; fi
+
+# ---------------------------------------------------------------------------
+# 3. Numbering gap — must FAIL.
+# ---------------------------------------------------------------------------
+GAP_DIR="$(make_fixture gap \
+  0001-first.md 0003-third.md <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+| [0003](0003-third.md) | Third | Accepted |
+EOF
+)"
+run_check "$GAP_DIR"
+if [ "$RC" -ne 0 ]; then ok "numbering gap: fails"; else fail "numbering gap: expected FAIL, got pass"; fi
+if [[ "${OUT,,}" == *gap* ]]; then ok "numbering gap: message mentions gap"; else fail "numbering gap: message missing 'gap': $OUT"; fi
+
+# ---------------------------------------------------------------------------
+# 4. Orphan index row (no matching file) — must FAIL.
+# ---------------------------------------------------------------------------
+ORPHAN_ROW_DIR="$(make_fixture orphan_row \
+  0001-first.md <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+| [0002](0002-second.md) | Second | Accepted |
+EOF
+)"
+run_check "$ORPHAN_ROW_DIR"
+if [ "$RC" -ne 0 ]; then ok "orphan index row: fails"; else fail "orphan index row: expected FAIL, got pass"; fi
+if [[ "${OUT,,}" == *"no matching file"* ]]; then ok "orphan index row: message mentions missing file"; else fail "orphan index row: message missing expected text: $OUT"; fi
+
+# ---------------------------------------------------------------------------
+# 5. Orphan file (no index row) — must FAIL.
+# ---------------------------------------------------------------------------
+ORPHAN_FILE_DIR="$(make_fixture orphan_file \
+  0001-first.md 0002-second.md <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+EOF
+)"
+run_check "$ORPHAN_FILE_DIR"
+if [ "$RC" -ne 0 ]; then ok "orphan file: fails"; else fail "orphan file: expected FAIL, got pass"; fi
+if [[ "${OUT,,}" == *"no matching index row"* ]]; then ok "orphan file: message mentions missing index row"; else fail "orphan file: message missing expected text: $OUT"; fi
+
+# ---------------------------------------------------------------------------
+# 6. The real repo's docs/decisions/ must PASS (the acceptance-critical case).
+# ---------------------------------------------------------------------------
+run_check "$ROOT/docs/decisions"
+if [ "$RC" -eq 0 ]; then ok "real docs/decisions/: passes"; else fail "real docs/decisions/: expected pass, got FAIL: $OUT"; fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "test_adr_index_check: ALL PASS"
+  exit 0
+else
+  echo "test_adr_index_check: $FAILURES FAILURE(S)"
+  exit 1
+fi

--- a/tools/adr-index-check.sh
+++ b/tools/adr-index-check.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# tools/adr-index-check.sh — deterministic decision-index drift guard (Issue #189).
+#
+# Checks that docs/decisions/README.md's index table and the docs/decisions/
+# directory agree:
+#   1. no ADR number appears in the index more than once (duplicate row),
+#   2. the index numbers are contiguous starting at the lowest one present
+#      (no gap),
+#   3. every index row has a matching docs/decisions/NNNN-*.md file, and
+#   4. every docs/decisions/NNNN-*.md file has a matching index row.
+#
+# Detection only (Issue #185 covers allocation/collision prevention at
+# authoring time). Usage:
+#   tools/adr-index-check.sh [decisions-dir]
+# Defaults to docs/decisions relative to the repo root.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIR="${1:-$ROOT/docs/decisions}"
+README="$DIR/README.md"
+
+fail=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf 'FAIL   %s\n' "$1"; fail=1; }
+
+if [ ! -f "$README" ]; then
+  bad "missing index file: $README"
+  echo "adr-index-check: FAIL"
+  exit 1
+fi
+
+# --- Collect index-row ADR numbers ------------------------------------------
+# Row shape: | [0024](0024-hit-locations.md) | ... | ... |
+mapfile -t rows < <(grep -oE '^\| \[[0-9]{4}\]\([0-9]{4}-[^)]+\.md\)' "$README")
+
+declare -A row_count=()
+declare -A row_file_mismatch=()
+row_numbers=()
+for row in "${rows[@]}"; do
+  link_num="$(printf '%s' "$row" | grep -oE '^\| \[[0-9]{4}\]' | grep -oE '[0-9]{4}')"
+  file_ref="$(printf '%s' "$row" | grep -oE '\([0-9]{4}-[^)]+\.md\)' | tr -d '()')"
+  file_num="${file_ref%%-*}"
+  row_numbers+=("$link_num")
+  row_count["$link_num"]=$(( ${row_count["$link_num"]:-0} + 1 ))
+  if [ "$link_num" != "$file_num" ]; then
+    row_file_mismatch["$link_num"]="$file_ref"
+  fi
+done
+
+if [ "${#row_numbers[@]}" -eq 0 ]; then
+  bad "no index rows found in $README (expected '| [NNNN](NNNN-slug.md) | ... |' rows)"
+fi
+
+# 1. Duplicates
+for num in "${!row_count[@]}"; do
+  if [ "${row_count[$num]}" -gt 1 ]; then
+    bad "duplicate ADR number in index: $num appears ${row_count[$num]} times"
+  fi
+done
+
+# 2. Gaps (contiguous numbering starting at the lowest index number present)
+if [ "${#row_numbers[@]}" -gt 0 ]; then
+  mapfile -t sorted_unique < <(printf '%s\n' "${row_numbers[@]}" | sort -un)
+  lo="${sorted_unique[0]}"
+  hi="${sorted_unique[-1]}"
+  lo_dec=$((10#$lo))
+  hi_dec=$((10#$hi))
+  missing=""
+  for ((n = lo_dec; n <= hi_dec; n++)); do
+    padded="$(printf '%04d' "$n")"
+    found=0
+    for num in "${sorted_unique[@]}"; do
+      if [ "$num" = "$padded" ]; then found=1; break; fi
+    done
+    if [ "$found" -eq 0 ]; then missing="$missing $padded"; fi
+  done
+  if [ -n "$missing" ]; then
+    bad "gap in ADR numbering between $lo and $hi — missing:$missing"
+  fi
+fi
+
+# 3. Index row -> file must exist
+for num in "${row_numbers[@]}"; do
+  match="$(find "$DIR" -maxdepth 1 -name "${num}-*.md" 2>/dev/null)"
+  if [ -z "$match" ]; then
+    bad "index row for $num has no matching file $DIR/${num}-*.md"
+  fi
+done
+for num in "${!row_file_mismatch[@]}"; do
+  bad "index row link number $num does not match its own filename reference (${row_file_mismatch[$num]})"
+done
+
+# 4. File -> index row must exist
+declare -A row_present=()
+for num in "${row_numbers[@]}"; do row_present["$num"]=1; done
+while IFS= read -r -d '' f; do
+  base="$(basename "$f")"
+  [ "$base" = "README.md" ] && continue
+  num="${base%%-*}"
+  if [[ ! "$num" =~ ^[0-9]{4}$ ]]; then
+    bad "unrecognized decision file name (expected NNNN-slug.md): $base"
+    continue
+  fi
+  if [ -z "${row_present[$num]:-}" ]; then
+    bad "$base has no matching index row for $num in README.md"
+  fi
+done < <(find "$DIR" -maxdepth 1 -name '*.md' -print0)
+
+if [ "$fail" = 0 ]; then
+  ok "decision index consistent: ${#row_numbers[@]} rows, no duplicates, no gaps, 1:1 with files"
+  echo "adr-index-check: PASS"
+else
+  echo "adr-index-check: FAIL"
+fi
+exit "$fail"

--- a/tools/orchestration-policy.sh
+++ b/tools/orchestration-policy.sh
@@ -71,6 +71,21 @@ else
   printf '%s\n' "$refs" "$usings" | sed '/^$/d;s/^/       /'
 fi
 
+# 5. Decision-index drift guard (burn-in F9): README.md and docs/decisions/*.md
+#    must agree — no duplicate ADR numbers, no gaps, 1:1 rows-to-files.
+section "decision-index consistency (ADR drift guard)"
+ADR_CHECK=tools/adr-index-check.sh
+if [ ! -x "$ADR_CHECK" ]; then
+  bad "missing or non-executable $ADR_CHECK"
+else
+  if adr_out="$("$ADR_CHECK" 2>&1)"; then
+    ok "docs/decisions/README.md matches docs/decisions/*.md (no duplicates/gaps/orphans)"
+  else
+    bad "decision index drift detected:"
+    printf '%s\n' "$adr_out" | sed 's/^/       /'
+  fi
+fi
+
 section "result"
 if [ "$fail" = 0 ]; then echo "orchestration-policy: PASS"; else echo "orchestration-policy: FAIL"; fi
 exit "$fail"


### PR DESCRIPTION
## Linked Issue

Closes #189

## Exact behavioral claim

A deterministic decision-index drift guard now fails a change whose `docs/decisions/README.md` has a duplicate ADR number, a numbering gap, an index row with no matching file, or an ADR file with no index row — catching the F9 class in CI/orchestration-policy instead of at the expensive architecture-review gate.

## Scope

New tools/adr-index-check.sh (takes an optional decisions-dir for fixture testing), wired into tools/orchestration-policy.sh alongside the other deterministic checks; new tests/tooling/test_adr_index_check.sh. No decision records modified.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_adr_index_check.sh` → 10/10 (clean index passes; duplicate/gap/orphan-row/orphan-file all fail; the real docs/decisions/ passes). `bash tools/orchestration-policy.sh` → PASS on the real 0001–0026 index.

## Decisions and tradeoffs

Kept the change tightly scoped to the named files; no ADR added and the decisions index untouched (deliberate, to avoid the F8/F9 collision class while several sibling PRs are in flight).

## Known limitations

None beyond what the linked Issue states.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
