### PR TITLE
Bind semantic gate verdicts to {head SHA + packet hash + gate identity}

### DIFF
--- a/.claude/agents/rules-conformance.md
+++ b/.claude/agents/rules-conformance.md
@@ -64,4 +64,8 @@ casual testing, and silently corrupts every layer above. Two documented near-mis
 For each rule checked: the rule, the section it comes from, how many rows or values
 you verified, and a verdict of CONFIRMED or a specific defect with the input that
 breaks it. Rank defects most severe first. Say plainly when something is correct —
-a clean verdict is a real result.
+a clean verdict is a real result. End with a single clear overall verdict line
+(`VERDICT: pass` or `VERDICT: fail`): the orchestrator records it with
+`tools/gate-evidence.sh`, which binds your verdict to the exact head SHA and
+review-packet hash you saw, so it cannot ride onto a later commit (Issue #205). A
+`BRIEF DEFICIENCY` return is not a pass — no verdict is recorded.

--- a/.claude/agents/scope-warden.md
+++ b/.claude/agents/scope-warden.md
@@ -59,4 +59,9 @@ enforcement working, not a bug; do not attempt to route around it.
 ## Output
 
 A short pass/fail per applicable item, with file and line for any failure. If
-nothing in the diff raises a semantic question, say so in one line and stop.
+nothing in the diff raises a semantic question, say so in one line and stop. End
+with a single clear overall verdict line (`VERDICT: pass` or `VERDICT: fail`): the
+orchestrator records it with `tools/gate-evidence.sh`, which binds your verdict to
+the exact head SHA and review-packet hash you saw, so it cannot be reused on a later
+commit (Issue #205). If you returned `BRIEF DEFICIENCY`, that is not a pass — no
+verdict is recorded.

--- a/docs/orchestration/agent-verification.md
+++ b/docs/orchestration/agent-verification.md
@@ -35,21 +35,59 @@ its numeric content-escalation — is derived from the PR's own diff):
 # 1. See what the route requires and what's missing (dry run).
 tools/agent-verify.sh <PR#>
 
-# 2. Post the aggregate status + a per-gate evidence block in the PR body.
+# 2. For each semantic gate, record a verdict BOUND to the head + review packet.
+#    (build the review packet the reviewer actually saw first)
+tools/agent-brief.py review <PR#> > /tmp/review.md
+tools/gate-evidence.sh --pr <PR#> --gate scope-warden --verdict pass \
+  --review-packet /tmp/review.md --model haiku --out /tmp/sw.json
+tools/gate-evidence.sh --pr <PR#> --gate rules-conformance --verdict pass \
+  --review-packet /tmp/review.md --model opus --out /tmp/rc.json
+
+# 3. Post the aggregate status + a per-gate evidence block in the PR body.
 tools/agent-verify.sh <PR#> \
-  --gate scope-warden=pass \
-  --gate rules-conformance=pass \
+  --gate-evidence /tmp/sw.json \
+  --gate-evidence /tmp/rc.json \
   --post --evidence
 ```
 
 - `ci` is **read from GitHub** (the `build-and-test` check-run on the head SHA), never
   supplied by hand.
-- Every *other* required gate must be supplied via `--gate NAME=pass|fail|skip`. A
-  gate the route does not require is rejected (a typo or a stale assumption); a
-  required gate left unsupplied leaves the aggregate `pending`, so **success is never
-  posted on incomplete evidence**.
+- Every *other* required gate must be supplied via `--gate-evidence FILE` (preferred)
+  or `--gate NAME=pass|fail|skip`. A gate the route does not require is rejected (a
+  typo or a stale assumption); a required gate left unsupplied leaves the aggregate
+  `pending`, so **success is never posted on incomplete evidence**.
 - Default is a dry run. `--post` posts the status; `--evidence` also writes a managed
-  `<!-- agent-verification -->` block into the PR body for humans.
+  `<!-- agent-verification -->` block into the PR body for humans (now with a per-gate
+  binding column).
+
+## Binding a semantic verdict to the head + review packet (#205)
+
+`agent-verification` is bound to the SHA by construction, but a verdict fed in as a
+naked `--gate scope-warden=pass` is an *unverifiable assertion*: nothing proves it was
+produced against **this** head and **this** review packet, so an accidentally reused
+pass could ride onto a new commit. That was the review's remaining accidental-error
+hole — a tired orchestrator, not a malicious one, is enough to trigger it.
+
+[`tools/gate-evidence.sh`](../../tools/gate-evidence.sh) closes it by recording a
+verdict as `{gate, verdict, headSha, reviewPacketSha256, sourcePacketSha256, reviewer,
+model}`, and `agent-verify.sh --gate-evidence FILE` **refuses** the verdict unless:
+
+- `headSha` still equals the current PR head; and
+- a freshly regenerated `agent-brief.py review <pr>` reproduces the recorded
+  `reviewPacketSha256` (agent-brief is deterministic — no timestamp — and the appended
+  `<!-- agent-verification -->` body block is section-less, so it does not perturb the
+  hash). A changed diff/claim/issue changes the hash, which correctly forces a re-review.
+
+`sourcePacketSha256` (codex conformance) is **recorded** for provenance but not
+re-validated: the source PDF is pinned by `orchestration-policy`, but the page range
+is not recoverable at verify time. Bound gates are `bound:true` in the evidence object;
+naked `--gate` gates are `bound:false`. `--post` will **not** mint `success` while any
+required non-`ci` pass gate is unbound, unless `--allow-unbound-gates` is passed —
+which is itself recorded as `unboundGatesAllowed:true`, so the override is never silent.
+
+`gate-evidence.sh` builds input only; it mints nothing. `agent-verify.sh` remains the
+one dynamic verification-evidence authority (#136) — this is a tightening of that
+interface, not a second authority or new control plane.
 - Works from any branch. When the working tree is on the PR head it routes from the
   local diff (`route.sh --base`); otherwise it fetches the full PR patch with
   `gh pr diff` and classifies it via `route.sh --diff-file`, so the `rules → formulas`

--- a/tests/tooling/test_agent_verify.sh
+++ b/tests/tooling/test_agent_verify.sh
@@ -3,10 +3,12 @@
 # canonical verification-evidence object (Issue #136).
 #
 # agent-verify.sh is the ONE dynamic verification-evidence authority: it reads
-# the real build-and-test check-run from GitHub, combines it with the --gate
-# evidence supplied for the route's other required gates, and must render the
-# same {schemaVersion, pr, issue, headSha, route, requiredGates, gates, aggregate}
-# object through --json/--json-out AND the human --evidence PR-body block.
+# the real build-and-test check-run from GitHub, combines it with the --gate /
+# --gate-evidence verdicts supplied for the route's other required gates, and must
+# render the same {schemaVersion, pr, issue, headSha, route, requiredGates, gates,
+# gateEvidence, unboundGatesAllowed, aggregate} object through --json/--json-out
+# AND the human --evidence PR-body block. Semantic-verdict head/packet binding
+# (Issue #205) is exercised by test_gate_evidence.sh and cases 10–13 below.
 #
 # No `gh` CLI network access is available in this environment (or in CI), so
 # this stubs `gh` with a fixture script that answers the exact calls
@@ -140,7 +142,7 @@ ev = json.load(sys.stdin)
 print(ev["schemaVersion"], ev["pr"], ev["issue"], ev["headSha"], ev["route"],
       ev["aggregate"], ev["gates"]["ci"], ev["gates"]["scope-warden"])
 ')"
-assert_eq "case1: schemaVersion" "1" "$schema"
+assert_eq "case1: schemaVersion" "2" "$schema"
 assert_eq "case1: pr number"     "999" "$pr"
 assert_eq "case1: linked issue"  "136" "$issue"
 assert_eq "case1: aggregate"     "success" "$agg"
@@ -149,7 +151,7 @@ assert_eq "case1: scope-warden gate" "pass" "$gate_sw"
 
 keys="$(printf '%s' "$json" | python3 -c 'import json,sys; print(sorted(json.load(sys.stdin).keys()))')"
 assert_eq "case1: exact canonical key set" \
-  "['aggregate', 'gates', 'headSha', 'issue', 'pr', 'requiredGates', 'route', 'schemaVersion']" \
+  "['aggregate', 'gateEvidence', 'gates', 'headSha', 'issue', 'pr', 'requiredGates', 'route', 'schemaVersion', 'unboundGatesAllowed']" \
   "$keys"
 
 rc=0; MOCK_CI_CONCLUSION=success run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass >/dev/null || rc=$?
@@ -250,15 +252,96 @@ assert_contains "case9: refusal message names the mismatch" "$err9" "refusing to
 assert_contains "case9: refusal message cites F10" "$err9" "F10"
 
 # --- case 10: converged-head guard is a no-op when gh and git agree -------- #
+# Gates are naked --gate here (unbound), so posting success now requires the
+# explicit --allow-unbound-gates override (Issue #205); this case tests the
+# convergence no-op, not binding. Cases 11–14 test the bound path.
 git -C "$ROOT" update-ref "$FIXTURE_REF" "$PR_HEAD_SHA"
 out10="$(MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
-  run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --post)"
+  run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --allow-unbound-gates --post)"
 assert_contains "case10: --post proceeds and posts when heads converge" "$out10" "posted: agent-verification = success"
 
 rc10=0
 MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
-  run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --post >/dev/null || rc10=$?
+  run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --allow-unbound-gates --post >/dev/null || rc10=$?
 assert_eq "case10: exit 0 when converged heads and gates all pass" "0" "$rc10"
+
+# =========================================================================== #
+# Issue #205 — semantic-verdict head/packet binding via --gate-evidence.
+# A stub agent-brief.py (AGENT_VERIFY_AGENT_BRIEF) emits a review packet whose
+# packet-sha256 footer we control; evidence files carry a headSha + a
+# reviewPacketSha256 that agent-verify must re-validate against the current PR
+# head + the freshly regenerated packet hash.
+# =========================================================================== #
+STUB_RPS="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+STUB_BRIEF="$WORKDIR/agent-brief-stub.sh"
+cat > "$STUB_BRIEF" <<STUB
+#!/usr/bin/env bash
+# emits a deterministic review packet with a controllable footer hash
+cat <<BODY
+# REVIEW BRIEF — stub
+BODY
+printf -- '---\npacket-schema: review-packet/1\npacket-version: 1\npacket-sha256: %s\n' "\${STUB_PACKET_SHA:-$STUB_RPS}"
+STUB
+chmod +x "$STUB_BRIEF"
+
+# helper: write a gate-evidence JSON file
+write_ev() { # $1=path $2=gate $3=verdict $4=headSha $5=reviewPacketSha256
+  cat > "$1" <<EV
+{ "schemaVersion": 1, "gate": "$2", "verdict": "$3", "pr": 999,
+  "headSha": "$4", "reviewPacketSha256": "$5", "sourcePacketSha256": null,
+  "reviewer": "$2", "model": "test" }
+EV
+}
+
+SW_EV="$WORKDIR/sw.json"; RC_EV="$WORKDIR/rc.json"
+
+# --- case 11: fresh bound evidence -> success, bound:true, posts ------------ #
+git -C "$ROOT" update-ref "$FIXTURE_REF" "$PR_HEAD_SHA"
+write_ev "$SW_EV" scope-warden     pass "$PR_HEAD_SHA" "$STUB_RPS"
+write_ev "$RC_EV" rules-conformance pass "$PR_HEAD_SHA" "$STUB_RPS"
+json11="$(MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
+  AGENT_VERIFY_AGENT_BRIEF="$STUB_BRIEF" \
+  run_verify 999 --gate-evidence "$SW_EV" --gate-evidence "$RC_EV" --json)"
+agg11="$(printf '%s' "$json11" | python3 -c 'import json,sys; print(json.load(sys.stdin)["aggregate"])')"
+assert_eq "case11: fresh bound evidence -> aggregate success" "success" "$agg11"
+bound11="$(printf '%s' "$json11" | python3 -c 'import json,sys; ev=json.load(sys.stdin); print(ev["gateEvidence"]["scope-warden"]["bound"], ev["gateEvidence"]["rules-conformance"]["bound"])')"
+assert_eq "case11: both gates marked bound" "True True" "$bound11"
+rps11="$(printf '%s' "$json11" | python3 -c 'import json,sys; print(json.load(sys.stdin)["gateEvidence"]["scope-warden"]["reviewPacketSha256"])')"
+assert_eq "case11: recorded review packet hash" "$STUB_RPS" "$rps11"
+
+out11="$(MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
+  AGENT_VERIFY_AGENT_BRIEF="$STUB_BRIEF" \
+  run_verify 999 --gate-evidence "$SW_EV" --gate-evidence "$RC_EV" --post)"
+assert_contains "case11: bound evidence posts success without --allow-unbound-gates" "$out11" "posted: agent-verification = success"
+
+# --- case 12: unbound --gate + --post (converged) is REFUSED --------------- #
+rc12=0
+err12="$(MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
+  run_verify 999 --gate scope-warden=pass --gate rules-conformance=pass --post 2>&1 1>/dev/null)" || rc12=$?
+assert_eq "case12: unbound --gate --post refused (exit 2)" "2" "$rc12"
+assert_contains "case12: refusal cites unbound" "$err12" "UNBOUND"
+assert_contains "case12: refusal cites Issue #205" "$err12" "#205"
+
+# --- case 13: stale head in evidence is refused ---------------------------- #
+write_ev "$SW_EV" scope-warden pass "$STALE_SHA" "$STUB_RPS"
+write_ev "$RC_EV" rules-conformance pass "$PR_HEAD_SHA" "$STUB_RPS"
+rc13=0
+err13="$(MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
+  AGENT_VERIFY_AGENT_BRIEF="$STUB_BRIEF" \
+  run_verify 999 --gate-evidence "$SW_EV" --gate-evidence "$RC_EV" --json 2>&1 1>/dev/null)" || rc13=$?
+assert_eq "case13: stale-head evidence refused (exit 2)" "2" "$rc13"
+assert_contains "case13: refusal names stale head" "$err13" "STALE"
+
+# --- case 14: stale review-packet hash in evidence is refused -------------- #
+# Evidence records the old hash; the stub now regenerates a DIFFERENT hash.
+write_ev "$SW_EV" scope-warden pass "$PR_HEAD_SHA" "$STUB_RPS"
+write_ev "$RC_EV" rules-conformance pass "$PR_HEAD_SHA" "$STUB_RPS"
+rc14=0
+err14="$(MOCK_HEAD_SHA="$PR_HEAD_SHA" MOCK_HEAD_REF_NAME="agent-verify-test-fixture-branch" MOCK_CI_CONCLUSION=success \
+  AGENT_VERIFY_AGENT_BRIEF="$STUB_BRIEF" STUB_PACKET_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+  run_verify 999 --gate-evidence "$SW_EV" --gate-evidence "$RC_EV" --json 2>&1 1>/dev/null)" || rc14=$?
+assert_eq "case14: stale-packet evidence refused (exit 2)" "2" "$rc14"
+assert_contains "case14: refusal names packet-hash mismatch" "$err14" "reviewPacketSha256"
 
 echo
 if [ "$FAILURES" -eq 0 ]; then

--- a/tests/tooling/test_gate_evidence.sh
+++ b/tests/tooling/test_gate_evidence.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# tests/tooling/test_gate_evidence.sh — fixture tests for tools/gate-evidence.sh,
+# the per-gate verdict builder that binds a reviewer's verdict to
+# {head SHA + review-packet hash + gate identity} (Issue #205).
+#
+# `gh` is stubbed on PATH to answer `gh pr view N --json headRefOid --jq
+# .headRefOid` with a fixed SHA. Packets are plain fixture files; the review
+# packet carries a `packet-sha256:` footer exactly as tools/agent-brief.py emits.
+#
+# Run directly:
+#   tests/tooling/test_gate_evidence.sh
+# Exit: 0 if every case passes, 1 on the first failure.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/gate-evidence.sh"
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+assert_eq() { local d="$1" e="$2" a="$3"; [ "$e" = "$a" ] && ok "$d" || fail "$d (expected [$e], got [$a])"; }
+assert_contains() { local d="$1" h="$2" n="$3"; case "$h" in *"$n"*) ok "$d" ;; *) fail "$d (missing [$n] in [$h])" ;; esac }
+
+WORKDIR="$(mktemp -d)"; BINDIR="$WORKDIR/bin"; mkdir -p "$BINDIR"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+HEAD="1234567890abcdef1234567890abcdef12345678"
+cat > "$BINDIR/gh" <<STUB
+#!/usr/bin/env bash
+# gh pr view N --json headRefOid --jq .headRefOid
+if [ "\${1:-}" = "pr" ] && [ "\${2:-}" = "view" ]; then printf '%s' "${HEAD}"; exit 0; fi
+exit 1
+STUB
+chmod +x "$BINDIR/gh"
+
+RPS="cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
+REVIEW="$WORKDIR/review.md"
+{ printf '# REVIEW BRIEF — fixture\n'; printf -- '---\npacket-schema: review-packet/1\npacket-version: 1\npacket-sha256: %s\n' "$RPS"; } > "$REVIEW"
+SOURCE="$WORKDIR/source.txt"; printf 'BRP source packet fixture\n' > "$SOURCE"
+SRC_SHA="$(sha256sum "$SOURCE" | cut -d' ' -f1)"
+
+run() { PATH="$BINDIR:$PATH" "$SCRIPT" "$@"; }
+
+# === 1. happy path (no source packet) ======================================= #
+j="$(run --pr 42 --gate scope-warden --verdict pass --review-packet "$REVIEW" --model haiku)"
+printf '%s' "$j" | python3 -m json.tool >/dev/null && ok "case1: valid JSON" || fail "case1: valid JSON"
+read -r g v pr hs rps sps rev mod <<< "$(printf '%s' "$j" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+print(d["gate"],d["verdict"],d["pr"],d["headSha"],d["reviewPacketSha256"],d["sourcePacketSha256"],d["reviewer"],d["model"])')"
+assert_eq "case1: gate"    "scope-warden" "$g"
+assert_eq "case1: verdict" "pass"         "$v"
+assert_eq "case1: pr"      "42"           "$pr"
+assert_eq "case1: headSha" "$HEAD"        "$hs"
+assert_eq "case1: reviewPacketSha256 from footer" "$RPS" "$rps"
+assert_eq "case1: sourcePacketSha256 null when none" "None" "$sps"
+assert_eq "case1: reviewer defaults to gate" "scope-warden" "$rev"
+assert_eq "case1: model recorded" "haiku" "$mod"
+
+# === 2. source packet hashed for provenance ================================= #
+j2="$(run --pr 42 --gate codex-conformance --verdict pass --review-packet "$REVIEW" --source-packet "$SOURCE")"
+sps2="$(printf '%s' "$j2" | python3 -c 'import json,sys; print(json.load(sys.stdin)["sourcePacketSha256"])')"
+assert_eq "case2: sourcePacketSha256 == sha256(file)" "$SRC_SHA" "$sps2"
+
+# === 3. --out writes a file ================================================= #
+run --pr 42 --gate scope-warden --verdict pass --review-packet "$REVIEW" --out "$WORKDIR/ev.json" 2>/dev/null
+[ -s "$WORKDIR/ev.json" ] && python3 -m json.tool < "$WORKDIR/ev.json" >/dev/null \
+  && ok "case3: --out wrote valid JSON" || fail "case3: --out wrote valid JSON"
+
+# === 4. bad verdict rejected ================================================ #
+rc=0; run --pr 42 --gate scope-warden --verdict maybe --review-packet "$REVIEW" >/dev/null 2>&1 || rc=$?
+assert_eq "case4: bad verdict rejected (exit 2)" "2" "$rc"
+
+# === 5. review packet without a footer rejected ============================= #
+NOFOOT="$WORKDIR/nofoot.md"; printf 'no footer here\n' > "$NOFOOT"
+rc=0; err="$(run --pr 42 --gate scope-warden --verdict pass --review-packet "$NOFOOT" 2>&1 1>/dev/null)" || rc=$?
+assert_eq "case5: missing footer rejected (exit 2)" "2" "$rc"
+assert_contains "case5: names the footer" "$err" "packet-sha256"
+
+# === 6. missing review packet file rejected ================================= #
+rc=0; run --pr 42 --gate scope-warden --verdict pass --review-packet "$WORKDIR/nope.md" >/dev/null 2>&1 || rc=$?
+assert_eq "case6: missing review packet rejected (exit 2)" "2" "$rc"
+
+# === 7. non-numeric pr rejected ============================================= #
+rc=0; run --pr abc --gate scope-warden --verdict pass --review-packet "$REVIEW" >/dev/null 2>&1 || rc=$?
+assert_eq "case7: non-numeric --pr rejected (exit 2)" "2" "$rc"
+
+echo
+if [ "$FAILURES" -eq 0 ]; then echo "test_gate_evidence.sh: all checks passed"; exit 0
+else echo "test_gate_evidence.sh: $FAILURES check(s) failed"; exit 1; fi

