### PR TITLE
Enforce implementer worktree isolation with a PreToolUse Write/Edit hook

### DIFF
--- a/.claude/agents/case-author.md
+++ b/.claude/agents/case-author.md
@@ -4,6 +4,12 @@ description: Authors and validates NoiRPG case data (cases/*.yaml) against the s
 model: sonnet
 effort: medium
 tools: Read, Grep, Glob, Bash, Write, Edit
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "tools/dispatch-write-guard.sh"
 ---
 
 You author and repair case data. Read `cases/SCHEMA.md` first, and `cases/overpass.yaml`

--- a/.claude/agents/engine-dev.md
+++ b/.claude/agents/engine-dev.md
@@ -4,6 +4,12 @@ description: Implements one GitHub Issue in the C#/.NET rules engine. Use for bo
 model: sonnet
 effort: medium
 tools: Read, Grep, Glob, Bash, Write, Edit
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "tools/dispatch-write-guard.sh"
 ---
 
 You implement exactly one Issue. Read `AGENTS.md` first, then the Issue and its task

--- a/.claude/agents/orchestration-dev.md
+++ b/.claude/agents/orchestration-dev.md
@@ -4,6 +4,12 @@ description: Implements one GitHub Issue in the repository's orchestration/tooli
 model: sonnet
 effort: medium
 tools: Read, Grep, Glob, Bash, Write, Edit
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "tools/dispatch-write-guard.sh"
 ---
 
 You implement exactly one Issue in the orchestration/tooling layer. Read `AGENTS.md`

--- a/.claude/agents/rules-extractor.md
+++ b/.claude/agents/rules-extractor.md
@@ -4,6 +4,12 @@ description: Extracts tables, values, and stat blocks from the ORC Content Docum
 model: haiku
 effort: medium
 tools: Read, Grep, Glob, Bash, Write, Edit
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "tools/dispatch-write-guard.sh"
 ---
 
 You transcribe rules data from the source book into ruleset JSON. You are a careful

--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -130,7 +130,7 @@ tools/dispatch-agent.sh <issue#>     # prints  path=<abs worktree>  branch=<issu
 ```
 
 Dispatch the implementer/writeup agent with that `path` as its working directory, and
-`--cleanup <issue#>` the worktree after merge. The two implementer-facing rails:
+`--cleanup <issue#>` the worktree after merge. The three implementer-facing rails:
 
 - `tools/dispatch-agent.sh <issue#>` never checks the feature branch out into the
   primary tree, so using it cannot reproduce F12.
@@ -139,10 +139,17 @@ Dispatch the implementer/writeup agent with that `path` as its working directory
   action and **stops with a dispatch error** if it finds itself in the primary
   checkout — a mechanical self-check (git's own worktree metadata), so a forgotten
   option fails fast instead of stranding the primary tree.
+- Those same roles register a PreToolUse `Write|Edit` hook,
+  [`tools/dispatch-write-guard.sh`](../tools/dispatch-write-guard.sh), so that even
+  if the agent skips its first-action check, the **first mutation whose target is in
+  the primary checkout is denied** (exit 2, reason fed back). This is the same
+  mechanical-hook pattern that makes reviewers read-only
+  ([`tools/reviewer-bash-guard.sh`](../tools/reviewer-bash-guard.sh), ADR 0026).
 
-A shell tool cannot intercept the harness's Agent dispatch itself; this is a preflight
-plus a self-check, which is what F12 needs. Reviewer (read-only) roles do not write and
-need no worktree.
+A shell tool cannot intercept the harness's Agent dispatch itself; but between the
+preflight, the self-check, and the write-time hook, an ordinary implementer role can
+no longer mutate the primary tree through the normal path — which is what F12 needs.
+Reviewer (read-only) roles do not write and need no worktree.
 
 ## Authoring a design-decision record (ADR) — the `NNNN` placeholder
 

--- a/tests/tooling/test_dispatch_write_guard.sh
+++ b/tests/tooling/test_dispatch_write_guard.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# tests/tooling/test_dispatch_write_guard.sh — fixture tests for the PreToolUse
+# Write/Edit isolation hook (Issue #213, burn-in F12).
+#
+# The guard reads a PreToolUse payload on stdin and BLOCKS (exit 2) a Write/Edit
+# whose target is in the PRIMARY checkout, approving (exit 0) a linked worktree or
+# a target outside any repo. All cases run in a throwaway repo + linked worktree,
+# so the real repository is never touched.
+#
+# Run directly:
+#   tests/tooling/test_dispatch_write_guard.sh
+# Exit: 0 if every case passes, 1 on the first failure.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="$ROOT/tools/dispatch-write-guard.sh"
+
+FAILURES=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+assert_eq() { local d="$1" e="$2" a="$3"; [ "$e" = "$a" ] && ok "$d" || fail "$d (expected [$e], got [$a])"; }
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# throwaway repo (primary) + a linked worktree
+REPO="$WORKDIR/repo"
+git init -q -b main "$REPO"
+git -C "$REPO" config user.email t@t; git -C "$REPO" config user.name t
+echo seed > "$REPO/seed.txt"; git -C "$REPO" add -A; git -C "$REPO" commit -qm seed
+WT="$WORKDIR/wt"
+git -C "$REPO" worktree add -q -b feature "$WT" HEAD
+
+# run the guard: $1 = cwd, $2 = payload on stdin ; echoes the exit code
+guard_rc() {
+  local cwd="$1" payload="$2" rc=0
+  ( cd "$cwd" && printf '%s' "$payload" | bash "$GUARD" ) >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+payload_for() { printf '{"tool_input":{"file_path":"%s"}}' "$1"; }
+
+# === 1. target in the PRIMARY checkout -> BLOCK (exit 2) ==================== #
+assert_eq "case1: write into primary tree is blocked" \
+  "2" "$(guard_rc "$REPO" "$(payload_for "$REPO/newfile.cs")")"
+
+# === 2. target in a LINKED worktree -> ALLOW (exit 0) ====================== #
+assert_eq "case2: write into a linked worktree is allowed" \
+  "0" "$(guard_rc "$REPO" "$(payload_for "$WT/newfile.cs")")"
+
+# === 3. target outside any repo (e.g. /tmp scratch) -> ALLOW =============== #
+assert_eq "case3: write outside any repo is allowed" \
+  "0" "$(guard_rc "$REPO" "$(payload_for "$WORKDIR/scratch.txt")")"
+
+# === 4. no file_path, cwd is the primary tree -> BLOCK ===================== #
+assert_eq "case4: no target + cwd primary is blocked" \
+  "2" "$(guard_rc "$REPO" '{}')"
+
+# === 5. no file_path, cwd is a linked worktree -> ALLOW ==================== #
+assert_eq "case5: no target + cwd worktree is allowed" \
+  "0" "$(guard_rc "$WT" '{}')"
+
+# === 6. malformed payload does not crash (fail-open to cwd classification) = #
+assert_eq "case6: malformed payload, cwd worktree -> allow" \
+  "0" "$(guard_rc "$WT" 'not json at all')"
+assert_eq "case6: malformed payload, cwd primary -> block" \
+  "2" "$(guard_rc "$REPO" 'not json at all')"
+
+# === 7. the reason is fed back on block ==================================== #
+err="$( ( cd "$REPO" && printf '%s' "$(payload_for "$REPO/x.cs")" | bash "$GUARD" ) 2>&1 1>/dev/null )"
+case "$err" in *"PRIMARY checkout"*) ok "case7: block reason names the primary checkout" ;;
+  *) fail "case7: block reason missing (got [$err])" ;; esac
+
+git -C "$REPO" worktree remove --force "$WT" >/dev/null 2>&1 || true
+echo
+if [ "$FAILURES" -eq 0 ]; then echo "test_dispatch_write_guard.sh: all checks passed"; exit 0
+else echo "test_dispatch_write_guard.sh: $FAILURES check(s) failed"; exit 1; fi

--- a/tools/dispatch-agent.sh
+++ b/tools/dispatch-agent.sh
@@ -34,7 +34,8 @@
 #
 # Usage:
 #   tools/dispatch-agent.sh <issue#>            # create/verify + print path,branch
-#   tools/dispatch-agent.sh --assert-isolated   # exit 1 in the primary worktree
+#   tools/dispatch-agent.sh --assert-isolated [PATH]  # exit 1 if PATH (default cwd)
+#                                                     # is in the primary worktree
 #   tools/dispatch-agent.sh --cleanup <issue#>  # remove the worktree if clean
 #   tools/dispatch-agent.sh --print-path <issue#>  # just the worktree path (no create)
 #
@@ -48,22 +49,34 @@ die() { echo "dispatch-agent: $*" >&2; exit 2; }
 command -v git >/dev/null 2>&1 || die "git not found"
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git repository"
 
-# --- primary vs linked worktree (mechanical, not path-string heuristics) ----- #
-# In the PRIMARY worktree, the absolute git dir IS the common git dir. In a
-# LINKED worktree, the git dir is <common>/worktrees/<name>, so the two differ.
 abs() { (cd "$1" 2>/dev/null && pwd) || return 1; }
-git_dir_abs="$(git rev-parse --absolute-git-dir)"
-common_dir_abs="$(abs "$(git rev-parse --git-common-dir)")" \
-  || die "cannot resolve --git-common-dir"
 
-is_primary_worktree() { [ "$git_dir_abs" = "$common_dir_abs" ]; }
+# --- primary vs linked worktree (mechanical, not path-string heuristics) ----- #
+# `git worktree list` always names the MAIN worktree first. If the worktree
+# containing DIR (its --show-toplevel) is that same path, DIR is in the PRIMARY
+# checkout. Works for an arbitrary DIR and across git versions, so the same
+# detector serves both the cwd self-check and tools/dispatch-write-guard.sh
+# classifying a write TARGET.
+#   returns 0 = primary, 1 = linked, 2 = DIR is not in a git worktree
+is_primary_worktree() {
+  local dir="${1:-.}" top main
+  top="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)" || return 2
+  main="$(git -C "$dir" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')"
+  [ -n "$top" ] && [ -n "$main" ] || return 2
+  [ "$top" = "$main" ]
+}
 
-# --- --assert-isolated: the implementer's first-action self-check ------------ #
+# --- --assert-isolated [PATH]: the implementer's first-action self-check, also
+# reused by tools/dispatch-write-guard.sh to classify a write TARGET ---------- #
+# Exit 0 = isolated (a linked worktree, or PATH not in any repo); exit 1 = PATH
+# is in the PRIMARY checkout. PATH defaults to the current directory.
 if [ "${1:-}" = "--assert-isolated" ]; then
-  [ $# -eq 1 ] || die "--assert-isolated takes no other arguments"
-  if is_primary_worktree; then
+  shift
+  check_dir="${1:-.}"
+  [ $# -le 1 ] || die "--assert-isolated takes at most one PATH argument"
+  if is_primary_worktree "$check_dir"; then
     cat >&2 <<EOF
-dispatch-agent: NOT ISOLATED — this is the PRIMARY checkout ($(git rev-parse --show-toplevel)).
+dispatch-agent: NOT ISOLATED — this is the PRIMARY checkout ($(git -C "$check_dir" rev-parse --show-toplevel)).
 An implementer/writeup agent must run in a dedicated worktree so it can never
 strand the primary tree on a feature branch (burn-in F12). Stop and report a
 dispatch error; the orchestrator should create your workspace with:
@@ -72,7 +85,7 @@ and dispatch you with that path as your working directory.
 EOF
     exit 1
   fi
-  echo "dispatch-agent: isolated worktree OK ($(git rev-parse --show-toplevel))"
+  echo "dispatch-agent: isolated worktree OK ($(git -C "$check_dir" rev-parse --show-toplevel 2>/dev/null || echo "$check_dir"))"
   exit 0
 fi
 

--- a/tools/dispatch-write-guard.sh
+++ b/tools/dispatch-write-guard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# tools/dispatch-write-guard.sh — a PreToolUse "command" hook that makes
+# implementer worktree isolation a RAIL rather than a first-action instruction
+# (Issue #213, burn-in F12). It mirrors tools/reviewer-bash-guard.sh: registered
+# in each implementer role's frontmatter (`.claude/agents/*.md`) matched on the
+# Write/Edit tools, so it runs ONLY while that subagent executes.
+#
+# Contract (same as reviewer-bash-guard.sh):
+#   read the PreToolUse JSON payload on stdin, inspect .tool_input.file_path, and
+#     exit 0  -> approve
+#     exit 2  -> block; stderr is fed back to the agent as the reason
+#   never exit non-{0,2}; a crash must not silently allow.
+#
+# Policy: BLOCK a Write/Edit whose TARGET resides in the PRIMARY checkout, so an
+# agent that skipped its `dispatch-agent.sh --assert-isolated` first action still
+# cannot strand the primary tree. Approve otherwise — a linked worktree, or a
+# target outside any git repo (e.g. /tmp scratch). Classification is delegated to
+# `dispatch-agent.sh --assert-isolated PATH` so there is one isolation detector.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+payload="$(cat 2>/dev/null || true)"
+
+# The file the tool intends to write/modify (.tool_input.file_path). Best-effort:
+# if we cannot parse it, fall back to the current directory.
+target="$(printf '%s' "$payload" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print((d.get("tool_input") or {}).get("file_path") or "")
+except Exception:
+    print("")
+' 2>/dev/null || true)"
+
+dir="."
+if [ -n "$target" ]; then
+  d="$(dirname "$target")"
+  [ -d "$d" ] && dir="$d"
+fi
+
+# Delegate to the one isolation detector. Exit 1 means "PATH is in the primary
+# checkout" — the only case we block. Exit 0 (linked/isolated) or any other
+# result (target not in a repo, detector error) is allowed: block only when we
+# can positively prove the target is the primary tree.
+rc=0
+"$HERE/dispatch-agent.sh" --assert-isolated "$dir" >/dev/null 2>&1 || rc=$?
+if [ "$rc" = 1 ]; then
+  {
+    echo "dispatch-write-guard: BLOCKED — this Write/Edit targets the PRIMARY checkout."
+    echo "Implementer agents must run in a dedicated worktree (burn-in F12): a write here"
+    echo "would strand the primary tree on a feature branch. Stop and return a dispatch"
+    echo "error. The orchestrator creates your workspace with 'tools/dispatch-agent.sh"
+    echo "<issue#>' and dispatches you there. (Backstop for the --assert-isolated first step.)"
+  } >&2
+  exit 2
+fi
+exit 0


### PR DESCRIPTION
## Linked Issue

Closes #213

## Exact behavioral claim

Implementer worktree isolation gains a mechanical backstop. New `tools/dispatch-write-guard.sh` is a PreToolUse hook (same contract as `tools/reviewer-bash-guard.sh`: exit 0 approve / exit 2 block, reason on stderr): it reads the payload's `.tool_input.file_path` and **blocks** any `Write`/`Edit` whose target is in the PRIMARY checkout, **allowing** a linked worktree or a target outside any git repo (e.g. `/tmp`). The four implementer roles (`engine-dev`, `orchestration-dev`, `case-author`, `rules-extractor`) register it on `Write|Edit`. So even if an agent skips its `dispatch-agent.sh --assert-isolated` first action, its first mutation into the primary tree is denied. Isolation detection is delegated to `dispatch-agent.sh --assert-isolated PATH` (now accepts an optional path) so there is a single detector; it uses `git worktree list` (main worktree first) vs `--show-toplevel`, robust for an arbitrary target dir.

## Scope

New `tools/dispatch-write-guard.sh`; `tools/dispatch-agent.sh` (`--assert-isolated` gains an optional PATH; detection switched to the worktree-list method — `test_dispatch_agent.sh` stays green); the four implementer role frontmatters (register the hook); `docs/agent-team.md` (documents the third rail); new `tests/tooling/test_dispatch_write_guard.sh`. No engine change.

## Rules conformance

N/A — orchestration tooling; no rules-engine files touched.

## Tests and evidence

`bash tests/tooling/test_dispatch_write_guard.sh` → all pass (block in primary tree, allow in linked worktree, allow outside any repo, cwd fallback both ways, malformed payload does not crash, block reason names the primary checkout). `bash tests/tooling/test_dispatch_agent.sh` → still green after the detection refactor. Full sweep: all 13 `tests/tooling/test_*.sh` + `test_pr_policy.py` PASS; role frontmatter parses (all four register `Write|Edit` → `tools/dispatch-write-guard.sh`). `bash tools/orchestration-policy.sh` → PASS. `tools/route.sh --base origin/main` → `route: tooling / gates: ci`. This PR's `orchestration-policy` check runs the new test on a real runner (#210).

## Decisions and tradeoffs

Blocks only when the target is provably in the primary worktree; fails open for non-repo targets so legitimate scratch writes are not blocked. Reused `dispatch-agent.sh` as the one detector rather than duplicating git logic in the guard. A shell hook still cannot prevent an agent being launched in the wrong cwd — but combined with the preflight and the first-action self-check, an ordinary implementer role can no longer mutate the primary tree through the normal path. No ADR added (mirrors ADR 0026's mechanism; documented inline) — can add one if you'd prefer symmetry.

## Known limitations

Covers the `Write`/`Edit` tools the implementer roles are granted; an agent with a different mutation path is out of scope. The hook is active only while the subagent runs (subagent-frontmatter hook), exactly like the reviewer bash guard.

## Agent provenance

Implemented and PR assembled by the orchestrator (Claude Opus 4.8) directly.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).