### PR TITLE
Merge-time ADR-number allocation (#185)

### DIFF
--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -124,6 +124,38 @@ implementer or writeup agent its own worktree so the primary checkout is never l
 stranded on a feature branch. If a non-isolated agent is used deliberately, expect to
 restore the primary tree afterward the same way.
 
+## Authoring a design-decision record (ADR) — the `NNNN` placeholder
+
+Never pick a `docs/decisions/NNNN-slug.md` number by reading the highest one
+committed on your own branch. Two authors on parallel branches off the same base can
+both see the same "latest" number and both claim the next one — exactly what happened
+on #170/#171 (burn-in finding **F8**: both authored `0025`; the collision only
+surfaced at merge time and had to be renumbered by hand).
+
+Instead, write the record with the literal placeholder token `NNNN` everywhere its
+number would appear: the filename (`docs/decisions/NNNN-slug.md`), the `# NNNN. Title`
+header, any self-reference in the body, and the `docs/decisions/README.md` row you add
+for it. Do not guess a number and do not reserve one in a shared file — either still
+races under true parallelism (see `docs/decisions/0027-adr-number-allocation.md` for
+why a `next-adr.sh`-style helper and a reservation registry were both rejected).
+
+The number is assigned exactly once, by `tools/assign-adr-number.sh`, run as a
+pre-merge step against the tree about to be merged — today that means whoever is
+merging the PR runs it by hand before merging, the same trust level as every other
+`tools/*.sh` gate in this repo. It finds the placeholder, computes the next free
+number from `docs/decisions/`, renames the file, and rewrites every reference
+(header, README row, any other Markdown file linking to the placeholder's old
+filename). It is safe to run more than once — a second run after a successful
+assignment finds no placeholder left and refuses cleanly rather than reassigning.
+See `docs/decisions/0027-adr-number-allocation.md` for the full mechanism and the
+rejected alternatives, and `tests/tooling/test_assign_adr_number.sh` for the
+concurrent-authoring case this fixes.
+
+`tools/adr-index-check.sh` (run by `tools/orchestration-policy.sh`) still checks the
+resulting index for a duplicate number, a gap, or a row/file mismatch — that guard is
+unchanged by this convention and continues to run as the after-the-fact drift check,
+not a replacement for assigning the number correctly in the first place.
+
 ## What verification passes should look for
 
 `docs/source-handling.md` lists the defect classes that have actually bitten this