--- a/tools/agent-verify.sh
+++ b/tools/agent-verify.sh
@@ -21,13 +21,30 @@
 # for a head SHA is built here, once, and both the machine (--json) and human
 # (--evidence) renderings come from that same in-memory object.
 #
+# Binding semantic verdicts to the head SHA + review packet (Issue #205): a gate
+# supplied as a naked `--gate NAME=pass` is an unverifiable assertion — nothing
+# proves that verdict was produced against THIS head and THIS review packet, so an
+# accidentally reused pass could ride onto a new SHA. `--gate-evidence FILE`
+# consumes a verdict file written by tools/gate-evidence.sh and REFUSES unless the
+# file's recorded head SHA still equals the current PR head AND a freshly
+# regenerated review packet (agent-brief.py review — deterministic) reproduces the
+# recorded packet hash. Bound gates are marked `bound:true` in the evidence object;
+# naked `--gate` gates are `bound:false`. `--post` will not mint `success` while any
+# required non-`ci` pass gate is unbound, unless `--allow-unbound-gates` is given
+# (recorded as `unboundGatesAllowed:true`). This is a tightening of the existing
+# authority, not new orchestration machinery — gate-evidence.sh only builds input.
+#
 # Usage:
-#   tools/agent-verify.sh <PR#> [--gate NAME=pass|fail|skip ...] [--base REF]
-#                               [--post] [--wait] [--evidence] [--json] [--json-out FILE]
+#   tools/agent-verify.sh <PR#> [--gate NAME=pass|fail|skip ...]
+#                               [--gate-evidence FILE ...] [--allow-unbound-gates]
+#                               [--base REF] [--post] [--wait] [--evidence]
+#                               [--json] [--json-out FILE]
 #
 #   * `ci` is read from GitHub (the `build-and-test` check-run) — never supplied.
