### PR TITLE
Discover case files recursively in CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,11 @@ jobs:
         if: always()
         run: |
           python3 -m pip install --quiet pyyaml
-          shopt -s nullglob
-          files=(cases/*.yaml cases/*.yml)
+          # Discover case files RECURSIVELY: the scenario route covers cases/**,
+          # so a nested case (e.g. cases/chapter-1/foo.yaml) must be validated
+          # too, not just top-level files. The name filter excludes non-YAML
+          # (e.g. cases/SCHEMA.md).
+          mapfile -t files < <(find cases -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)
           if [ ${#files[@]} -eq 0 ]; then
             echo "No case files to validate."
             exit 0


### PR DESCRIPTION
## Linked Issue

Closes #215

## Exact behavioral claim

The `build-and-test` "Validate case data" step now discovers case YAML recursively under `cases/` via `find cases -type f \( -name '*.yaml' -o -name '*.yml' \)` (sorted), instead of the top-level `cases/*.yaml` / `*.yml` glob. So a nested case such as `cases/chapter-1/foo.yaml` — which routes as `scenario` — is now validated too, closing the gap between the route (`cases/**`) and what CI actually checks. The name filter still excludes non-YAML (e.g. `cases/SCHEMA.md`), the no-files no-op is preserved, and any validator FAIL still fails the required job.

## Scope

`.github/workflows/ci.yml` — the file-discovery line of the "Validate case data" step only. No change to the validator, the route map, or any other step.

## Rules conformance

N/A — CI configuration; no rules-engine files touched.

## Tests and evidence

`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → valid YAML. Simulated locally with a temporary `cases/chapter-1/nested.yaml`: `find` returned both `cases/chapter-1/nested.yaml` and `cases/overpass.yaml` (and not `SCHEMA.md`), both validated PASS; temp removed afterward. `tools/route.sh --base origin/main` → `route: tooling / gates: ci`.

## Decisions and tradeoffs

Used `find` (recursive) over a bash globstar (`shopt -s globstar; cases/**/*.yaml`) for portability and an explicit type/name filter. Sorted output for deterministic logs.

## Known limitations

Symlinked case files outside `cases/` are not followed (intentional). Non-`.yaml/.yml` case encodings are out of scope (the schema is YAML).

## Agent provenance

Implemented and PR assembled by the orchestrator (Claude Opus 4.8) directly.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).