--- a/docs/decisions/0027-adr-number-allocation.md
+++ b/docs/decisions/0027-adr-number-allocation.md
@@ -1,0 +1,109 @@
+# 0027. ADR-number allocation is serialized at merge time, not authoring time
+
+## Status
+
+Accepted — 2026-09-01. Resolves #185.
+
+## Context
+
+Burn-in finding **F8** (`docs/orchestration/agent-verification-burn-in.md`): #170 and
+#171 ran in parallel, each read `0024` as the latest committed decision record on its
+own base, and each authored `0025`. The collision only surfaced at merge time, and the
+orchestrator had to renumber #170's record to `0026` by hand, updating every reference
+(its own header, its `docs/decisions/README.md` row, and any cross-links) manually.
+
+ADR numbers were being chosen at *authoring* time, by eyeballing the latest committed
+record on the author's own branch. That races under exactly the condition the agent
+team is built for: multiple implementers working in parallel off a common, possibly
+stale, base. `tools/adr-index-check.sh` (Issue #189) detects the resulting drift — a
+duplicate number, a gap — after the fact; it does not prevent it.
+
+This is a house rule, not a sourced mechanic — orchestration process, out of scope for
+`docs/source-handling.md`.
+
+## Decision
+
+**Merge-time assignment.** A design-decision author writes their ADR with a literal
+placeholder number, `NNNN`, everywhere the number would normally appear: the filename
+(`docs/decisions/NNNN-slug.md`), the `# NNNN. Title` header, any self-reference inside
+the body, and the `docs/decisions/README.md` index row they add. Two authors on
+parallel branches can both write `NNNN` — there is nothing to collide over, because no
+number has actually been chosen yet.
+
+The number is assigned exactly once, by `tools/assign-adr-number.sh`, run as a
+pre-merge step against the tree that is about to land (i.e. by whoever/whatever is
+about to merge the PR — the orchestrator, run by hand today; nothing here requires a
+new automated merge gate). The tool:
+
+1. Finds the `NNNN-*.md` placeholder(s) in `docs/decisions/`.
+2. Computes the next free four-digit number from the union of existing
+   `docs/decisions/NNNN-*.md` filenames and `README.md` index rows.
+3. Renames the file and rewrites every `NNNN` occurrence inside it to the assigned
+   number.
+4. Rewrites the matching `README.md` row (matched by the placeholder's *old filename*,
+   so an unrelated in-flight placeholder with a different slug is left alone).
+5. Rewrites any other tracked Markdown file that links to the placeholder's exact old
+   filename.
+
+If two placeholders are present when the tool runs (the literal #170/#171 shape,
+replayed against a single merged tree instead of two independent branches), it assigns
+them sequential numbers in filename order — deterministic, not a second race, because
+by the time the tool runs there is exactly one tree and one invocation.
+
+### Considered and rejected
+
+- **(a) A `tools/next-adr.sh` helper authors call themselves.** Simplest to build, but
+  does not fix the bug: two authors can each call it before either has merged, and
+  both still get told the same "next" number. Rejected — this is the scheme that
+  already failed on #170/#171 in spirit (the number is still picked from the
+  possibly-stale state each author happens to see).
+- **(c) A reservation registry** — a committed file where a number is claimed before
+  authoring begins. Explicit and auditable, but it is itself an append-only file that
+  two parallel branches can both append to and then merge — the exact F9-class merge
+  hazard (`docs/orchestration/agent-verification-burn-in.md`) this issue is trying to
+  avoid, just relocated to a different file. Rejected.
+- **(b) Merge-time assignment (chosen).** The only option under which the number is
+  read from, and written to, a single tree at a single point in (logical) time. It
+  costs a merge-time step and reference-rewriting, both of which
+  `tools/assign-adr-number.sh` automates so the cost is one command, not manual
+  renumbering.
+
+### Bootstrapping this very record
+
+`tools/assign-adr-number.sh` is introduced by this same PR, so it cannot yet govern the
+PR that creates it — there was no prior committed tool to run against this file. This
+record's number, `0027`, was therefore assigned by hand, the same way every prior ADR
+was: `main` was at `0026` when this branch started, and no other decision record was
+in flight concurrently. Every ADR authored after this one uses the `NNNN` placeholder
+and this tool.
+
+## Consequences
+
+- `tools/assign-adr-number.sh` is new (`tests/tooling/test_assign_adr_number.sh`
+  covers: placeholder to next-free-number, all references rewritten, refuses cleanly
+  when no placeholder is present, a second run after a successful assignment is a
+  safe no-op, and the #170/#171-shaped concurrent case resolves to distinct numbers).
+- `docs/agent-team.md` documents the `NNNN` placeholder as the authoring convention for
+  every future design-decision PR, and names this ADR as the reason.
+- `tools/adr-index-check.sh` (Issue #189) is unchanged and still runs as the
+  after-the-fact drift guard in `tools/orchestration-policy.sh`; this ADR's mechanism
+  is what should now make that guard's failure mode — duplicate/gap — unreachable in
+  the normal case, not a replacement for it.
+- No new control-plane component. This is a Bash script invoked as a manual pre-merge
+  step, the same trust and automation posture as every other `tools/*.sh` gate in this
+  repo — consistent with the "no new orchestration machinery for now" locked decision
+  in `AGENTS.md`.
+
+## Known limitations
+
+- The tool must actually be run before merge for the guarantee to hold — nothing
+  currently blocks a merge that skips it (no CI gate invokes it; `tools/route.sh`'s
+  `tooling` route is `ci`-only). If a PR is merged with an un-renamed `NNNN-slug.md`
+  still in the tree, `tools/adr-index-check.sh` will catch the resulting drift (a
+  non-four-digit filename fails its filename-shape check) at the next
+  `orchestration-policy.sh` run, but only after the fact. Wiring this into an
+  automated pre-merge check, if the manual step proves unreliable in practice, is
+  future work and out of this issue's scope.
+- Rewriting external cross-links (step 5) is a literal-filename search over tracked
+  Markdown files under the given scan root; a reference written in prose without the
+  exact old filename string (e.g. "see the new ADR about X") is not found or rewritten.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -49,3 +49,4 @@ supersedes it — the original is not edited or deleted.
 | [0024](0024-hit-locations.md) | Hit locations: type, D20 location table, per-location hit points, and armor-by-location | Accepted |
 | [0025](0025-agent-verification-trust-root.md) | The `agent-verification` trust root, and the codex-conformance / semantic-gate triage policy | Accepted |
 | [0026](0026-reviewer-mechanical-read-only.md) | Verification reviewers get a constrained, mechanically-enforced read-only Bash layer | Accepted |
+| [0027](0027-adr-number-allocation.md) | ADR-number allocation is serialized at merge time, not authoring time | Accepted |

--- a/tests/tooling/test_assign_adr_number.sh
+++ b/tests/tooling/test_assign_adr_number.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# tests/tooling/test_assign_adr_number.sh — fixture tests for
+# tools/assign-adr-number.sh (Issue #185, F8).
+#
+# Proves the merge-time ADR-number assignment tool: assigns the next free
+# number to a placeholder, rewrites all references (header, README row,
+# external cross-links), is idempotent (a second run after a successful
+# assignment is a safe no-op), refuses when no placeholder is present, and
+# resolves a concurrent-allocation race (two placeholders authored off the
+# same base, both present when the tool runs, get distinct numbers).
+#
+# Run directly:
+#   tests/tooling/test_assign_adr_number.sh
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/assign-adr-number.sh"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+
+# ---------------------------------------------------------------------------
+# Fixture 1: placeholder -> next free number, references rewritten.
+# ---------------------------------------------------------------------------
+F1="$WORKDIR/f1"
+mkdir -p "$F1"
+cat > "$F1/README.md" <<'EOF'
+# Architecture Decision Records
+
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+| [0002](0002-second.md) | Second | Accepted |
+| [NNNN](NNNN-third-thing.md) | Third thing | Accepted |
+EOF
+printf '# 0001. First\n\nStub.\n' > "$F1/0001-first.md"
+printf '# 0002. Second\n\nStub.\n' > "$F1/0002-second.md"
+cat > "$F1/NNNN-third-thing.md" <<'EOF'
+# NNNN. Third thing
+
+## Status
+
+Proposed — 2026-09-01.
+
+## Context
+
+See NNNN-third-thing.md for the full record once it lands.
+EOF
+
+OUT="$("$SCRIPT" "$F1" 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ]; then ok "assigns exit 0"; else fail "assigns exit 0: got $RC: $OUT"; fi
+if [ -f "$F1/0003-third-thing.md" ]; then ok "next free number is 0003 (0001,0002 taken)"; else fail "expected $F1/0003-third-thing.md; dir: $(ls "$F1")"; fi
+if [ ! -e "$F1/NNNN-third-thing.md" ]; then ok "placeholder file removed"; else fail "placeholder file still present"; fi
+
+if grep -q '^# 0003\. Third thing' "$F1/0003-third-thing.md" 2>/dev/null; then
+  ok "header rewritten to assigned number"
+else
+  fail "header not rewritten: $(cat "$F1/0003-third-thing.md" 2>/dev/null)"
+fi
+if grep -q '0003-third-thing.md' "$F1/0003-third-thing.md" 2>/dev/null && ! grep -q 'NNNN' "$F1/0003-third-thing.md" 2>/dev/null; then
+  ok "self-reference to own filename rewritten, no NNNN left in body"
+else
+  fail "self-reference not rewritten cleanly: $(cat "$F1/0003-third-thing.md" 2>/dev/null)"
+fi
+if grep -q '\[0003\](0003-third-thing.md)' "$F1/README.md"; then
+  ok "README row rewritten to assigned number and filename"
+else
+  fail "README row not rewritten: $(cat "$F1/README.md")"
+fi
+if grep -q '\[0001\](0001-first.md)' "$F1/README.md" && grep -q '\[0002\](0002-second.md)' "$F1/README.md"; then
+  ok "unrelated README rows untouched"
+else
+  fail "unrelated README rows were touched: $(cat "$F1/README.md")"
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture 1b: external cross-reference to the placeholder gets rewritten too.
+# ---------------------------------------------------------------------------
+F1B="$WORKDIR/f1b"
+mkdir -p "$F1B/docs/decisions" "$F1B/docs"
+cat > "$F1B/docs/decisions/README.md" <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+| [NNNN](NNNN-third-thing.md) | Third thing | Accepted |
+EOF
+printf '# 0001. First\n\nStub.\n' > "$F1B/docs/decisions/0001-first.md"
+printf '# NNNN. Third thing\n\nStub.\n' > "$F1B/docs/decisions/NNNN-third-thing.md"
+cat > "$F1B/docs/agent-team.md" <<'EOF'
+See [the third thing](decisions/NNNN-third-thing.md) for background.
+EOF
+
+"$SCRIPT" "$F1B/docs/decisions" "$F1B" >/dev/null 2>&1
+if grep -q 'decisions/0002-third-thing.md' "$F1B/docs/agent-team.md" 2>/dev/null; then
+  ok "external cross-link to the placeholder rewritten"
+else
+  fail "external cross-link not rewritten: $(cat "$F1B/docs/agent-team.md" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture 2: refuses when no placeholder is present.
+# ---------------------------------------------------------------------------
+F2="$WORKDIR/f2"
+mkdir -p "$F2"
+cat > "$F2/README.md" <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+EOF
+printf '# 0001. First\n\nStub.\n' > "$F2/0001-first.md"
+
+OUT="$("$SCRIPT" "$F2" 2>&1)"; RC=$?
+if [ "$RC" -ne 0 ]; then ok "refuses with no placeholder present"; else fail "expected non-zero exit with no placeholder, got 0"; fi
+if [[ "${OUT,,}" == *placeholder* ]]; then ok "refusal message mentions 'placeholder'"; else fail "refusal message unclear: $OUT"; fi
+BEFORE_LISTING="$(ls "$F2")"
+if [ "$BEFORE_LISTING" = "$(ls "$F2")" ]; then ok "refusal leaves directory untouched"; else fail "refusal mutated directory"; fi
+
+# ---------------------------------------------------------------------------
+# Fixture 3: idempotent — a second run after a successful assignment is a
+# safe no-op (no further renames, no double-assignment, state unchanged).
+# ---------------------------------------------------------------------------
+F3="$WORKDIR/f3"
+mkdir -p "$F3"
+cat > "$F3/README.md" <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+| [NNNN](NNNN-idempotent-case.md) | Idempotent case | Accepted |
+EOF
+printf '# 0001. First\n\nStub.\n' > "$F3/0001-first.md"
+printf '# NNNN. Idempotent case\n\nStub.\n' > "$F3/NNNN-idempotent-case.md"
+
+"$SCRIPT" "$F3" >/dev/null 2>&1
+LISTING_AFTER_FIRST="$(ls "$F3" | sort)"
+README_AFTER_FIRST="$(cat "$F3/README.md")"
+
+set +e
+"$SCRIPT" "$F3" >"$WORKDIR/second_run.out" 2>&1
+RC2=$?
+set -e
+LISTING_AFTER_SECOND="$(ls "$F3" | sort)"
+README_AFTER_SECOND="$(cat "$F3/README.md")"
+
+if [ "$RC2" -ne 0 ]; then ok "second run on an already-assigned dir refuses (no placeholder left)"; else fail "second run unexpectedly succeeded (should have nothing left to assign)"; fi
+if [ "$LISTING_AFTER_FIRST" = "$LISTING_AFTER_SECOND" ]; then ok "idempotent: directory listing unchanged by the second run"; else fail "directory listing changed between runs:\n$LISTING_AFTER_FIRST\nvs\n$LISTING_AFTER_SECOND"; fi
+if [ "$README_AFTER_FIRST" = "$README_AFTER_SECOND" ]; then ok "idempotent: README.md unchanged by the second run"; else fail "README.md changed between runs"; fi
+
+# ---------------------------------------------------------------------------
+# Fixture 4: concurrent-allocation case (the #170/#171 collision this issue
+# fixes) — two placeholders authored off the same base, both present when
+# the assignment tool runs once against the merged tree, must not collide.
+# ---------------------------------------------------------------------------
+F4="$WORKDIR/f4"
+mkdir -p "$F4"
+cat > "$F4/README.md" <<'EOF'
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-first.md) | First | Accepted |
+| [NNNN](NNNN-branch-a.md) | Branch A decision | Accepted |
+| [NNNN](NNNN-branch-b.md) | Branch B decision | Accepted |
+EOF
+printf '# 0001. First\n\nStub.\n' > "$F4/0001-first.md"
+printf '# NNNN. Branch A decision\n\nStub.\n' > "$F4/NNNN-branch-a.md"
+printf '# NNNN. Branch B decision\n\nStub.\n' > "$F4/NNNN-branch-b.md"
+
+"$SCRIPT" "$F4" >/dev/null 2>&1
+if [ -f "$F4/0002-branch-a.md" ] && [ -f "$F4/0003-branch-b.md" ]; then
+  ok "concurrent placeholders assigned distinct, sequential numbers (0002, 0003)"
+else
+  fail "concurrent placeholders did not get distinct sequential numbers: $(ls "$F4")"
+fi
+if bash "$ROOT/tools/adr-index-check.sh" "$F4" >/dev/null 2>&1; then
+  ok "resulting index passes adr-index-check.sh (no duplicate/gap)"
+else
+  fail "resulting index failed adr-index-check.sh: $(bash "$ROOT/tools/adr-index-check.sh" "$F4" 2>&1)"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "test_assign_adr_number: PASS"
+  exit 0
+else
+  echo "test_assign_adr_number: FAIL ($FAILURES failures)"
+  exit 1
+fi

--- a/tools/assign-adr-number.sh
+++ b/tools/assign-adr-number.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tools/assign-adr-number.sh — merge-time ADR-number assignment (Issue #185, F8).
+#
+# Authors write a design-decision record with a placeholder number:
+#   docs/decisions/NNNN-slug.md
+# with an "NNNN" placeholder token wherever the number is referenced (the
+# `# NNNN. Title` header, a `Status`/`Supersedes` line, and its own
+# docs/decisions/README.md index row). Two authors on parallel branches can
+# both write "NNNN" without colliding, because no number is actually chosen
+# until this tool runs, once, at merge time, against the merged tree — see
+# docs/decisions/0027-adr-number-allocation.md for the full rationale.
+#
+# What it does, for each docs/decisions/NNNN-*.md placeholder file found:
+#   1. Computes the next free four-digit ADR number from the existing
+#      docs/decisions/NNNN-*.md files and README.md index rows.
+#   2. Renames the placeholder file to that number.
+#   3. Rewrites the "NNNN" token to the assigned number everywhere inside
+#      that file (header, self-references, its own filename mentioned in
+#      prose all share the literal "NNNN" placeholder).
+#   4. Rewrites the matching docs/decisions/README.md row(s) (identified by
+#      the placeholder's old filename, so unrelated rows are untouched even
+#      if more than one placeholder is in flight).
+#   5. Rewrites any other tracked *.md file under the repo root (excluding
+#      .git) that links to the placeholder's exact old filename.
+#
+# Multiple placeholders in the same directory are assigned sequential
+# numbers in filename order, deterministically.
+#
+# Usage:
+#   tools/assign-adr-number.sh [decisions-dir] [scan-root]
+# Defaults: decisions-dir = docs/decisions, scan-root = repo root (used only
+# for step 5, rewriting external references).
+#
+# Refuses (exit 1) if no NNNN-*.md placeholder exists in decisions-dir —
+# there is nothing to assign. Running it again after a successful run is
+# therefore a safe no-op: the placeholder is gone, so the second invocation
+# refuses cleanly without touching any file a second time.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIR="${1:-$ROOT/docs/decisions}"
+SCAN_ROOT="${2:-$ROOT}"
+README="$DIR/README.md"
+
+die() { printf 'assign-adr-number: %s\n' "$1" >&2; exit 1; }
+
+[ -d "$DIR" ] || die "no such decisions directory: $DIR"
+
+mapfile -t placeholders < <(find "$DIR" -maxdepth 1 -name 'NNNN-*.md' | sort)
+if [ "${#placeholders[@]}" -eq 0 ]; then
+  die "no placeholder ADR found in $DIR (expected NNNN-slug.md) — nothing to assign"
+fi
+
+# --- Determine the current high-water mark -----------------------------
+# Union of digits seen in docs/decisions/NNNN-*.md filenames and README.md
+# index rows, so a drifted README (or a directory missing a file) still
+# never causes a re-issued number.
+highest=0
+while IFS= read -r -d '' f; do
+  base="$(basename "$f")"
+  [ "$base" = "README.md" ] && continue
+  num="${base%%-*}"
+  [[ "$num" =~ ^[0-9]{4}$ ]] || continue
+  n=$((10#$num))
+  [ "$n" -gt "$highest" ] && highest=$n
+done < <(find "$DIR" -maxdepth 1 -name '*.md' -print0)
+
+if [ -f "$README" ]; then
+  while IFS= read -r num; do
+    [[ "$num" =~ ^[0-9]{4}$ ]] || continue
+    n=$((10#$num))
+    [ "$n" -gt "$highest" ] && highest=$n
+  done < <(grep -oE '^\| \[[0-9]{4}\]' "$README" 2>/dev/null | grep -oE '[0-9]{4}')
+fi
+
+next="$highest"
+
+for old_path in "${placeholders[@]}"; do
+  next=$((next + 1))
+  num="$(printf '%04d' "$next")"
+
+  old_name="$(basename "$old_path")"      # NNNN-slug.md
+  slug_suffix="${old_name#NNNN-}"         # slug.md
+  new_name="${num}-${slug_suffix}"        # 0027-slug.md
+  new_path="$DIR/$new_name"
+
+  [ -e "$new_path" ] && die "refusing to overwrite existing file: $new_path"
+
+  mv -- "$old_path" "$new_path"
+
+  # Step 3: rewrite the literal placeholder token inside the renamed file.
+  # "NNNN" is not a real word and appears only as this placeholder, so a
+  # global replace is safe and also correctly updates any prose mention of
+  # the file's own filename (which shares the same "NNNN-slug.md" text).
+  sed -i "s/NNNN/${num}/g" "$new_path"
+
+  # Step 4: rewrite only the README row(s) that reference this placeholder's
+  # old filename, so a second in-flight placeholder with a different slug
+  # (and therefore a different old_name) is left untouched.
+  if [ -f "$README" ]; then
+    esc_old_name="$(printf '%s' "$old_name" | sed 's/[.[\*^$]/\\&/g')"
+    sed -i "/${esc_old_name}/s/NNNN/${num}/g" "$README"
+  fi
+
+  # Step 5: rewrite any other tracked markdown file that links to the exact
+  # old filename (e.g. a cross-reference from another doc).
+  if [ -d "$SCAN_ROOT" ]; then
+    esc_old_name_lit="$(printf '%s' "$old_name" | sed 's/[.[\*^$]/\\&/g')"
+    while IFS= read -r -d '' f; do
+      [ "$f" = "$new_path" ] && continue
+      [ "$f" = "$README" ] && continue
+      grep -q "$old_name" "$f" 2>/dev/null || continue
+      sed -i "s/${esc_old_name_lit}/${new_name}/g" "$f"
+    done < <(find "$SCAN_ROOT" -name '*.md' -not -path '*/.git/*' -print0 2>/dev/null)
+  fi
+
+  printf 'assign-adr-number: %s -> %s\n' "$old_name" "$new_name"
+done


### PR DESCRIPTION
## Linked Issue

Closes #185

## Exact behavioral claim

ADR numbers are now assigned at **merge time**, not authoring time, so parallel design-decision work can no longer collide (the F8 `0025` collision between #170/#171). Authors write `docs/decisions/NNNN-slug.md` with an `NNNN` placeholder; `tools/assign-adr-number.sh` (a pre-merge step) computes the next free number, renames the file, and rewrites its header, the README row, and any links. Concurrent placeholders get sequential numbers deterministically.

## Scope

New `tools/assign-adr-number.sh` + `tests/tooling/test_assign_adr_number.sh`; the decision recorded as new ADR `docs/decisions/0027-adr-number-allocation.md` (number assigned by hand — the bootstrapping case) + its README row; an "Authoring a design-decision record" section in `docs/agent-team.md`. No existing ADRs (0001–0026) touched.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_assign_adr_number.sh` → 16/16 (assign next-free, header/self-ref/README/external-link rewrite, refuse-with-no-placeholder, idempotent no-op, concurrent-placeholder #170/#171 case). `bash tools/adr-index-check.sh` → PASS (27 rows, no dup/gap, 1:1 with files). `bash tools/orchestration-policy.sh` → PASS (including the #189 ADR drift guard — this PR's own 0027 dogfoods it).

## Decisions and tradeoffs

Merge-time assignment chosen (per the settled decision) as the only collision-proof option under true parallelism. Triggering is a documented pre-merge step (matches how this repo merges today), not a CI gate — the #189 index guard is the after-the-fact backstop if the step is skipped; this limitation is stated in ADR 0027.

## Known limitations

Nothing yet *blocks* a merge that skips running the tool; the index-drift guard catches the resulting drift after the fact. Documented in ADR 0027.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