-#   * every OTHER required gate must be supplied via --gate; a missing one leaves
-#     the aggregate `pending` (success is never posted on incomplete evidence).
+#   * every OTHER required gate must be supplied via --gate or --gate-evidence; a
+#     missing one leaves the aggregate `pending` (success is never posted on
+#     incomplete evidence). Prefer --gate-evidence: it binds the verdict to the
+#     head SHA + review packet; --gate stays for dry-runs / skip / fail / override.
 #   * default is a DRY RUN that prints the plan; --post actually posts the status;
 #     --evidence additionally writes the per-gate block into the PR body.
 #   * --json prints the canonical evidence object to stdout as JSON (nothing else
@@ -47,14 +64,18 @@ CONTEXT="agent-verification"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 die() { echo "agent-verify: $*" >&2; exit 2; }
 
-PR=""; BASE="origin/main"; POST=0; EVIDENCE=0; JSON=0; JSON_OUT=""; WAIT=0
+PR=""; BASE="origin/main"; POST=0; EVIDENCE=0; JSON=0; JSON_OUT=""; WAIT=0; ALLOW_UNBOUND=0
 declare -A GATE=()
+declare -a GATE_EVIDENCE_FILES=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --gate) [ $# -ge 2 ] || die "--gate needs NAME=STATE"
             n="${2%%=*}"; s="${2#*=}"
             case "$s" in pass|fail|skip) ;; *) die "gate state must be pass|fail|skip: $2" ;; esac
             GATE["$n"]="$s"; shift 2 ;;
