### PR TITLE
Make worktree isolation a dispatch rail (burn-in F12)

### DIFF
--- a/.claude/agents/case-author.md
+++ b/.claude/agents/case-author.md
@@ -9,6 +9,20 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 You author and repair case data. Read `cases/SCHEMA.md` first, and `cases/overpass.yaml`
 as the reference implementation.
 
+## Worktree isolation (run this FIRST)
+
+You write files, so you must run in a dedicated worktree, never the primary checkout
+(burn-in F12). Before reading or editing anything else, run:
+
+```bash
+tools/dispatch-agent.sh --assert-isolated
+```
+
+If it exits non-zero you are in the primary checkout — **stop immediately and return a
+dispatch error** ("not dispatched into an isolated worktree"); do not `Write`/`Edit`.
+The orchestrator creates your workspace with `tools/dispatch-agent.sh <issue#>` and
+dispatches you with that path as your working directory.
+
 ## Packet-first
 
 A generated TASK packet (`tools/agent-brief.py task <issue>`) is your starting

--- a/.claude/agents/engine-dev.md
+++ b/.claude/agents/engine-dev.md
@@ -9,6 +9,20 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 You implement exactly one Issue. Read `AGENTS.md` first, then the Issue and its task
 packet. Do not read the whole repository.
 
+## Worktree isolation (run this FIRST)
+
+You write files, so you must run in a dedicated worktree, never the primary checkout
+(burn-in F12). Before reading or editing anything else, run:
+
+```bash
+tools/dispatch-agent.sh --assert-isolated
+```
+
+If it exits non-zero you are in the primary checkout — **stop immediately and return a
+dispatch error** ("not dispatched into an isolated worktree"); do not `Write`/`Edit`.
+The orchestrator creates your workspace with `tools/dispatch-agent.sh <issue#>` and
+dispatches you with that path as your working directory.
+
 ## Boundaries
 
 - One concern, one branch, one PR. If you discover unrelated work, file a separate

--- a/.claude/agents/orchestration-dev.md
+++ b/.claude/agents/orchestration-dev.md
@@ -9,6 +9,20 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 You implement exactly one Issue in the orchestration/tooling layer. Read `AGENTS.md`
 first, then the Issue and its task packet. Do not survey the whole repository.
 
+## Worktree isolation (run this FIRST)
+
+You write files, so you must run in a dedicated worktree, never the primary checkout
+(burn-in F12). Before reading or editing anything else, run:
+
+```bash
+tools/dispatch-agent.sh --assert-isolated
+```
+
+If it exits non-zero you are in the primary checkout — **stop immediately and return a
+dispatch error** ("not dispatched into an isolated worktree"); do not `Write`/`Edit`.
+The orchestrator creates your workspace with `tools/dispatch-agent.sh <issue#>` and
+dispatches you with that path as your working directory.
+
 ## What you handle
 
 GitHub workflow files, Bash/Python orchestration tools, issue/PR workflow tooling,

--- a/.claude/agents/rules-extractor.md
+++ b/.claude/agents/rules-extractor.md
@@ -9,6 +9,20 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 You transcribe rules data from the source book into ruleset JSON. You are a careful
 copyist, not a designer.
 
+## Worktree isolation (run this FIRST)
+
+You write files, so you must run in a dedicated worktree, never the primary checkout
+(burn-in F12). Before reading or editing anything else, run:
+
+```bash
+tools/dispatch-agent.sh --assert-isolated
+```
+
+If it exits non-zero you are in the primary checkout — **stop immediately and return a
+dispatch error** ("not dispatched into an isolated worktree"); do not `Write`/`Edit`.
+The orchestrator creates your workspace with `tools/dispatch-agent.sh <issue#>` and
+dispatches you with that path as your working directory.
+
 ## Packet-first
 
 A generated TASK packet (`tools/agent-brief.py task <issue>`) is your starting

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ TestResults/
 __pycache__/
 *.py[cod]
 
