### PR TITLE
Run control-plane tooling tests as a required check (orchestration-policy)

### DIFF
--- a/.github/workflows/orchestration-policy.yml
+++ b/.github/workflows/orchestration-policy.yml
@@ -3,6 +3,12 @@ name: orchestration-policy
 # The instant-policy tier (#61): fast, mechanical guardrails from AGENTS.md with
 # no build or restore. Complements build-and-test (BannedApiAnalyzers, tests) and
 # scope-warden. Runs in parallel with CI on every PR.
+#
+# This job ALSO runs the control-plane regression suite (tests/tooling/*), so the
+# tests OF the rails are a required check — not just "the orchestrator says it ran
+# them" (#209). A tooling change (route.sh, agent-verify.sh, gate-evidence.sh,
+# dispatch-agent.sh, pr_policy.py, …) routes to `ci` only, so without this a
+# regression in a rail could merge with GitHub never proving its tests passed.
 on:
   pull_request:
   push:
@@ -18,8 +24,52 @@ permissions:
 jobs:
   orchestration-policy:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Run policy checks
+        with:
+          # Full history: several tooling regression tests reach real ancestor
+          # commits (HEAD~2/HEAD~3) and add linked worktrees, which a shallow
+          # (fetch-depth: 1) checkout cannot satisfy.
+          fetch-depth: 0
+
+      - name: Deterministic policy checks
         run: bash tools/orchestration-policy.sh
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install test dependencies
+        # poppler-utils gives test_source_slice.sh a real pdftotext so it runs
+        # its extraction cases instead of skipping them. Everything else the
+        # suite needs (bash, git, jq, python3) is already on the runner.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq poppler-utils
+
+      - name: Configure git identity
+        # Several tests create fixture commits / linked worktrees.
+        run: |
+          git config --global user.email "ci@noirpg.invalid"
+          git config --global user.name "NoiRPG CI"
+
+      - name: Control-plane regression tests (the rails' own tests)
+        # Runs the whole tests/tooling suite; a single failure fails the required
+        # check. The tests stub `gh`, so this needs no network and no token.
+        run: |
+          set -uo pipefail
+          fail=0
+          shopt -s nullglob
+          for t in tests/tooling/test_*.sh; do
+            echo "::group::$t"
+            if bash "$t"; then echo "PASS $t"; else echo "FAIL $t"; fail=1; fi
+            echo "::endgroup::"
+          done
+          for t in tests/tooling/test_*.py; do
+            echo "::group::$t"
+            if python3 "$t"; then echo "PASS $t"; else echo "FAIL $t"; fail=1; fi
+            echo "::endgroup::"
+          done
+          exit "$fail"


### PR DESCRIPTION
## Linked Issue

Closes #209

## Exact behavioral claim

The required `orchestration-policy` job now runs the whole control-plane regression suite — every `tests/tooling/test_*.sh` and `tests/tooling/test_*.py` — after the deterministic `orchestration-policy.sh` checks, failing the job on any failure. This makes the tests OF the rails a required GitHub check: a regression in `route.sh`, `agent-verify.sh`, `gate-evidence.sh`, `dispatch-agent.sh`, or `pr_policy.py` (all `tooling`-routed → CI-only) can no longer merge without GitHub proving their tests passed. The job name / required-check context stays `orchestration-policy` (no ruleset change). To run the suite the job checks out full history (`fetch-depth: 0`), sets a git identity, and installs `poppler-utils` (so `source-slice` runs its extraction cases instead of skipping); the tests stub `gh`, so no network/token is used. This PR's own `orchestration-policy` run exercises the change end-to-end.

## Scope

`.github/workflows/orchestration-policy.yml` only (added steps + `fetch-depth: 0` + `timeout-minutes` 3→10). No change to `tools/orchestration-policy.sh`, the tests themselves, the route table, or the ruleset.

## Rules conformance

N/A — CI/orchestration tooling; no rules-engine files (`src/Brp.*`) touched.

## Tests and evidence

Simulated the new CI step locally: `for t in tests/tooling/test_*.sh; do bash "$t"; done` + `python3 tests/tooling/test_*.py` → all 12 suites PASS. `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/orchestration-policy.yml'))"` → valid YAML. `bash tools/orchestration-policy.sh` → PASS. `tools/route.sh --base origin/main` → `route: tooling / gates: ci`. The `orchestration-policy` check on this PR runs the suite on a real runner.

## Decisions and tradeoffs

Put the tests in `orchestration-policy` rather than the `.NET` `build-and-test` job (they are shell/python control-plane tests, a natural fit) and rather than reopening the deferred CI-tiering project (#61). Kept the same job/context name so no ruleset edit is needed. `fetch-depth: 0` is required because `test_agent_verify.sh`/`test_agent_brief.sh` reach `HEAD~2/HEAD~3` and add worktrees. `poppler-utils` is installed so `source-slice` coverage is real; if it were absent the test skips rather than fails, so this is coverage, not a hard dependency.

## Known limitations

Adds ~an apt install + suite runtime to the `orchestration-policy` job (still well under the 10-minute cap). The suite is deterministic and network-independent by construction (stubbed `gh`); a test that violated that would surface here as a failure, which is the point.

## Agent provenance

Implemented and PR assembled by the orchestrator (Claude Opus 4.8) directly — a change to the required-check surface itself.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).