### PR TITLE
Verify review-packet body matches its footer hash in gate-evidence

### DIFF
--- a/tests/tooling/test_gate_evidence.sh
+++ b/tests/tooling/test_gate_evidence.sh
@@ -33,9 +33,23 @@ exit 1
 STUB
 chmod +x "$BINDIR/gh"
 
-RPS="cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
+# Build a packet with a TRUTHFUL footer (body hash matches), mirroring
+# tools/agent-brief.py render(): body = "\n".join(lines).rstrip() + "\n", and the
+# footer's packet-sha256 is sha256(body). Prints the digest.
+make_packet() { # $1=path  $2=body-text
+  python3 - "$1" "$2" <<'PY'
+import hashlib, sys
+path, raw = sys.argv[1], sys.argv[2]
+body = raw.rstrip() + "\n"
+digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+footer = "\n---\npacket-schema: review-packet/1\npacket-version: 1\npacket-sha256: %s\n" % digest
+open(path, "w", encoding="utf-8").write(body + footer)
+print(digest)
+PY
+}
+
 REVIEW="$WORKDIR/review.md"
-{ printf '# REVIEW BRIEF — fixture\n'; printf -- '---\npacket-schema: review-packet/1\npacket-version: 1\npacket-sha256: %s\n' "$RPS"; } > "$REVIEW"
+RPS="$(make_packet "$REVIEW" "# REVIEW BRIEF — fixture")"
 SOURCE="$WORKDIR/source.txt"; printf 'BRP source packet fixture\n' > "$SOURCE"
 SRC_SHA="$(sha256sum "$SOURCE" | cut -d' ' -f1)"
 
@@ -84,6 +98,26 @@ assert_eq "case6: missing review packet rejected (exit 2)" "2" "$rc"
 # === 7. non-numeric pr rejected ============================================= #
 rc=0; run --pr abc --gate scope-warden --verdict pass --review-packet "$REVIEW" >/dev/null 2>&1 || rc=$?
 assert_eq "case7: non-numeric --pr rejected (exit 2)" "2" "$rc"
+
+# === 8. tampered packet (body edited, footer kept) is rejected ============== #
+# Build a truthful packet, then corrupt the body without touching the footer:
+# the recomputed body hash must no longer match the declared footer hash.
+TAMPER="$WORKDIR/tamper.md"; make_packet "$TAMPER" "# REVIEW BRIEF — original body" >/dev/null
+python3 - "$TAMPER" <<'PY'
+p = __import__("sys").argv[1]
+t = open(p, encoding="utf-8").read()
+idx = t.rfind("\n---\npacket-schema:")
+# Insert text INTO the body (before the footer), leaving the footer hash stale.
+open(p, "w", encoding="utf-8").write(t[:idx] + "TAMPERED\n" + t[idx:])
+PY
+rc=0; err="$(run --pr 42 --gate scope-warden --verdict pass --review-packet "$TAMPER" 2>&1 1>/dev/null)" || rc=$?
+assert_eq "case8: tampered packet rejected (exit 2)" "2" "$rc"
+assert_contains "case8: names the body/footer mismatch" "$err" "does not match its footer hash"
+
+# === 9. a truthful packet still passes (regression) ========================= #
+GOOD="$WORKDIR/good.md"; g="$(make_packet "$GOOD" "# REVIEW BRIEF — clean")"
+sha9="$(run --pr 42 --gate scope-warden --verdict pass --review-packet "$GOOD" | python3 -c 'import json,sys; print(json.load(sys.stdin)["reviewPacketSha256"])')"
+assert_eq "case9: truthful packet accepted, records its real hash" "$g" "$sha9"
 
 echo
 if [ "$FAILURES" -eq 0 ]; then echo "test_gate_evidence.sh: all checks passed"; exit 0

--- a/tools/gate-evidence.sh
+++ b/tools/gate-evidence.sh
@@ -69,14 +69,45 @@ case "$VERDICT" in pass|fail|skip) ;; *) die "--verdict must be pass|fail|skip: 
 HEAD_SHA="$(gh pr view "$PR" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)"
 [ -n "$HEAD_SHA" ] || die "cannot read head SHA for PR #$PR (is gh authenticated?)"
 
