### PR TITLE
Guard agent-verify --post against gh-git head lag (#191)

### DIFF
--- a/tests/tooling/test_agent_verify.sh
+++ b/tests/tooling/test_agent_verify.sh
@@ -22,7 +22,12 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT/tools/agent-verify.sh"
 
 WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
+# Issue #191's converged-head-guard cases stash a throwaway remote-tracking
+# ref under the real repo's refs/remotes/origin/ namespace (no network, no
+# effect on any real branch) so the guard's `git rev-parse origin/<ref>` has
+# something deterministic to compare against; clean it up unconditionally.
+FIXTURE_REF="refs/remotes/origin/agent-verify-test-fixture-branch"
+trap 'rm -rf "$WORKDIR"; git -C "$ROOT" update-ref -d "$FIXTURE_REF" >/dev/null 2>&1 || true' EXIT
 
 FAILURES=0
 ok()   { printf 'ok   - %s\n' "$1"; }
@@ -67,6 +72,7 @@ emit() {
 }
 
 HEAD_SHA="${MOCK_HEAD_SHA:-deadbeef1234567890deadbeef1234567890dead}"
+HEAD_REF_NAME="${MOCK_HEAD_REF_NAME:-agent-verify-test-branch}"
 PR_BODY="${MOCK_PR_BODY:-Closes #136}"
 CI_CONCLUSION="${MOCK_CI_CONCLUSION:-success}"
 
@@ -74,8 +80,8 @@ case "$1 $2" in
   "pr view")
     jsonf="$(find_flag_value --json "$@" || true)"
     case "$jsonf" in
-      headRefOid,url,state)
-        emit "{\"headRefOid\":\"$HEAD_SHA\",\"url\":\"https://example.invalid/pull/999\",\"state\":\"OPEN\"}" "$@" ;;
+      headRefOid,headRefName,url,state)
+        emit "{\"headRefOid\":\"$HEAD_SHA\",\"headRefName\":\"$HEAD_REF_NAME\",\"url\":\"https://example.invalid/pull/999\",\"state\":\"OPEN\"}" "$@" ;;
       body)
         emit "{\"body\":\"$PR_BODY\"}" "$@" ;;
       *) echo "mock gh: unhandled pr view --json $jsonf" >&2; exit 1 ;;
@@ -222,6 +228,37 @@ DIFFFILE="$WORKDIR/numeric.diff"
 printf '%s\n' "$NUMERIC_DIFF" > "$DIFFFILE"
 route8_direct="$("$ROOT/tools/route.sh" --json --diff-file "$DIFFFILE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["route"])')"
 assert_eq "case8: agrees with tools/route.sh --diff-file on the identical patch" "$route8_direct" "$route8"
+
+# --- case 9: converged-head guard refuses --post on a gh/git head mismatch
+# (Issue #191, burn-in F10) ------------------------------------------------- #
+# Seed the fixture remote-tracking ref with a real ancestor commit (so `git
+# rev-parse` succeeds), but tell the gh stub to report a DIFFERENT ancestor as
+# the PR's head — simulating gh lagging behind git after a push. Both are
+# deliberately NOT the checked-out HEAD, so agent-verify.sh still takes the
+# `gh pr diff` route-derivation path like every other case here, rather than
+# the on-PR-head `route.sh --base` path (whose required-gate set would depend
+# on this branch's own uncommitted diff).
+PR_HEAD_SHA="$(git -C "$ROOT" rev-parse HEAD~2)"
+STALE_SHA="$(git -C "$ROOT" rev-parse HEAD~3)"
+git -C "$ROOT" update-ref "$FIXTURE_REF" "$PR_HEAD_SHA"
+
+rc9=0
+err9="$(MOCK_HEAD_SHA="$STALE_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
+  run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --post 2>&1 1>/dev/null)" || rc9=$?
+assert_eq "case9: --post refuses on gh/git head mismatch" "2" "$rc9"
+assert_contains "case9: refusal message names the mismatch" "$err9" "refusing to post"
+assert_contains "case9: refusal message cites F10" "$err9" "F10"
+
+# --- case 10: converged-head guard is a no-op when gh and git agree -------- #
+git -C "$ROOT" update-ref "$FIXTURE_REF" "$PR_HEAD_SHA"
+out10="$(MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
+  run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --post)"
+assert_contains "case10: --post proceeds and posts when heads converge" "$out10" "posted: agent-verification = success"
+
+rc10=0
+MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
+  run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --post >/dev/null || rc10=$?
+assert_eq "case10: exit 0 when converged heads and gates all pass" "0" "$rc10"
 
 echo
 if [ "$FAILURES" -eq 0 ]; then