+# Dispatched-agent worktrees (tools/dispatch-agent.sh). Each is a full linked
+# checkout under the primary tree; it must never show up as untracked here.
+.worktrees/
+
 # Editors
 .vs/
 .vscode/

--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -115,14 +115,32 @@ that implements an already-settled one, and `case-author` is a content-producing
 **Verification agents get read-only tools.** An agent that can edit what it is checking
 will eventually make the check pass instead of making the code right.
 
-**Dispatch implementer and writeup agents with worktree isolation.** Burn-in finding
-F12 (`docs/orchestration/agent-verification-burn-in.md`): the #174 writeup agent was
+**Dispatch implementer and writeup agents through `tools/dispatch-agent.sh` — worktree
+isolation is a rail, not a reminder.** Burn-in finding F12
+(`docs/orchestration/agent-verification-burn-in.md`): the #174 writeup agent was
 dispatched without worktree isolation, created its feature branch in the primary
 checkout, and left it there — the primary tree had to be manually restored
-(`git checkout main` plus a fast-forward) during cleanup. Give a dispatched
-implementer or writeup agent its own worktree so the primary checkout is never left
-stranded on a feature branch. If a non-isolated agent is used deliberately, expect to
-restore the primary tree afterward the same way.
+(`git checkout main` plus a fast-forward) during cleanup. Rather than remembering to
+"give the agent a worktree", stand its workspace up mechanically:
+
+```bash
+tools/dispatch-agent.sh <issue#>     # prints  path=<abs worktree>  branch=<issue-n-slug>
+```
+
+Dispatch the implementer/writeup agent with that `path` as its working directory, and
+`--cleanup <issue#>` the worktree after merge. The two implementer-facing rails:
+
+- `tools/dispatch-agent.sh <issue#>` never checks the feature branch out into the
+  primary tree, so using it cannot reproduce F12.
+- Every implementer role (`engine-dev`, `orchestration-dev`, `case-author`,
+  `rules-extractor`) runs `tools/dispatch-agent.sh --assert-isolated` as its first
+  action and **stops with a dispatch error** if it finds itself in the primary
+  checkout — a mechanical self-check (git's own worktree metadata), so a forgotten
+  option fails fast instead of stranding the primary tree.
+
+A shell tool cannot intercept the harness's Agent dispatch itself; this is a preflight
+plus a self-check, which is what F12 needs. Reviewer (read-only) roles do not write and
+need no worktree.
 
 ## Authoring a design-decision record (ADR) — the `NNNN` placeholder
 

--- a/tests/tooling/test_dispatch_agent.sh
+++ b/tests/tooling/test_dispatch_agent.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# tests/tooling/test_dispatch_agent.sh — fixture tests for tools/dispatch-agent.sh,
+# the worktree-isolation rail (Issue #203, burn-in F12).
+#
+# Every case runs inside a THROWAWAY git repo in a tempdir, so the test never
+# touches the real repository's worktrees or branches. `origin/main` is not
+# available there, so BASE_REF is pointed at a local commit-ish; the tool's
+# `git fetch` is best-effort and simply no-ops. `gh` is stubbed on PATH to
+# exercise the title→slug branch-naming path deterministically.
+#
+# Run directly:
+#   tests/tooling/test_dispatch_agent.sh
+#
+# Exit: 0 if every case passes, 1 on the first failure.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/dispatch-agent.sh"
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then ok "$desc"; else
+    fail "$desc (expected [$expected], got [$actual])"
+  fi
+}
+
+WORKDIR="$(mktemp -d)"
+BINDIR="$WORKDIR/bin"
+mkdir -p "$BINDIR"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# gh stub: answers `gh issue view N --json title --jq .title` with a fixed title
+# so the slug path is deterministic. GH_TITLE controls the answer; empty/unset
+# makes the stub print nothing (exercises the no-title fallback).
+cat > "$BINDIR/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
+  printf '%s' "${GH_TITLE:-}"
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$BINDIR/gh"
+
+# --- a fresh throwaway repo per invocation ---------------------------------- #
+new_repo() {
+  local d; d="$(mktemp -d "$WORKDIR/repo.XXXXXX")"
+  git -C "$d" init -q -b main
+  git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  echo seed > "$d/seed.txt"
+  git -C "$d" add -A; git -C "$d" commit -qm seed
+  echo "$d"
+}
+
+# Run dispatch-agent from within repo $1 with our gh stub on PATH and a local BASE_REF.
+run() {
+  local repo="$1"; shift
+  ( cd "$repo" && PATH="$BINDIR:$PATH" BASE_REF="main" "$SCRIPT" "$@" )
+}
+
+# === 1. --assert-isolated: primary fails, linked passes ===================== #
+repo="$(new_repo)"
+run "$repo" --assert-isolated >/dev/null 2>&1
+assert_eq "--assert-isolated exits non-zero in the primary worktree" "1" "$?"
+
+# create a worktree, then assert-isolated inside it
+out="$(run "$repo" 7 2>/dev/null)"
+wt="$(printf '%s\n' "$out" | sed -n 's/^path=//p')"
+[ -n "$wt" ] && [ -d "$wt" ] && ok "create: worktree directory exists ($wt)" \
+  || fail "create: worktree directory missing (out=$out)"
+( cd "$wt" && PATH="$BINDIR:$PATH" "$SCRIPT" --assert-isolated >/dev/null 2>&1 )
+assert_eq "--assert-isolated exits zero inside a linked worktree" "0" "$?"
+
+# === 2. branch naming: no title -> issue-N ================================== #
+assert_eq "no-title branch name is issue-7" "issue-7" \
+  "$(printf '%s\n' "$out" | sed -n 's/^branch=//p')"
+assert_eq "worktree path is <root>/.worktrees/issue-7" "$repo/.worktrees/issue-7" "$wt"
+
+# === 3. branch naming: title -> issue-N-slug ================================ #
+repo2="$(new_repo)"
+out2="$(cd "$repo2" && PATH="$BINDIR:$PATH" GH_TITLE="Fix the Overpass Case!" BASE_REF=main "$SCRIPT" 42 2>/dev/null)"
+assert_eq "titled branch name is slugified" "issue-42-fix-the-overpass-case" \
+  "$(printf '%s\n' "$out2" | sed -n 's/^branch=//p')"
+
+# === 4. --print-path has no side effects ==================================== #
+repo3="$(new_repo)"
+pp="$(run "$repo3" --print-path 5)"
+assert_eq "--print-path prints the path" "$repo3/.worktrees/issue-5" "$pp"
+[ ! -d "$repo3/.worktrees/issue-5" ] && ok "--print-path created nothing" \
+  || fail "--print-path created a worktree (should not)"
+
+# === 5. reuse: second create for the same issue reuses the worktree ========= #
+run "$repo3" 5 >/dev/null 2>&1
+out5="$(run "$repo3" 5 2>/dev/null)"
+assert_eq "reuse: prints the same path" "$repo3/.worktrees/issue-5" \
+  "$(printf '%s\n' "$out5" | sed -n 's/^path=//p')"
+
+# === 6. cleanup: clean worktree removed; missing is a no-op ================= #
+run "$repo3" --cleanup 5 >/dev/null 2>&1
+assert_eq "cleanup of a clean worktree succeeds" "0" "$?"
+[ ! -d "$repo3/.worktrees/issue-5" ] && ok "cleanup removed the directory" \
+  || fail "cleanup left the directory behind"
+run "$repo3" --cleanup 5 >/dev/null 2>&1
+assert_eq "cleanup of a missing worktree is a no-op (exit 0)" "0" "$?"
+
+# === 7. cleanup refuses a DIRTY worktree (never --force) ==================== #
+repo4="$(new_repo)"
+out4="$(run "$repo4" 9 2>/dev/null)"
+wt4="$(printf '%s\n' "$out4" | sed -n 's/^path=//p')"
+echo "uncommitted" > "$wt4/dirty.txt"
+run "$repo4" --cleanup 9 >/dev/null 2>&1
+assert_eq "cleanup refuses a dirty worktree (exit 2)" "2" "$?"
+[ -d "$wt4" ] && ok "dirty worktree preserved" || fail "dirty worktree was removed"
+
+# === 8. bad input ============================================================ #
+run "$repo4" abc >/dev/null 2>&1
+assert_eq "non-numeric issue rejected" "2" "$?"
+
+echo
+if [ "$FAILURES" -eq 0 ]; then echo "all dispatch-agent tests passed"; exit 0
+else echo "$FAILURES dispatch-agent test(s) failed"; exit 1; fi