+    --gate-evidence) [ $# -ge 2 ] || die "--gate-evidence needs FILE"
+            GATE_EVIDENCE_FILES+=("$2"); shift 2 ;;
+    --allow-unbound-gates) ALLOW_UNBOUND=1; shift ;;
     --base) BASE="${2:-}"; shift 2 ;;
     --post) POST=1; shift ;;
     --wait) WAIT=1; shift ;;
@@ -65,7 +86,15 @@ while [ $# -gt 0 ]; do
     *)  [ -z "$PR" ] || die "unexpected argument: $1"; PR="$1"; shift ;;
   esac
 done
-[ -n "$PR" ] || die "usage: agent-verify.sh <PR#> [--gate NAME=STATE ...] [--post] [--wait] [--evidence] [--json] [--json-out FILE]"
+[ -n "$PR" ] || die "usage: agent-verify.sh <PR#> [--gate NAME=STATE ...] [--gate-evidence FILE ...] [--allow-unbound-gates] [--post] [--wait] [--evidence] [--json] [--json-out FILE]"
+
+# agent-brief.py, used to regenerate the review packet hash for --gate-evidence
+# freshness checks. Overridable (tests stub it) but defaults to the repo tool.
+AGENT_BRIEF="${AGENT_VERIFY_AGENT_BRIEF:-$ROOT/tools/agent-brief.py}"
+
+# Per-gate binding provenance (parallel to GATE/RESULT), populated from
+# --gate-evidence files below. BOUND defaults to 0 for any gate not bound.
+declare -A BOUND=() EV_HEADSHA=() EV_RPS=() EV_SPS=() EV_REVIEWER=() EV_MODEL=()
 
 # --- resolve the PR ------------------------------------------------------- #
 read_pr_head() {
@@ -162,6 +191,64 @@ for n in "${!GATE[@]}"; do
   [ "$n" = ci ] && die "ci is read from GitHub, not supplied via --gate"
 done
 
+# --- consume --gate-evidence files and bind them to head + review packet --- #
+# A gate-evidence file (tools/gate-evidence.sh) carries a verdict plus the head
+# SHA and review-packet hash it was produced against. We accept its verdict ONLY
+# if both still hold for the current PR: the recorded head equals the PR head,
+# and a freshly regenerated review packet reproduces the recorded packet hash.
+# This is the mechanical freshness the naked `--gate` path lacks (Issue #205).
+CURRENT_RPS=""; CURRENT_RPS_COMPUTED=0
+current_review_packet_sha() {
+  # Regenerate the review packet for this PR and return its packet-sha256 footer.
+  # agent-brief.py is deterministic (no timestamp), so the same repo/PR state
+  # reproduces the same hash the reviewer's packet carried. Computed once.
+  if [ "$CURRENT_RPS_COMPUTED" = 0 ]; then
+    CURRENT_RPS="$("$AGENT_BRIEF" review "$PR" 2>/dev/null \
+      | grep -E '^packet-sha256:[[:space:]]*[0-9a-f]+' | tail -1 | awk '{print $2}')" || true
+    CURRENT_RPS_COMPUTED=1
+  fi
+  printf '%s' "$CURRENT_RPS"
+}
+
+for f in ${GATE_EVIDENCE_FILES[@]+"${GATE_EVIDENCE_FILES[@]}"}; do
+  [ -n "$f" ] || continue
+  [ -f "$f" ] || die "--gate-evidence file not found: $f"
+  # Parse the file into TSV: gate, verdict, headSha, rps, sps, reviewer, model.
+  IFS=$'\t' read -r eg ev eh erps esps erev emod < <(python3 - "$f" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    d = json.load(fh)
+def g(k):
+    v = d.get(k)
+    return "" if v is None else str(v)
+print("\t".join([g("gate"), g("verdict"), g("headSha"), g("reviewPacketSha256"),
+                 g("sourcePacketSha256"), g("reviewer"), g("model")]))
+PYEOF
+  ) || die "cannot parse gate-evidence file (not valid JSON?): $f"
+
+  [ -n "$eg" ] || die "gate-evidence $f: missing 'gate'"
+  case "$ev" in pass|fail|skip) ;; *) die "gate-evidence $f: verdict must be pass|fail|skip (got '${ev:-<empty>}')" ;; esac
+  printf '%s\n' "${REQUIRED[@]}" | grep -qx "$eg" || die "gate-evidence $f: gate '$eg' is not required by route '$ROUTE_NAME'"
+  [ "$eg" = ci ] && die "gate-evidence $f: ci is read from GitHub, not supplied as evidence"
+  [ -n "${GATE[$eg]+x}" ] && die "gate '$eg' supplied both as --gate and --gate-evidence — use one"
+  [ -n "${BOUND[$eg]+x}" ] && die "gate '$eg' supplied by more than one --gate-evidence file"
+
+  # Freshness 1: the head the verdict was bound to must still be the PR head.
+  [ "$eh" = "$HEAD_SHA" ] || die "gate-evidence $f: recorded headSha ${eh:0:7} != current PR head ${HEAD_SHA:0:7} — this verdict is STALE (produced against a superseded commit). Re-run gate '$eg' on the current head and rebuild its evidence."
+  # Freshness 2: the review packet the reviewer saw must still regenerate.
+  cur="$(current_review_packet_sha)"
+  [ -n "$cur" ] || die "cannot regenerate the review packet for PR #$PR (agent-brief.py review) to verify gate-evidence freshness"
+  [ "$erps" = "$cur" ] || die "gate-evidence $f: recorded reviewPacketSha256 ${erps:0:12} != freshly regenerated ${cur:0:12} — the review packet gate '$eg' saw no longer matches this PR (diff/claim/issue changed). Re-run the gate on the current packet."
+
+  GATE["$eg"]="$ev"
+  BOUND["$eg"]=1
+  EV_HEADSHA["$eg"]="$eh"; EV_RPS["$eg"]="$erps"; EV_SPS["$eg"]="$esps"
+  EV_REVIEWER["$eg"]="$erev"; EV_MODEL["$eg"]="$emod"
+done
+
+# Any gate supplied via naked --gate (not evidence) is unbound.
+for n in "${!GATE[@]}"; do [ -n "${BOUND[$n]+x}" ] || BOUND["$n"]=0; done
+
 # --- ci: read the build-and-test check-run on the head SHA ---------------- #
 ci_conclusion() {
   gh api "repos/{owner}/{repo}/commits/$HEAD_SHA/check-runs" \
@@ -198,11 +285,22 @@ STATE="$overall"
 # exact object — neither reconstructs gate state independently (see #136).
 GATES_KV=""
 for g in "${REQUIRED[@]}"; do GATES_KV+="$g=${RESULT[$g]};"; done
-EVIDENCE_JSON="$(python3 - "$PR" "$ISSUE_NUM" "$HEAD_SHA" "$ROUTE_NAME" "$STATE" "$GATES_KV" <<'PYEOF'
+
+# Per-gate binding provenance, one TSV record per non-ci required gate, passed to
+# the builder via the environment so tabs survive intact:
+#   gate \t bound(0|1) \t headSha \t reviewPacketSha256 \t sourcePacketSha256 \t reviewer \t model
+PROV_TSV=""
+for g in "${REQUIRED[@]}"; do
+  [ "$g" = ci ] && continue
+  PROV_TSV+="$g"$'\t'"${BOUND[$g]:-0}"$'\t'"${EV_HEADSHA[$g]:-}"$'\t'"${EV_RPS[$g]:-}"$'\t'"${EV_SPS[$g]:-}"$'\t'"${EV_REVIEWER[$g]:-}"$'\t'"${EV_MODEL[$g]:-}"$'\n'
+done
+
+EVIDENCE_JSON="$(PROV_TSV="$PROV_TSV" python3 - "$PR" "$ISSUE_NUM" "$HEAD_SHA" "$ROUTE_NAME" "$STATE" "$GATES_KV" "$ALLOW_UNBOUND" <<'PYEOF'
 import json
+import os
 import sys
 
-pr, issue, head_sha, route, aggregate, gates_kv = sys.argv[1:7]
+pr, issue, head_sha, route, aggregate, gates_kv, allow_unbound = sys.argv[1:8]
 gates = {}
 required = []
 for pair in gates_kv.split(";"):
@@ -212,25 +310,62 @@ for pair in gates_kv.split(";"):
     gates[name] = state
     required.append(name)
 
+gate_evidence = {}
+for line in os.environ.get("PROV_TSV", "").splitlines():
+    if not line:
+        continue
+    parts = line.split("\t")
+    while len(parts) < 7:
+        parts.append("")
+    name, bound, hsha, rps, sps, reviewer, model = parts[:7]
+    gate_evidence[name] = {
+        "bound": bound == "1",
+        "headSha": hsha or None,
+        "reviewPacketSha256": rps or None,
+        "sourcePacketSha256": sps or None,
+        "reviewer": reviewer or None,
+        "model": model or None,
+    }
+
 evidence = {
-    "schemaVersion": 1,
+    "schemaVersion": 2,
     "pr": int(pr) if pr.isdigit() else pr,
     "issue": int(issue) if issue.isdigit() else None,
     "headSha": head_sha,
     "route": route,
     "requiredGates": required,
     "gates": gates,
+    "gateEvidence": gate_evidence,
+    "unboundGatesAllowed": allow_unbound == "1",
     "aggregate": aggregate,
 }
 print(json.dumps(evidence, indent=2))
 PYEOF
 )"
 