--- a/tools/agent-verify.sh
+++ b/tools/agent-verify.sh
@@ -23,7 +23,7 @@
 #
 # Usage:
 #   tools/agent-verify.sh <PR#> [--gate NAME=pass|fail|skip ...] [--base REF]
-#                               [--post] [--evidence] [--json] [--json-out FILE]
+#                               [--post] [--wait] [--evidence] [--json] [--json-out FILE]
 #
 #   * `ci` is read from GitHub (the `build-and-test` check-run) — never supplied.
 #   * every OTHER required gate must be supplied via --gate; a missing one leaves
@@ -32,6 +32,13 @@
 #     --evidence additionally writes the per-gate block into the PR body.
 #   * --json prints the canonical evidence object to stdout as JSON (nothing else
 #     is written to stdout in that mode); --json-out FILE writes it to a file.
+#   * --post refuses (clear message, non-zero) if the gh-reported PR head
+#     disagrees with the branch's actual git ref — the gh API can lag several
+#     polls behind git after a push/update-branch (burn-in F10), and acting on
+#     that stale read risks posting the status onto a superseded head.
+#     --wait polls (gh, then git) until the two converge before proceeding; the
+#     dry-run path (no --post) is unaffected by the guard, though it still runs
+#     under --wait if requested.
 #
 # Exit: 0 if the aggregate is success, 1 otherwise (so a caller can branch on it).
 set -euo pipefail
@@ -40,7 +47,7 @@ CONTEXT="agent-verification"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 die() { echo "agent-verify: $*" >&2; exit 2; }
 
-PR=""; BASE="origin/main"; POST=0; EVIDENCE=0; JSON=0; JSON_OUT=""
+PR=""; BASE="origin/main"; POST=0; EVIDENCE=0; JSON=0; JSON_OUT=""; WAIT=0
 declare -A GATE=()
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -50,6 +57,7 @@ while [ $# -gt 0 ]; do
             GATE["$n"]="$s"; shift 2 ;;
     --base) BASE="${2:-}"; shift 2 ;;
     --post) POST=1; shift ;;