--- a/tools/dispatch-agent.sh
+++ b/tools/dispatch-agent.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# tools/dispatch-agent.sh — make worktree isolation a RAIL, not a convention.
+#
+# Burn-in F12 (docs/orchestration/agent-verification-burn-in.md): a dispatched
+# implementer/writeup agent created its feature branch in the PRIMARY checkout
+# and left it stranded there. The fix documented at the time was a sentence in
+# docs/agent-team.md — "give the agent its own worktree" — which a forgotten
+# option or a future orchestrator regression can silently violate.
+#
+# This tool turns that convention into two mechanical rails:
+#
+#   1. `<issue#>`         — the ONE way to stand up an implementer workspace:
+#                           derives a branch off origin/main, creates (or
+#                           re-verifies) a dedicated git worktree under
+#                           .worktrees/, and prints its absolute path + branch
+#                           for the orchestrator to pass as the agent's cwd. It
+#                           never checks the feature branch out into the primary
+#                           tree, so the F12 failure cannot happen by using it.
+#
+#   2. `--assert-isolated` — the self-check an implementer runs as its FIRST
+#                           action: exit non-zero if the cwd is the primary
+#                           worktree, zero if it is a linked one. Detection is
+#                           mechanical (git's own worktree metadata), never a
+#                           guess based on the path string. A dispatched agent
+#                           that finds itself un-isolated stops instead of
+#                           writing into the primary tree.
+#
+#   3. `--cleanup <issue#>` — remove the worktree after merge, only if clean.
+#
+# What this deliberately does NOT do: it cannot intercept the harness's Agent
+# tool (a shell script has no way to), so it is a preflight + self-check, not an
+# execution sandbox. That is the whole ask from the review — "a small dispatch
+# wrapper/preflight is enough" — no daemon, scheduler, or service.
+#
+# Usage:
+#   tools/dispatch-agent.sh <issue#>            # create/verify + print path,branch
+#   tools/dispatch-agent.sh --assert-isolated   # exit 1 in the primary worktree
+#   tools/dispatch-agent.sh --cleanup <issue#>  # remove the worktree if clean
+#   tools/dispatch-agent.sh --print-path <issue#>  # just the worktree path (no create)
+#
+# Env:
+#   BASE_REF      base to branch from (default: origin/main)
+#   WORKTREE_DIR  container dir for worktrees (default: <mainroot>/.worktrees)
+set -euo pipefail
+
+die() { echo "dispatch-agent: $*" >&2; exit 2; }
+
+command -v git >/dev/null 2>&1 || die "git not found"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git repository"
+
+# --- primary vs linked worktree (mechanical, not path-string heuristics) ----- #
+# In the PRIMARY worktree, the absolute git dir IS the common git dir. In a
+# LINKED worktree, the git dir is <common>/worktrees/<name>, so the two differ.
+abs() { (cd "$1" 2>/dev/null && pwd) || return 1; }
+git_dir_abs="$(git rev-parse --absolute-git-dir)"
+common_dir_abs="$(abs "$(git rev-parse --git-common-dir)")" \
+  || die "cannot resolve --git-common-dir"
+
+is_primary_worktree() { [ "$git_dir_abs" = "$common_dir_abs" ]; }
+
+# --- --assert-isolated: the implementer's first-action self-check ------------ #
+if [ "${1:-}" = "--assert-isolated" ]; then
+  [ $# -eq 1 ] || die "--assert-isolated takes no other arguments"
+  if is_primary_worktree; then
+    cat >&2 <<EOF
+dispatch-agent: NOT ISOLATED — this is the PRIMARY checkout ($(git rev-parse --show-toplevel)).
+An implementer/writeup agent must run in a dedicated worktree so it can never
+strand the primary tree on a feature branch (burn-in F12). Stop and report a
+dispatch error; the orchestrator should create your workspace with:
+    tools/dispatch-agent.sh <issue#>
+and dispatch you with that path as your working directory.
+EOF
+    exit 1
+  fi
+  echo "dispatch-agent: isolated worktree OK ($(git rev-parse --show-toplevel))"
+  exit 0
+fi
+
+# Everything below operates on the MAIN worktree regardless of where we are run
+# from, so the tool works when invoked from the primary checkout (the normal
+# case) or from another worktree.
+main_root="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+[ -n "$main_root" ] || die "cannot determine the main worktree root"
+
+BASE_REF="${BASE_REF:-origin/main}"
+WORKTREE_DIR="${WORKTREE_DIR:-$main_root/.worktrees}"
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-40 | sed -E 's/-+$//'
+}
+
+# Branch name for an issue: issue-<n>-<slug-of-title> (slug best-effort via gh).
+branch_for_issue() {
+  local n="$1" title="" slug=""
+  if command -v gh >/dev/null 2>&1; then
+    title="$(gh issue view "$n" --json title --jq '.title' 2>/dev/null || true)"
+  fi
+  slug="$(slugify "$title")"
+  if [ -n "$slug" ]; then echo "issue-${n}-${slug}"; else echo "issue-${n}"; fi
+}
+
+worktree_path_for_issue() { echo "$WORKTREE_DIR/issue-$1"; }
+
+# --- --cleanup <issue#> ------------------------------------------------------ #
+if [ "${1:-}" = "--cleanup" ]; then
+  [ $# -eq 2 ] || die "usage: --cleanup <issue#>"
+  n="$2"; [[ "$n" =~ ^[0-9]+$ ]] || die "issue number must be numeric: $n"
+  wt="$(worktree_path_for_issue "$n")"
+  if ! git -C "$main_root" worktree list --porcelain | grep -qx "worktree $wt"; then
+    echo "dispatch-agent: no worktree registered at $wt (nothing to clean up)"
+    exit 0
+  fi
+  # `git worktree remove` refuses a dirty worktree unless --force; we never
+  # force, so uncommitted work is preserved and the caller is told.
+  if ! git -C "$main_root" worktree remove "$wt" 2>/dev/null; then
+    die "worktree at $wt is not clean (uncommitted changes) — commit/push or discard first; refusing to --force"
+  fi
+  echo "dispatch-agent: removed worktree $wt"
+  exit 0
+fi
+
+# --- --print-path <issue#> (no side effects) --------------------------------- #
+PRINT_ONLY=0
+if [ "${1:-}" = "--print-path" ]; then PRINT_ONLY=1; shift; fi
+
+# --- <issue#>: create or verify the dedicated worktree ----------------------- #
+[ $# -eq 1 ] || die "usage: tools/dispatch-agent.sh <issue#> | --assert-isolated | --cleanup <issue#> | --print-path <issue#>"
+case "$1" in -*) die "unknown option: $1" ;; esac
+n="$1"; [[ "$n" =~ ^[0-9]+$ ]] || die "issue number must be numeric: $n"
+
+wt="$(worktree_path_for_issue "$n")"
+
+if [ "$PRINT_ONLY" = 1 ]; then
+  echo "$wt"
+  exit 0
+fi
+
+branch="$(branch_for_issue "$n")"
+
+# Refuse to operate in-place: the target worktree must never be the primary
+# checkout (this is what would recreate F12).
+if [ "$(abs "$wt" 2>/dev/null || echo "$wt")" = "$(abs "$main_root")" ]; then
+  die "refusing to use the primary checkout ($main_root) as an implementer worktree"
+fi
+
+git -C "$main_root" fetch --no-tags -q origin "${BASE_REF#origin/}" 2>/dev/null || true
+
+# Already registered? Verify it points at our branch, then reuse it.
+if git -C "$main_root" worktree list --porcelain | grep -qx "worktree $(abs "$wt" 2>/dev/null || echo "$wt")" \
+   || git -C "$main_root" worktree list --porcelain | grep -qx "worktree $wt"; then
+  cur="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+  if [ "$cur" != "$branch" ]; then
+    die "worktree $wt already exists on branch '$cur', not '$branch' — resolve manually (or --cleanup $n first)"
+  fi
+  echo "dispatch-agent: reusing worktree"
+else
+  mkdir -p "$WORKTREE_DIR"
+  if git -C "$main_root" show-ref --verify --quiet "refs/heads/$branch"; then
+    git -C "$main_root" worktree add "$wt" "$branch" >&2
+  else
+    git -C "$main_root" worktree add -b "$branch" "$wt" "$BASE_REF" >&2
+  fi
+fi
+
+# Machine-parseable last two lines: absolute path, then branch.
+echo "path=$(abs "$wt")"
+echo "branch=$branch"


### PR DESCRIPTION
## Linked Issue

Closes #203

## Exact behavioral claim

`tools/dispatch-agent.sh` turns worktree isolation from a documented convention into a mechanical rail. `tools/dispatch-agent.sh <issue#>` derives `issue-<n>-<slug>` off `origin/main`, creates (or re-verifies) a dedicated worktree under `.worktrees/issue-<n>`, and prints `path=<abs>` / `branch=<name>`; it never checks the feature branch out into the primary tree. `tools/dispatch-agent.sh --assert-isolated` exits non-zero in the PRIMARY worktree and zero in a linked one, decided by git's own metadata (`--absolute-git-dir` vs `--git-common-dir`), not a cwd-string heuristic. `--cleanup <issue#>` removes a worktree only when clean (never `--force`). Each implementer role (`engine-dev`, `orchestration-dev`, `case-author`, `rules-extractor`) now runs `--assert-isolated` as its first action and stops with a dispatch error if it is in the primary checkout.

## Scope

New `tools/dispatch-agent.sh`; new `tests/tooling/test_dispatch_agent.sh`; the four implementer role docs under `.claude/agents/` (isolation precondition); `docs/agent-team.md` (F12 paragraph → "dispatch via `tools/dispatch-agent.sh`"); `.gitignore` (`.worktrees/`). No engine or CI change. Reviewer (read-only) roles are untouched — they do not write and need no worktree.

## Rules conformance

N/A — orchestration tooling; no rules-engine files (`src/Brp.*`) touched.

## Tests and evidence

`bash tests/tooling/test_dispatch_agent.sh` → all 15 assertions pass (isolated throwaway git repos, `gh` stubbed, `BASE_REF=main`; covers assert-isolated both directions, create/reuse, slug naming, `--print-path` no-op, cleanup of clean/missing, refusal on a dirty worktree, bad input). Manual: `tools/dispatch-agent.sh --assert-isolated` in the primary tree → exit 1; created a real worktree for a throwaway issue, ran `--assert-isolated` inside it → exit 0, primary tree stayed clean, `--cleanup` removed it. `tools/route.sh --base origin/main` → `route: tooling / gates: ci`. `bash tools/orchestration-policy.sh` → PASS.

## Decisions and tradeoffs

Isolation detection uses git worktree metadata rather than matching the cwd string (the recorded dead end on the Issue). The tool is a preflight + self-check, not an execution sandbox: a shell script cannot intercept the harness's Agent tool, so the rail is (a) one command that builds the correct worktree and (b) a mechanical first-action check that fails fast — exactly the "small dispatch wrapper/preflight" the review called sufficient. `--cleanup` never forces, so uncommitted work is preserved and the caller is told.

## Known limitations

Cannot physically prevent launching an agent in the primary tree; it makes the un-isolated case fail loudly and immediately instead of silently stranding the tree. `tests/tooling/*.sh` (this test included) are not yet run in CI — separate gap (#61).

## Agent provenance

Implemented and PR assembled by the orchestrator (Claude Opus 4.8) directly — a control-plane change to the dispatch mechanism itself.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).