+# Required non-ci gates that PASSED but are unbound (naked --gate). These are the
+# accidental-error hole from Issue #205: a success that isn't tied to head+packet.
+UNBOUND_PASS=()
+for g in "${REQUIRED[@]}"; do
+  [ "$g" = ci ] && continue
+  [ "${RESULT[$g]}" = pass ] && [ "${BOUND[$g]:-0}" = 0 ] && UNBOUND_PASS+=("$g")
+done
+
 # --- render the plan (suppressed in --json mode so stdout is pure JSON) --- #
 if [ "$JSON" = 0 ]; then
   echo "PR #$PR  head=$HEAD_SHA  route=$ROUTE_NAME"
   echo "status: $CONTEXT = $STATE  ($DESC)"
-  for g in "${REQUIRED[@]}"; do printf '  %-20s %s\n' "$g" "${RESULT[$g]}"; done
+  for g in "${REQUIRED[@]}"; do
+    b=""
+    if [ "$g" != ci ]; then
+      case "${BOUND[$g]:-0}" in 1) b="  [bound]" ;; *) [ -n "${GATE[$g]+x}" ] && b="  [unbound]" ;; esac
+    fi
+    printf '  %-20s %s%s\n' "$g" "${RESULT[$g]}" "$b"
+  done
+  if [ "${#UNBOUND_PASS[@]}" -gt 0 ] && [ "$ALLOW_UNBOUND" = 0 ]; then
+    echo "WARNING: unbound pass gate(s): ${UNBOUND_PASS[*]} — --post will refuse to mint success"
+    echo "         (bind them via tools/gate-evidence.sh + --gate-evidence, or pass --allow-unbound-gates)"
+  fi
 fi
 
 # Renders the human PR-body block FROM $EVIDENCE_JSON (via stdin), not by
