### PR TITLE
Fix contradictory routing prose (enforced gates; non-rules is CI-only)

### DIFF
--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -195,8 +195,11 @@ Issue (ready)
   -> PR review + merge
 ```
 
-For non-rules work — tooling, CLI, docs, case data — stop after `scope-warden`. The
-expensive verification layers exist for one specific risk and buy nothing elsewhere.
+For non-rules work — tooling, CLI, docs, case data — the route is `ci`-only: no
+semantic reviewer runs at all, not even `scope-warden` (it is a `rules`/`formulas`
+gate). The expensive verification layers exist for one specific risk and buy nothing
+elsewhere. See [`docs/orchestration/routing.md`](orchestration/routing.md) for the
+route → required-gates table.
 
 ## Briefing agents efficiently
 

--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -7,10 +7,11 @@ is the machine-readable form of the pipeline in
 which reviewers a change needs; it asks [`tools/route.sh`](../../tools/route.sh).
 
 Route derivation and labelling are live and consumed by `pr-policy` (which records
-the route in its evidence artifact). The gate **enforcement** that once sat on top of
+the route in its evidence artifact). The per-reviewer *fan-out* that once sat on top of
 this — the `gates-satisfied` aggregator and the gate-poster App — was removed in
-#90/#91; the "required gates" below are the reviewers a change *conceptually* needs,
-no longer an automated check.
+#90/#91, but the required gate set is **not** unenforced: it is now enforced through
+the required `agent-verification` status, which is green only when every gate the
+route requires passed for the exact head SHA. See [§Enforcement](#enforcement) below.
 
 `tools/route.sh` is the **one route authority** (#137): it is the only place that
 parses a diff for content escalation, composes architecture, and applies the


### PR DESCRIPTION
## Linked Issue

Closes #207

## Exact behavioral claim

Docs-only. Two stale statements from the control-plane review (§10) are corrected. `docs/orchestration/routing.md`'s opening paragraph no longer says the required gates are "no longer an automated check" — it now states the per-reviewer App fan-out was removed but the gate set is enforced through the required `agent-verification` status, and links the (already-correct) §Enforcement section. `docs/agent-team.md`'s non-rules guidance no longer says "stop after `scope-warden`"; it states that non-rules routes are `ci`-only and `scope-warden` does not run for them, pointing at the route table.

## Scope

`docs/orchestration/routing.md` (one paragraph) and `docs/agent-team.md` (one paragraph). No change to `tools/route.sh`, `agent-verify.sh`, CI, the route table, or any behavior.

## Rules conformance

N/A — documentation only; no rules-engine files touched.

## Tests and evidence

`tools/route.sh --base origin/main --json` → `route: docs, gates: [ci]`. `bash tools/orchestration-policy.sh` → PASS. Wording checked against the current §Enforcement section (which already describes `agent-verification` as required) and against `tools/route.sh`'s gate table (docs/tooling/presentation/scenario/gameplay = `ci` only).

## Decisions and tradeoffs

Kept the removal-of-the-App history (it is still true and worth recording) but corrected the conclusion drawn from it. Fixed only the two flagged paragraphs; the rest of both documents already matched the implemented system.

## Known limitations

None — prose alignment with the already-implemented enforcement.

## Agent provenance

Written by the orchestrator (Claude Opus 4.8) as the documentation follow-up to #202/#204/#206.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).