+    --wait) WAIT=1; shift ;;
     --evidence) EVIDENCE=1; shift ;;
     --json) JSON=1; shift ;;
     --json-out) [ $# -ge 2 ] || die "--json-out needs FILE"; JSON_OUT="$2"; shift 2 ;;
@@ -57,13 +65,56 @@ while [ $# -gt 0 ]; do
     *)  [ -z "$PR" ] || die "unexpected argument: $1"; PR="$1"; shift ;;
   esac
 done
-[ -n "$PR" ] || die "usage: agent-verify.sh <PR#> [--gate NAME=STATE ...] [--post] [--evidence] [--json] [--json-out FILE]"
+[ -n "$PR" ] || die "usage: agent-verify.sh <PR#> [--gate NAME=STATE ...] [--post] [--wait] [--evidence] [--json] [--json-out FILE]"
 
 # --- resolve the PR ------------------------------------------------------- #
-read -r HEAD_SHA PR_URL PR_STATE < <(gh pr view "$PR" \
-  --json headRefOid,url,state --jq '[.headRefOid, .url, .state] | @tsv') \
-  || die "cannot read PR #$PR"
+read_pr_head() {
+  read -r HEAD_SHA HEAD_REF_NAME PR_URL PR_STATE < <(gh pr view "$PR" \
+    --json headRefOid,headRefName,url,state \
+    --jq '[.headRefOid, .headRefName, .url, .state] | @tsv') \
+    || die "cannot read PR #$PR"
+}
+read_pr_head
 [ -n "$HEAD_SHA" ] || die "PR #$PR has no head SHA"
+[ -n "$HEAD_REF_NAME" ] || die "PR #$PR has no head branch name"
+
+# --- converged-head guard (burn-in F10) ------------------------------------ #
+# `gh pr view --json headRefOid` can lag several polls behind the branch's
+# real git tip right after a push/update-branch. Acting on that stale read —
+# posting `agent-verification`, or merging — risks silently targeting a
+# SUPERSEDED head. Treat git, the actual mover of the ref, as ground truth:
+# re-derive the branch's tip locally and refuse unless it agrees with gh.
+#
+# Prefers an already-known remote-tracking ref (no network) and only falls
+# back to a fetch if the ref is not present locally yet, mirroring the BASE
+# resolution above.
+GIT_HEAD_SHA=""
+git_head_for_ref() {
+  local ref="$1" sha
+  sha="$(git -C "$ROOT" rev-parse --quiet --verify "origin/$ref" 2>/dev/null || true)"
+  if [ -z "$sha" ]; then
+    git -C "$ROOT" fetch -q origin "$ref" >/dev/null 2>&1 || true
+    sha="$(git -C "$ROOT" rev-parse --quiet --verify "origin/$ref" 2>/dev/null || true)"
+  fi
+  printf '%s' "$sha"
+}
+converged() {
+  GIT_HEAD_SHA="$(git_head_for_ref "$HEAD_REF_NAME")"
+  [ -n "$GIT_HEAD_SHA" ] && [ "$GIT_HEAD_SHA" = "$HEAD_SHA" ]
+}
+
+if [ "$WAIT" = 1 ]; then
+  POLL_ATTEMPTS="${AGENT_VERIFY_POLL_ATTEMPTS:-12}"
+  POLL_INTERVAL="${AGENT_VERIFY_POLL_INTERVAL:-5}"
+  attempt=1
+  until converged; do
+    [ "$attempt" -ge "$POLL_ATTEMPTS" ] && \
+      die "gave up waiting for gh/git head convergence on PR #$PR after $POLL_ATTEMPTS polls (gh head=$HEAD_SHA, git head=${GIT_HEAD_SHA:-<none>} for branch $HEAD_REF_NAME); the gh API is still lagging behind git (see burn-in F10) — refusing to proceed"
+    sleep "$POLL_INTERVAL"
+    attempt=$((attempt + 1))
+    read_pr_head
+  done
+fi
 
 # --- resolve the linked issue (best-effort; used both for the route's issue-
 # intent floor and for the evidence object) -------------------------------- #
@@ -215,6 +266,7 @@ print("\n".join(out))
 }
 
 if [ "$POST" = 1 ]; then
+  converged || die "refusing to post: gh reports head $HEAD_SHA for branch $HEAD_REF_NAME but git's actual tip is ${GIT_HEAD_SHA:-<unknown>} — the gh API is lagging behind git (burn-in F10); acting now would post onto a stale/superseded head. Re-run (optionally with --wait) once they converge."
   gh api -X POST "repos/{owner}/{repo}/statuses/$HEAD_SHA" \
     -f state="$STATE" -f context="$CONTEXT" -f description="$DESC" -f target_url="$PR_URL" \
     --jq '"posted: \(.context) = \(.state)"' || die "failed to post status"


### PR DESCRIPTION
## Linked Issue

Closes #191

## Exact behavioral claim

Posting `agent-verification` now refuses to act on a stale head: `tools/agent-verify.sh --post` first checks the `gh`-reported PR head equals `git rev-parse origin/<headRef>` and dies with a clear message (citing F10) if they disagree, so it can no longer post onto a superseded SHA while the gh API lags git. A `--wait` flag polls to convergence.

## Scope

tools/agent-verify.sh (new converged-head guard on `--post`, `--wait` flag, `read_pr_head()` refactor), tests/tooling/test_agent_verify.sh. Dry-run path unchanged.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_agent_verify.sh` → all 30 checks pass (25 existing + 5 new: guard fires on head disagreement, posts when heads agree).

## Decisions and tradeoffs

Kept the change tightly scoped to the named files; no ADR added and the decisions index untouched (deliberate, to avoid the F8/F9 collision class while several sibling PRs are in flight).

## Known limitations

None beyond what the linked Issue states.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