@@ -246,27 +381,52 @@ head7 = ev["headSha"][:7]
 route = ev["route"]
 required = ev["requiredGates"]
 gates = ev["gates"]
+gate_ev = ev.get("gateEvidence", {})
 passed = sum(1 for g in required if gates[g] == "pass")
 total = len(required)
+
+
+def binding(g):
+    if g == "ci":
+        return "GitHub `build-and-test` @ this SHA"
+    ge = gate_ev.get(g)
+    if ge and ge.get("bound"):
+        rps = (ge.get("reviewPacketSha256") or "")[:12]
+        who = ge.get("reviewer") or g
+        return "bound — %s, packet `%s`" % (who, rps)
+    return "unbound (`--gate` assertion)"
+
 
 out = []
 out.append("<!-- agent-verification:start -->")
 out.append("### agent-verification — `%s` for `%s`" % (aggregate, head7))
 out.append("")
-out.append("| gate | result |")
-out.append("|---|---|")
+out.append("| gate | result | evidence |")
+out.append("|---|---|---|")
 for g in required:
-    out.append("| `%s` | %s |" % (g, gates[g]))
+    out.append("| `%s` | %s | %s |" % (g, gates[g], binding(g)))
 out.append("")
 out.append("_%d/%d gates passed [route: %s]. Regenerated per head SHA by "
-            "`tools/agent-verify.sh`._" % (passed, total, route))
+            "`tools/agent-verify.sh`; semantic verdicts bound to head + review "
+            "packet via `tools/gate-evidence.sh`._" % (passed, total, route))
+if ev.get("unboundGatesAllowed"):
+    out.append("")
+    out.append("> ⚠️ `--allow-unbound-gates` was used: one or more semantic "
+               "verdicts were accepted without head/packet binding.")
 out.append("<!-- agent-verification:end -->")
 print("\n".join(out))
 '
 }
 
 if [ "$POST" = 1 ]; then
+  # F10 first: is the head we would post onto even the real branch tip?
   converged || die "refusing to post: gh reports head $HEAD_SHA for branch $HEAD_REF_NAME but git's actual tip is ${GIT_HEAD_SHA:-<unknown>} — the gh API is lagging behind git (burn-in F10); acting now would post onto a stale/superseded head. Re-run (optionally with --wait) once they converge."
