### PR TITLE
Run case_validator.py in required CI (deterministic scenario gate)

### DIFF
--- a/.github/route-map
+++ b/.github/route-map
@@ -51,7 +51,9 @@ src/Noir.Rules/**          gameplay
 
 # `scenario` — authored case/scenario content and the engine that loads it.
 # Gate set is `ci` only: tools/case_validator.py is the deterministic enforcer
-# of schema, the Three Doors rule, junction budget, and canonical skills.
+# of schema, the Three Doors rule, junction budget, and canonical skills, and it
+# RUNS in the required build-and-test job (ci.yml "Validate case data") over
+# every cases/*.yaml — so a malformed case fails a required check.
 # `case-author` is a content-producing role, not a second reviewer — no Opus
 # review on ordinary case YAML.
 cases/**                   scenario

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,37 @@ jobs:
         if: always()
         run: dotnet format --verify-no-changes --no-restore
 
+      # Deterministic scenario gate. The `scenario` route (tools/route.sh) is
+      # CI-only precisely because tools/case_validator.py mechanically enforces
+      # the case schema, the Three Doors rule, the junction budget, and the
+      # canonical skill list — so that validator must actually RUN in the
+      # required job, not merely be pointed at. Runs regardless of earlier
+      # failures (if: always()) and hard-fails the job on any FAIL, so a
+      # malformed case can never merge behind a green build-and-test.
+      - name: Install Python (case validator)
+        if: always()
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Validate case data
+        id: cases
+        if: always()
+        run: |
+          python3 -m pip install --quiet pyyaml
+          shopt -s nullglob
+          files=(cases/*.yaml cases/*.yml)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No case files to validate."
+            exit 0
+          fi
+          rc=0
+          for f in "${files[@]}"; do
+            echo "== $f =="
+            python3 tools/case_validator.py "$f" || rc=1
+          done
+          exit "$rc"
+
       # The summary is the point of this workflow. It exists so an agent can decide
       # its next action from tens of lines instead of thousands. It is deliberately
       # not a second copy of the log.

--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -106,7 +106,9 @@ content and its schema engine, `cases/**` and `src/Noir.Scenario/**`), and
 against a printed BRP table, so none of them gets `rules-conformance` or
 `codex-conformance`; instead each relies on a deterministic, code-level gate:
 CI plus the layer's own tests for `gameplay`, and `tools/case_validator.py` (schema,
-the Three Doors rule, junction budget, canonical skills) for `scenario`. `design-critic`
+the Three Doors rule, junction budget, canonical skills) for `scenario` — the latter
+run over every `cases/*.yaml` inside the required `build-and-test` job, so a malformed
+case fails a required check rather than relying on anyone to remember to validate it. `design-critic`
 sits at the design/phase gate where a mechanic is *decided*, not on every routine PR
 that implements an already-settled one, and `case-author` is a content-producing role
 — it is not paired with an Opus review on ordinary case YAML. See

--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -74,9 +74,13 @@ against a printed source table, so none of them needs `rules-conformance` or
 - **`scenario`** is authored case/scenario content. Its correctness is machine-checked
   by [`tools/case_validator.py`](../../tools/case_validator.py) — schema, the Three
   Doors rule, the junction budget, canonical skill names, and load/parse validity — all
-  deterministic. `case-author` (Sonnet, see [`agent-team.md`](../agent-team.md)) is a
-  content-producing role, not a second reviewer; it does not get paired with an Opus
-  review on ordinary case YAML.
+  deterministic. That validator is not merely *pointed at* this route: the required
+  `build-and-test` job runs it over every `cases/*.yaml` on every PR (see
+  [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml), "Validate case data"),
+  so a malformed case fails a required check and cannot merge behind a green build —
+  which is what makes `ci`-only a sufficient gate for this route. `case-author` (Sonnet,
+  see [`agent-team.md`](../agent-team.md)) is a content-producing role, not a second
+  reviewer; it does not get paired with an Opus review on ordinary case YAML.
 - **`presentation`** is game engine / client / presentation code. It gets its own route
   rather than the generic `tooling` catch-all so its gate set is legible on its own
   terms, even though none of `src/Noir.Game/**` or `src/Noir.Client/**` exists yet —


### PR DESCRIPTION
## Linked Issue

Closes #201

## Exact behavioral claim

The required `build-and-test` job now runs `tools/case_validator.py` over every `cases/*.yaml`. A new "Validate case data" step (with `actions/setup-python@v5` + `pip install pyyaml`) loops the validator over all case files, hard-fails the job on any validator `FAIL`, and exits cleanly (`No case files to validate.`) when none exist. `cases/overpass.yaml` passes, so `build-and-test` stays green on `main` today. The step runs `if: always()` so a malformed case is reported even when an earlier step failed.

## Scope

`.github/workflows/ci.yml` (two new steps inside `build-and-test`). Prose alignment only: `.github/route-map`, `docs/orchestration/routing.md`, `docs/agent-team.md` — each now states the validator actually runs in required CI. No change to the validator itself, no new C#/test project, no change to any other route.

## Rules conformance

N/A — CI/orchestration tooling; no rules-engine files (`src/Brp.*`) touched.

## Tests and evidence

`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → valid YAML. Local reproduction of the CI step: `shopt -s nullglob; for f in cases/*.yaml; do python3 tools/case_validator.py "$f"; done` → `cases/overpass.yaml` PASS, rc=0. `tools/route.sh --base origin/main` → `route: tooling / gates: ci`. `bash tools/orchestration-policy.sh` → PASS. The CI run on this PR exercises the new step end-to-end on a GitHub runner.

## Decisions and tradeoffs

Chose the review's simplest option — run the existing Python validator as a CI step — over porting its invariants to C# `dotnet test`. Used `actions/setup-python` + `pip install pyyaml` rather than relying on whatever the runner's system Python happens to carry, so the gate is deterministic. Left `summarize.py` untouched (a failing step already surfaces in the checks UI). Did not wire the `tests/tooling/*.sh` suite into CI — that is a separate gap (see #61) noted for follow-up.

## Known limitations

The validator only sees `cases/*.yaml`; the (not-yet-existing) `src/Noir.Scenario/**` load path is covered by `dotnet test` when it lands, not here. `tests/tooling/*.sh` still do not run in CI.

## Agent provenance

Implemented and PR assembled by the orchestrator (Claude Opus 4.8) directly — a cross-cutting CI/orchestration change, not routine layer implementation.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).