### PR TITLE
Capture per-run Codex token telemetry; document hard gaps (#190)

### DIFF
--- a/docs/agent-team-ledger/README.md
+++ b/docs/agent-team-ledger/README.md
@@ -79,6 +79,32 @@ The schema is complete; the **capture** is not yet. Fields currently marked `NI`
 need logging the present subagent-completion telemetry does not expose. This mirrors the paper's own
 candor in §4.7/§8 — and pins exactly what to build before the 30–100-task study the reviewer wants:
 
+- **Codex runs now log `tokens_total` (#190 spike).** `tools/codex-agent.sh` parses the
+  `usage` object `codex exec --json` reports on its final `turn.completed` event
+  (`input_tokens + output_tokens`) and records it on every `codex-*` job row where the
+  event was parseable. Before #190 every Codex row was an unconditional `tokens_total = NI`
+  (see the `codex-conformance` rows from Issue #112/PR #179 below, all logged before this
+  change). `cost_usd` for Codex runs stays `NI` — the binary reports no dollar figure and
+  no per-model Codex pricing table exists in this repo to multiply against without
+  guessing; see `docs/orchestration/metrics.md` for the full spike writeup, including why
+  the plain-text "tokens used" line codex prints without `--json` was rejected as a source
+  (it disagreed with the structured figure by ~3x on an equivalent prompt in testing, with
+  no documented definition of what it counts).
+- **Per-rework (per-job) token deltas for Claude subagent resumes remain a hard `NI` gap —
+  investigated and confirmed not obtainable (#190 spike).** Subagent completion telemetry
+  reports a *cumulative-per-resume* total each time a subagent thread is resumed for
+  another rework round (see the Issue #112/PR #179 rework rows below: ~178k → ~231k →
+  ~272k → ~285k across implement + three reworks). Only the first figure (the initial,
+  un-resumed job) is a clean per-job number. Subtracting successive cumulative totals to
+  approximate a per-job delta was considered and rejected: each resume re-establishes
+  context (re-reads files, restates prior findings) whose cost is commingled with the new
+  round's actual work in the same cumulative figure, so a subtracted delta would not
+  cleanly represent "tokens this rework round cost" — it would silently blend in
+  re-context-loading cost that varies resume to resume for reasons unrelated to the size of
+  the fix. This is Claude Code / Agent-SDK subagent-resume runtime behavior, not something
+  exposed by any script in `tools/` that this repository controls, so there is nothing to
+  instrument here beyond recording the honest gap. A resumed rework job's `tokens_total`
+  stays `NI` rather than a mis-derived subtraction.
 - **`tokens_R` / `tokens_A` / `tokens_H` (the C2 centerpiece) are `NI`.** Subagent completion
   telemetry reports only a *single total* output-token figure — no per-turn input/cached/reasoning/
   tool breakdown and no turn-level R/A/H category. The R/A/H split therefore *cannot* be derived

--- a/docs/orchestration/metrics.md
+++ b/docs/orchestration/metrics.md
@@ -98,13 +98,37 @@ conformance stages actually made; see Cost / Job telemetry below.
 
 | Metric | Source | Status |
 |---|---|---|
-| Output tokens per layer / per phase | [`docs/agent-team-ledger/jobs.csv`](../agent-team-ledger/jobs.csv) `tokens_total` | **exact for logged jobs** |
+| Output tokens per layer / per phase (Claude subagent jobs) | [`docs/agent-team-ledger/jobs.csv`](../agent-team-ledger/jobs.csv) `tokens_total` | **exact for logged jobs** |
+| Input+output tokens per Codex run | same, `tokens_total` on `agent_role`-`codex-*` rows | **exact for logged Codex runs, added #190** |
 | Findings by detecting stage | [`docs/agent-team-ledger/findings.csv`](../agent-team-ledger/findings.csv) | **exact for logged findings** |
 
-Only **output-token totals** are available. The R/A/H decomposition (`tokens_R/A/H`) and
-`cost_usd` are `NI` in the ledger — see the ledger
+Claude subagent jobs still expose only **output-token totals**. The R/A/H decomposition
+(`tokens_R/A/H`) and `cost_usd` are `NI` in the ledger — see the ledger
 [`README.md`](../agent-team-ledger/README.md) gap list. The tool reports the totals it has
 and repeats the `NI` caveat rather than implying a full cost accounting exists.
+
+**Codex runs (#190 spike outcome).** `codex exec --json` emits one `turn.completed` event
+per run carrying a structured `usage` object: `input_tokens`, `cached_input_tokens`,
+`cache_write_input_tokens`, `output_tokens`, `reasoning_output_tokens`. `tools/codex-agent.sh`
+now parses that event and logs `tokens_total = input_tokens + output_tokens` on every
+`codex-*` ledger row where it was parseable, instead of an unconditional `NI`. Two things
+were spiked and found **not** obtainable, and remain hard `NI` gaps:
+
+- **`cost_usd` for Codex runs.** The binary reports no dollar figure at any verbosity
+  (`--json` or otherwise), and this repo has no authoritative per-model Codex pricing table
+  to multiply the token counts by without guessing. Fabricating one would violate the
+  ledger's no-invented-numbers rule, so `cost_usd` stays `NI`.
+- **The human-readable "tokens used" line** that `codex exec` prints without `--json` is
+  *not* a usable substitute for the structured figure above — on an equivalent prompt in
+  this spike it disagreed with `usage.input_tokens + usage.output_tokens` by roughly 3x,
+  and the binary documents no definition of what it counts (cumulative session? current
+  turn only? cache-adjusted?). It is not parsed for that reason.
+
+A side effect: `codex-agent.sh` now always passes `--json`, so its live terminal transcript
+is one JSON object per turn event rather than prose. `--output-last-message` still writes
+the plain-text final answer to the `OUT` file for anyone reading the result, and a raw copy
+of the JSONL event stream is kept at a sibling temp file (printed at the end of the run) so
+the usage figure is independently checkable.
 
 ### Job telemetry (briefing efficiency, build/verify/rework)
 

--- a/tools/codex-agent.sh
+++ b/tools/codex-agent.sh
@@ -34,7 +34,10 @@
 # Env overrides: CODEX_BIN, CODEX_MODEL, OUT.
 # LEDGER_LOG=1 additionally appends one job row via tools/ledger-log.sh (never
 # fabricated — set ISSUE/PR/SEQ/LAYER/PHASE to whatever is actually known; unset
-# fields land as NI). Off by default.
+# fields land as NI). Off by default. Logs after the run completes, and includes
+# --tokens-total whenever `codex exec --json`'s turn.completed usage was
+# parseable (Issue #190 spike) — otherwise that field lands NI like the rest.
+# cost_usd is never computed here; see the note beside its ledger row below.
 
 set -euo pipefail
 
@@ -162,12 +165,22 @@ PROMPT_HASH="$(printf '%s' "$HASH_INPUT" | sha256sum | cut -d' ' -f1)"
 
 OUT="${OUT:-$(mktemp -t codex-${ROLE}-XXXX.md)}"
 
+# --json (Issue #190 spike): the only per-run token/cost figure `codex exec`
+# actually exposes is the `usage` object on its final `turn.completed` JSONL
+# event (input_tokens/cached_input_tokens/output_tokens/reasoning_output_tokens).
+# The human-readable "tokens used" line printed without --json is NOT a
+# reliable substitute — spiking this showed it disagreeing with the structured
+# usage figure by ~3x on an equivalent prompt, with no documented definition of
+# what it counts, so it is not parsed. Using --json changes the terminal
+# transcript from prose to one JSON object per turn event; --output-last-message
+# still writes the plain-text final answer to $OUT for anyone reading the result.
 CMD=("$CODEX_BIN" exec
   -C "$REPO_ROOT"
   -s "$SANDBOX"
   -c "model_reasoning_effort=\"${EFFORT}\""
   --output-last-message "$OUT"
-  --skip-git-repo-check)
+  --skip-git-repo-check
+  --json)
 
 [[ -n "${CODEX_MODEL:-}" ]] && CMD+=(-m "$CODEX_MODEL")
 
@@ -189,17 +202,46 @@ fi
 
 echo "codex-agent: role=${ROLE} packet-type=${PACKET_TYPE} prompt-sha256=${PROMPT_HASH}"
 
+# Ledger logging moves to AFTER the run (was: before) so a real --tokens-total
+# can be attached when the run actually produced one (#190). The CSV is
+# append-only, so a pre-invocation row could never be back-filled with the
+# figure below; a failed invocation (non-zero exit under `set -e`) now simply
+# does not log a row rather than logging an all-NI placeholder for work that
+# never completed.
+EVENTS_LOG="$(mktemp -t codex-${ROLE}-events-XXXX.jsonl)"
+printf '%s\n\n%s\n' "$CONTEXT" "$TASK" | "${CMD[@]}" - | tee "$EVENTS_LOG"
+echo
+echo "=== last message written to: $OUT ==="
+echo "=== JSONL events written to: $EVENTS_LOG ==="
+
+# Parse the final turn's usage object, if present and parseable. Never fabricate
+# a figure: absent/malformed usage data leaves tokens_total as NI, exactly like
+# every other unmeasured ledger field.
+TOKENS_TOTAL=""
+USAGE_LINE="$(grep '"type":"turn.completed"' "$EVENTS_LOG" | tail -1 || true)"
+if [[ -n "$USAGE_LINE" ]] && command -v jq >/dev/null 2>&1; then
+  INPUT_TOK="$(printf '%s' "$USAGE_LINE" | jq -r '.usage.input_tokens // empty' 2>/dev/null || true)"
+  OUTPUT_TOK="$(printf '%s' "$USAGE_LINE" | jq -r '.usage.output_tokens // empty' 2>/dev/null || true)"
+  if [[ "$INPUT_TOK" =~ ^[0-9]+$ && "$OUTPUT_TOK" =~ ^[0-9]+$ ]]; then
+    TOKENS_TOTAL=$((INPUT_TOK + OUTPUT_TOK))
+    echo "codex-agent: usage input_tokens=${INPUT_TOK} output_tokens=${OUTPUT_TOK} tokens_total=${TOKENS_TOTAL}"
+  fi
+fi
+[[ -z "$TOKENS_TOTAL" ]] && echo "codex-agent: no parseable usage in turn.completed — tokens_total will log NI"
+
+# cost_usd is deliberately never computed here: codex exec reports no dollar
+# figure at any verbosity, and this repo has no authoritative per-model Codex
+# pricing table to multiply tokens by without guessing. It stays NI (see
+# docs/orchestration/metrics.md).
+
 if [[ "${LEDGER_LOG:-0}" == "1" ]]; then
   LARGS=(job --packet-type "$PACKET_TYPE" --prompt-hash "$PROMPT_HASH"
     --agent-role "codex-${ROLE}" --model "${CODEX_MODEL:-codex}" --effort "$EFFORT")
-  [ -n "${ISSUE:-}" ] && LARGS+=(--issue "$ISSUE")
-  [ -n "${PR:-}" ]    && LARGS+=(--pr "$PR")
-  [ -n "${SEQ:-}" ]   && LARGS+=(--seq "$SEQ")
-  [ -n "${LAYER:-}" ] && LARGS+=(--layer "$LAYER")
-  [ -n "${PHASE:-}" ] && LARGS+=(--phase "$PHASE")
+  [ -n "${ISSUE:-}" ]   && LARGS+=(--issue "$ISSUE")
+  [ -n "${PR:-}" ]      && LARGS+=(--pr "$PR")
+  [ -n "${SEQ:-}" ]     && LARGS+=(--seq "$SEQ")
+  [ -n "${LAYER:-}" ]   && LARGS+=(--layer "$LAYER")
+  [ -n "${PHASE:-}" ]   && LARGS+=(--phase "$PHASE")
+  [ -n "$TOKENS_TOTAL" ] && LARGS+=(--tokens-total "$TOKENS_TOTAL")
   "$REPO_ROOT/tools/ledger-log.sh" "${LARGS[@]}" || echo "codex-agent: ledger-log failed (non-fatal)" >&2
 fi
-
-printf '%s\n\n%s\n' "$CONTEXT" "$TASK" | "${CMD[@]}" -
-echo
-echo "=== last message written to: $OUT ==="


### PR DESCRIPTION
## Linked Issue

Closes #190

## Exact behavioral claim

Per-run Codex token usage is now captured. The spike found `codex exec --json` emits a `turn.completed` event with a structured `usage` object; `tools/codex-agent.sh` now parses it and (with `LEDGER_LOG=1`) records `tokens_total` on `codex-*` ledger rows that were previously an unconditional `NI`. `cost_usd` for Codex and per-rework Claude subagent token deltas were investigated and confirmed **not obtainable** from available telemetry — documented as hard `NI` gaps with the reasoning, not fabricated.

## Scope

`tools/codex-agent.sh` (passes `--json`, parses `turn.completed` usage, optional ledger write moved to after the run), `docs/orchestration/metrics.md` and `docs/agent-team-ledger/README.md` (spike outcome + updated gap list). `tools/orchestration-metrics.py` needed no change — it already aggregates `tokens_total` generically. No ADR; `docs/decisions/` untouched.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_codex_agent.sh` → pass (DRY_RUN paths unchanged); `bash tests/tooling/test_orchestration_metrics.sh` → pass (no parsing change); regression: `test_agent_brief.sh`/`test_agent_verify.sh` pass; `bash tools/orchestration-policy.sh` → PASS. Live smoke against the real `codex` binary produced `tokens_total=16802` in a scratch ledger row (reverted afterward).

## Decisions and tradeoffs

The `--json` requirement changes `codex-agent.sh`'s live transcript from prose to one JSON object per turn event; the plain-text final answer is still written to `--output-last-message` ($OUT), so verdict capture for the codex-conformance gate is unaffected, and the raw JSONL is kept at a sibling temp file. The non-`--json` "tokens used" line was rejected as a source (disagreed with the structured figure ~3x, undefined semantics).

## Known limitations

Codex `cost_usd` and per-rework Claude token deltas remain `NI` (documented why). Terminal transcript is now JSONL rather than prose.

## Agent provenance

Implemented by the `orchestration-dev` agent (Sonnet) in an isolated worktree; diff reviewed and PR assembled by the orchestrator (Claude Opus 4.8).

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).