+  # #205 next: even on the real head, a success must be tied to {head SHA + review
+  # packet} for every semantic gate, unless the operator explicitly overrides
+  # (recorded as unboundGatesAllowed in the object).
+  if [ "$STATE" = success ] && [ "${#UNBOUND_PASS[@]}" -gt 0 ] && [ "$ALLOW_UNBOUND" = 0 ]; then
+    die "refusing to post success: gate(s) [${UNBOUND_PASS[*]}] passed but are UNBOUND — supplied via --gate, so their verdict is not mechanically tied to head ${HEAD_SHA:0:7} + the review packet (Issue #205). Re-run each gate on the current head and supply tools/gate-evidence.sh output via --gate-evidence, or pass --allow-unbound-gates to override (the override is recorded in the evidence)."
+  fi
   gh api -X POST "repos/{owner}/{repo}/statuses/$HEAD_SHA" \
     -f state="$STATE" -f context="$CONTEXT" -f description="$DESC" -f target_url="$PR_URL" \
     --jq '"posted: \(.context) = \(.state)"' || die "failed to post status"

--- a/tools/codex-agent.sh
+++ b/tools/codex-agent.sh
@@ -31,6 +31,12 @@
 #   --source-packet   tools/source-slice.py --pages A-B    (authoritative source text)
 #   --packet          any single bounded file, for simcheck (e.g. a source-slice packet)
 #
+# Recording the codex-conformance verdict: after this run, the orchestrator records
+# the verdict with tools/gate-evidence.sh, passing the SAME --review-packet and
+# --source-packet, so the verdict is bound to {head SHA + review-packet hash} and the
+# source-packet hash is recorded for provenance (Issue #205). agent-verify.sh then
+# refuses that gate if the packet the diff no longer regenerates to the same hash.
+#
 # Env overrides: CODEX_BIN, CODEX_MODEL, OUT.
 # LEDGER_LOG=1 additionally appends one job row via tools/ledger-log.sh (never
 # fabricated — set ISSUE/PR/SEQ/LAYER/PHASE to whatever is actually known; unset

--- a/tools/gate-evidence.sh
+++ b/tools/gate-evidence.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# tools/gate-evidence.sh — write ONE per-gate verdict-evidence file that binds a
+# semantic reviewer's verdict to {head SHA + review-packet hash + gate identity}.
+#
+# This is a small INPUT builder for the repo's one verification-evidence
+# authority (tools/agent-verify.sh) — it is deliberately NOT a second authority
+# and mints nothing. The orchestrator runs a reviewer against a bounded review
+# packet (tools/agent-brief.py review <pr>) plus, for codex conformance, a source
+# packet (tools/source-slice.py); it reads the verdict; then it calls this to
+# record that verdict as a machine-readable file. `tools/agent-verify.sh
+# --gate-evidence FILE` re-derives the current PR head and the current review
+# packet hash and REFUSES to mint `agent-verification` unless the recorded
+# head/hash still match — so a stale or accidentally reused verdict can never
+# ride onto a new head SHA (Issue #205, the review's remaining accidental-error
+# hole).
+#
+# What this records vs. what agent-verify.sh enforces at verify time:
+#   headSha            the PR head now (from gh). agent-verify refuses unless it
+#                      still equals the PR head at verify time.
+#   reviewPacketSha256 the `packet-sha256` footer of the review packet the
+#                      reviewer actually saw. agent-verify regenerates the packet
+#                      (agent-brief.py is deterministic) and refuses on mismatch.
+#   sourcePacketSha256 sha256 of the source packet file (codex conformance only).
+#                      RECORDED for provenance/audit; not re-validated (the PDF
+#                      is pinned, but the page range is not recoverable at verify
+#                      time). null when no source packet applies.
+#   gate/verdict/reviewer/model/runId  identity + provenance.
+#
+# Usage:
+#   tools/gate-evidence.sh --pr N --gate NAME --verdict pass|fail|skip \
+#       --review-packet FILE [--source-packet FILE] \
+#       [--reviewer R] [--model M] [--run-id ID] [--out FILE]
+#
+# Writes the JSON object to --out (default: stdout).
+set -euo pipefail
+
+die() { echo "gate-evidence: $*" >&2; exit 2; }
+
+PR=""; GATE=""; VERDICT=""; REVIEW_PACKET=""; SOURCE_PACKET=""
+REVIEWER=""; MODEL=""; RUN_ID=""; OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pr)            PR="${2:-}"; shift 2 ;;
+    --gate)          GATE="${2:-}"; shift 2 ;;
+    --verdict)       VERDICT="${2:-}"; shift 2 ;;
+    --review-packet) REVIEW_PACKET="${2:-}"; shift 2 ;;
+    --source-packet) SOURCE_PACKET="${2:-}"; shift 2 ;;
+    --reviewer)      REVIEWER="${2:-}"; shift 2 ;;
+    --model)         MODEL="${2:-}"; shift 2 ;;
+    --run-id)        RUN_ID="${2:-}"; shift 2 ;;
+    --out)           OUT="${2:-}"; shift 2 ;;
+    -*)              die "unknown option: $1" ;;
+    *)               die "unexpected argument: $1" ;;
+  esac
+done
+
+[ -n "$PR" ]  || die "--pr is required"
+[ -n "$GATE" ] || die "--gate is required"
+[[ "$PR" =~ ^[0-9]+$ ]] || die "--pr must be numeric: $PR"
+case "$VERDICT" in pass|fail|skip) ;; *) die "--verdict must be pass|fail|skip: ${VERDICT:-<empty>}" ;; esac
+[ -n "$REVIEW_PACKET" ] || die "--review-packet is required"
+[ -f "$REVIEW_PACKET" ] || die "review packet not found: $REVIEW_PACKET"
+[ -z "$SOURCE_PACKET" ] || [ -f "$SOURCE_PACKET" ] || die "source packet not found: $SOURCE_PACKET"
+
+# Reviewer defaults to the gate name (scope-warden's reviewer is scope-warden).
+[ -n "$REVIEWER" ] || REVIEWER="$GATE"
+
+# The current PR head — the SHA this verdict is being bound to.
+HEAD_SHA="$(gh pr view "$PR" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)"
+[ -n "$HEAD_SHA" ] || die "cannot read head SHA for PR #$PR (is gh authenticated?)"
+
+# The review packet's own content hash, from its deterministic footer.
+packet_footer_sha() {
+  # `|| true` so a footer-less packet yields "" (caught below) rather than
+  # aborting under `set -o pipefail` when grep finds no match.
+  { grep -E '^packet-sha256:[[:space:]]*[0-9a-f]+' "$1" | tail -1 | awk '{print $2}'; } || true
+}
+REVIEW_PACKET_SHA="$(packet_footer_sha "$REVIEW_PACKET")"
+[ -n "$REVIEW_PACKET_SHA" ] || die "review packet has no 'packet-sha256:' footer: $REVIEW_PACKET (was it built by tools/agent-brief.py review?)"
+
+SOURCE_PACKET_SHA=""
+if [ -n "$SOURCE_PACKET" ]; then
+  SOURCE_PACKET_SHA="$(sha256sum "$SOURCE_PACKET" | cut -d' ' -f1)"
+fi
+
+EVIDENCE_JSON="$(python3 - "$PR" "$GATE" "$VERDICT" "$HEAD_SHA" "$REVIEW_PACKET_SHA" "$SOURCE_PACKET_SHA" "$REVIEWER" "$MODEL" "$RUN_ID" <<'PYEOF'
+import json
+import sys
+
+pr, gate, verdict, head_sha, rps, sps, reviewer, model, run_id = sys.argv[1:10]
+obj = {
+    "schemaVersion": 1,
+    "gate": gate,
+    "verdict": verdict,
+    "pr": int(pr),
+    "headSha": head_sha,
+    "reviewPacketSha256": rps,
+    "sourcePacketSha256": sps or None,
+    "reviewer": reviewer,
+    "model": model or None,
+    "runId": run_id or None,
+}
+print(json.dumps(obj, indent=2))
+PYEOF
+)"
+
+if [ -n "$OUT" ]; then
+  printf '%s\n' "$EVIDENCE_JSON" > "$OUT"
+  echo "gate-evidence: wrote $GATE=$VERDICT for PR #$PR @ ${HEAD_SHA:0:7} -> $OUT" >&2
+else
+  printf '%s\n' "$EVIDENCE_JSON"
+fi