-# The review packet's own content hash, from its deterministic footer.
-packet_footer_sha() {
-  # `|| true` so a footer-less packet yields "" (caught below) rather than
-  # aborting under `set -o pipefail` when grep finds no match.
-  { grep -E '^packet-sha256:[[:space:]]*[0-9a-f]+' "$1" | tail -1 | awk '{print $2}'; } || true
+# The review packet's own content hash — but do NOT merely read the footer:
+# recompute sha256(body) and refuse unless it reproduces the declared footer
+# hash, so a packet whose body was edited/truncated after generation (leaving a
+# stale-but-matching footer) cannot be bound as if it were the reviewed bytes
+# (Issue #211). The body/footer split mirrors tools/agent-brief.py render():
+# body = everything up to the "\n---\npacket-schema:" footer, and the digest is
+# sha256 of exactly that substring (which ends in the body's own trailing \n).
+verify_packet_and_get_sha() {
+  python3 - "$1" <<'PY'
+import hashlib
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+marker = "\n---\npacket-schema:"
+idx = text.rfind(marker)
+if idx == -1:
+    sys.stderr.write("no 'packet-schema/packet-sha256' footer (was it built by "
+                     "tools/agent-brief.py?)\n")
+    sys.exit(1)
+m = re.search(r"packet-sha256:\s*([0-9a-f]+)", text[idx:])
+if not m:
+    sys.stderr.write("footer has no 'packet-sha256:' line\n")
+    sys.exit(1)
+declared = m.group(1)
+computed = hashlib.sha256(text[:idx].encode("utf-8")).hexdigest()
+if computed != declared:
+    sys.stderr.write(
+        "packet body does not match its footer hash (declared %s…, recomputed "
+        "%s…) — the packet was edited/truncated after generation; refusing to "
+        "bind a verdict to a packet whose footer is untruthful\n"
+        % (declared[:12], computed[:12]))
+    sys.exit(1)
+print(declared)
+PY
 }
-REVIEW_PACKET_SHA="$(packet_footer_sha "$REVIEW_PACKET")"
-[ -n "$REVIEW_PACKET_SHA" ] || die "review packet has no 'packet-sha256:' footer: $REVIEW_PACKET (was it built by tools/agent-brief.py review?)"
+REVIEW_PACKET_SHA="$(verify_packet_and_get_sha "$REVIEW_PACKET")" \
+  || die "review packet failed integrity verification: $REVIEW_PACKET"
 
 SOURCE_PACKET_SHA=""
 if [ -n "$SOURCE_PACKET" ]; then


### PR DESCRIPTION
## Linked Issue

Closes #211

## Exact behavioral claim

`tools/gate-evidence.sh` no longer trusts a review packet's `packet-sha256:` footer blindly: it recomputes `sha256(body)` — where `body` is the packet content up to the `\n---\npacket-schema:` footer, exactly as `tools/agent-brief.py`'s `render()` hashes it — and refuses (exit 2, clear message naming the mismatch) unless the recomputed hash equals the declared footer hash. So a packet whose body was edited/truncated after generation (leaving a stale-but-otherwise-plausible footer) can no longer be bound as if it were the bytes the reviewer saw. A truthful `agent-brief.py` packet is accepted unchanged.

## Scope

`tools/gate-evidence.sh` (footer-read replaced with an integrity-verifying read) and `tests/tooling/test_gate_evidence.sh` (fixtures now build packets with a truthful footer via a `render()`-mirroring helper; new tamper-rejection and truthful-packet regression cases). No change to `agent-brief.py` or `agent-verify.sh`.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_gate_evidence.sh` → all 19 checks pass (incl. case8 tampered-packet rejection and case9 truthful-packet acceptance). Full sweep: all `tests/tooling/test_*.sh` + `test_pr_policy.py` PASS. Reconstruction verified against a real packet: `tools/agent-brief.py review 210` → recomputed `sha256(body)` equals the declared footer hash. `tools/route.sh --base origin/main` → `route: tooling / gates: ci`.

## Decisions and tradeoffs

Body/footer split uses `text.rfind("\n---\npacket-schema:")` (the footer is always last), and the hash is over that exact substring, which ends in the body's own trailing newline — matching `render()` byte-for-byte (confirmed empirically). The check lives in `gate-evidence.sh` (the point that ingests an externally-produced packet); `agent-verify.sh` already regenerates the packet itself and compares hashes, so it needs no equivalent.

## Known limitations

Still binds an orchestrator-entered verdict, not the reviewer process itself (unchanged; ADR 0025 trust root). Integrity is proven for the review packet; the source packet remains a recorded provenance hash as before.

## Agent provenance

Implemented and PR assembled by the orchestrator (Claude Opus 4.8) directly.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).