### PR TITLE
Document worktree-isolation discipline for dispatched agents (#192)

### DIFF
--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -115,6 +115,15 @@ that implements an already-settled one, and `case-author` is a content-producing
 **Verification agents get read-only tools.** An agent that can edit what it is checking
 will eventually make the check pass instead of making the code right.
 
+**Dispatch implementer and writeup agents with worktree isolation.** Burn-in finding
+F12 (`docs/orchestration/agent-verification-burn-in.md`): the #174 writeup agent was
+dispatched without worktree isolation, created its feature branch in the primary
+checkout, and left it there — the primary tree had to be manually restored
+(`git checkout main` plus a fast-forward) during cleanup. Give a dispatched
+implementer or writeup agent its own worktree so the primary checkout is never left
+stranded on a feature branch. If a non-isolated agent is used deliberately, expect to
+restore the primary tree afterward the same way.
+
 ## What verification passes should look for
 
 `docs/source-handling.md` lists the defect classes that have actually bitten this


### PR DESCRIPTION
## Linked Issue

Closes #192

## Exact behavioral claim

The agent-team docs now record the worktree-isolation convention for dispatched implementer/writeup agents, so the primary checkout is never left stranded on a feature branch (burn-in F12).

## Scope

docs/agent-team.md only — one bullet in the routing-rules section. No code change.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tools/orchestration-policy.sh` → PASS (docs-only change).

## Decisions and tradeoffs

Kept the change tightly scoped to the named files; no ADR added and the decisions index untouched (deliberate, to avoid the F8/F9 collision class while several sibling PRs are in flight).

## Known limitations

None beyond what the linked Issue states.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