### PR DESCRIPTION
## Linked Issue

Closes #205

## Exact behavioral claim

Semantic gate verdicts are now mechanically bound to `{head SHA + review-packet hash + gate identity}`, closing the review's remaining accidental-error hole. New `tools/gate-evidence.sh` writes a per-gate verdict file `{schemaVersion, gate, verdict, pr, headSha, reviewPacketSha256, sourcePacketSha256|null, reviewer, model, runId}` from the live PR head (`gh`) and the review/source packets the reviewer saw. `tools/agent-verify.sh` gains `--gate-evidence FILE` (repeatable): it accepts the verdict only if `headSha` still equals the current PR head **and** a freshly regenerated `agent-brief.py review <pr>` reproduces the recorded `reviewPacketSha256`; otherwise it refuses (exit 2) naming the stale head or packet-hash mismatch. The canonical evidence object is now `schemaVersion:2` with a per-gate `gateEvidence` block (`bound`, `headSha`, `reviewPacketSha256`, `sourcePacketSha256`, `reviewer`, `model`) and a top-level `unboundGatesAllowed`. `--post` refuses to mint `success` while any required non-`ci` pass gate is unbound (naked `--gate`), unless `--allow-unbound-gates` is given (recorded as `unboundGatesAllowed:true`). `--gate` still works for dry-runs / `skip` / `fail` / override.

## Scope

New `tools/gate-evidence.sh`; `tools/agent-verify.sh` (`--gate-evidence`, `--allow-unbound-gates`, freshness checks, provenance in the one canonical object, post-time refusal); `.claude/agents/{scope-warden,rules-conformance}.md` and `tools/codex-agent.sh` (record verdict via `gate-evidence.sh`); `docs/orchestration/agent-verification.md` (binding + trust boundary). Tests: new `tests/tooling/test_gate_evidence.sh`, updated `tests/tooling/test_agent_verify.sh`. No engine or route change. `gate-evidence.sh` builds input only and mints nothing — `agent-verify.sh` stays the one dynamic evidence authority (#136); no new control plane (per the orchestration-dev invariants).

## Rules conformance

N/A — orchestration tooling; no rules-engine files (`src/Brp.*`) touched.

## Tests and evidence

`bash tests/tooling/test_gate_evidence.sh` → all pass. `bash tests/tooling/test_agent_verify.sh` → all 39 checks pass (incl. new cases 11–14: fresh-bound success + post, unbound `--gate --post` refusal citing #205, stale-head refusal, stale-packet-hash refusal). Full sweep: all `tests/tooling/test_*.sh` + `python3 tests/tooling/test_pr_policy.py` + `bash tools/orchestration-policy.sh` → PASS. Live smoke against PR #204: `tools/agent-brief.py review 204` emits a `packet-sha256` footer; `tools/gate-evidence.sh --pr 204 …` recorded the live head `86c9a83` + that footer hash; `tools/agent-verify.sh 204 --gate-evidence …` correctly rejected a gate not required by route `tooling` (exit 2). `tools/route.sh --base origin/main` → `route: tooling / gates: ci`.

## Decisions and tradeoffs

Kept `--gate` (your call: add, don't replace) but made `--post` refuse to mint success on an unbound pass gate unless `--allow-unbound-gates` is passed — otherwise "keep `--gate`" would have left the hole open. Freshness is enforced by regenerating the deterministic review packet and comparing its `packet-sha256`, not by trusting a copied hash; a changed diff/claim/issue changes the hash and correctly forces a re-review. `sourcePacketSha256` is recorded but not re-validated (the PDF is pinned by `orchestration-policy`, but the page range is not recoverable at verify time) — documented explicitly. Bumped the canonical object to `schemaVersion:2` (added `gateEvidence` + `unboundGatesAllowed`); `pr_policy.py`'s separate evidence schema is unaffected.

## Known limitations

`sourcePacketSha256` is provenance-only. The trust root is unchanged (ADR 0025 — local orchestrator credential, accidental-error protection, not adversarial-agent). `tests/tooling/*.sh` still do not run in CI (#61). This PR is route `tooling` (CI-only), so the new binding path is exercised by its unit tests and a live smoke, not by this PR's own gate set.

## Agent provenance

Implemented and PR assembled by the orchestrator (Claude Opus 4.8) directly — a tightening of the verification authority itself, which the orchestration-dev invariants place under the main loop's care rather than a routine implementer.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).