### PR TITLE
Ch 8 — Money & Wealth levels (Destitute→Wealthy), tied to Status

### DIFF
--- a/docs/decisions/0030-money-and-wealth-levels.md
+++ b/docs/decisions/0030-money-and-wealth-levels.md
@@ -1,0 +1,68 @@
+# 0030. Money and Wealth levels: the modern-era Status table only, five ordinal levels, no economy sim
+
+## Status
+
+Accepted — 2026-09-01. Resolves #229.
+
+## Context
+
+Issue #229 (sub-issue of #116) asks for "the Money & Wealth abstraction (Destitute → Wealthy) as
+a clean rules mechanic tied to the Status skill", citing `orc-scope-filter.md` Ch 8, line 129:
+"a clean abstraction (Destitute → Wealthy) that suits a game where the PI's finances are a story
+element, and it ties to the `Status` skill."
+
+The book prints the five Wealth levels and their prose descriptions once, in Ch 2: Characters,
+"Wealth" (p.19): Destitute, Poor, Average, Affluent, Wealthy. It then ties Status to Wealth in
+Ch 3: Skills, "Status Skill, Social Status, & Character Wealth" (p.51), which prints **three**
+era tables mapping a Status rating (01-00) to a Social Rank, a typical Wealth Rating, and a
+Wealth Cap: Prehistoric, Ancient/Dark Age/Medieval/Imperial, and Victorian/Western/Pulp/Modern.
+"Your gamemaster should revise these tables or create new ones, as desired" — the book treats the
+choice of table as a setting decision.
+
+NoiRPG's own era policy (AGENTS.md invariant 4: "Modern era baselines, not historical") already
+resolves this choice project-wide, and is the same policy `EraConditionalBaseChance`
+(`docs/decisions/0011-skill-definition.md`) encodes for skill base chances. A noir-era PI setting
+is squarely the "Modern" column of the third table's own title
+("Victorian/Western/Pulp/Modern").
+
+## Decision
+
+- Ship only the **Victorian/Western/Pulp/Modern Status** table (p.51) as
+  `wealth-ruleset.json` / `NoirWealthRuleset.Load()`, rather than transcribing all three era
+  tables and picking one at evaluation time. The Prehistoric and Ancient tables describe settings
+  this project's era policy never selects, and carrying dead data for them would misrepresent
+  what the engine actually uses (contrast `EraConditionalBaseChance`, which does carry both sides
+  because a single `SkillDefinition` datum is reused verbatim from the printed pair; here the
+  choice is a whole ruleset, so nothing is gained by shipping the untaken branches).
+- `Brp.Rules.Wealth.WealthLevel` is a five-value enum (`Destitute` = 0 through `Wealthy` = 4) in
+  the book's own ascending order, so callers can compare levels ordinally — the book itself
+  relies on this ordering (Ch 8, "Charges or Limited-Use Equipment", p.190: a resource "two or
+  three Wealth levels lower than the equipment's cost").
+- `WealthTable.ForStatus(int)` mirrors the existing banded-lookup shape (`MajorWoundTable`,
+  `IllnessSeverityTable`): a printed 00 reads as 100, matching the project's universal d100
+  convention. `WealthRuleset` wraps the table with two convenience reads,
+  `WealthLevelForStatus` (the "Wealth Rating" column) and `MaximumWealthForStatus` (the
+  "Wealth Cap" column).
+- Nothing here wires a `WealthLevel` onto `Brp.Rules.Characters.Character` or reads a specific
+  character's Status rating automatically. Issue #229 asks for the mechanic, not for Layer 4
+  character state; a caller (creation, or a future Ch 8 gear-affordability issue) looks up a
+  Status rating against `WealthRuleset` itself.
+
+## Consequences
+
+- `Brp.Data.NoirWealthRuleset` loads the table from `wealth-ruleset.json` (AGENTS.md invariant 7:
+  rules values are data, not constants), matching every other table-backed ruleset's loader shape.
+- Money amounts, prices, starting cash, and purchasing power are explicitly out of scope — "the
+  PI's finances are a story element," not a simulated economy. A future Ch 8 issue that needs
+  actual currency (e.g. #228's gear↔skill mapping, or a starting-equipment budget) can consume
+  `WealthLevel` as an input without this ADR needing to be revisited.
+- The Prehistoric and Ancient/Dark Age/Medieval/Imperial Status tables are not modeled. If a
+  future setting needs them, that is a new, explicit scope decision, not a silent extension of
+  this one.
+
+## Known limitations
+
+- The book's alternate initial-wealth method (Ch 2, p.19: "begin your character at the lowest of
+  the wealth ranges, adjusted upward for each successful Status roll you can make... after your
+  character has been created") is not implemented; this ADR covers only the Status→Wealth lookup
+  table itself, not a character-creation wealth-assignment procedure.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -52,3 +52,4 @@ supersedes it — the original is not edited or deleted.
 | [0027](0027-adr-number-allocation.md) | ADR-number allocation is serialized at merge time, not authoring time | Accepted |
 | [0028](0028-complementary-skills-and-augments.md) | Complementary Skills and Augments are two mechanics, not one | Accepted |
 | [0029](0029-special-damage-effects.md) | Special-damage effects (Crushing stun, Impaling lodged weapon, Knockback, Bleeding, Entangling) and Fighting Defensively | Accepted |
+| [0030](0030-money-and-wealth-levels.md) | Money and Wealth levels: the modern-era Status table only, five ordinal levels, no economy sim | Accepted |

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -33,6 +33,7 @@
     <EmbeddedResource Include="complementary-skills-ruleset.json" />
     <EmbeddedResource Include="special-damage-effects-ruleset.json" />
     <EmbeddedResource Include="poison-catalog.json" />
+    <EmbeddedResource Include="wealth-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirWealthRuleset.cs
+++ b/src/Brp.Data/NoirWealthRuleset.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Brp.Rules.Wealth;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's Money and Wealth levels from embedded JSON. Sourced: Ch 3: Skills, "Status
+/// Skill, Social Status, &amp; Character Wealth" (p.51), the "Victorian/Western/Pulp/Modern Status"
+/// table (Issue #229). See <see cref="WealthRuleset"/> for the field-level citation.
+/// </summary>
+public static class NoirWealthRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable wealth ruleset from the shipped data.</summary>
+    public static WealthRuleset Load()
+    {
+        var assembly = typeof(NoirWealthRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.wealth-ruleset.json")
+            ?? throw new InvalidOperationException("The wealth ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<WealthRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The wealth ruleset data is empty.");
+
+        var bands = data.WealthTable.Select(row => new WealthBand(
+            row.Minimum,
+            row.Maximum,
+            row.SocialRank,
+            Enum.Parse<WealthLevel>(row.WealthRating),
+            Enum.Parse<WealthLevel>(row.MaximumWealth)));
+
+        return new WealthRuleset(new WealthTable(bands));
+    }
+
+    private sealed class WealthRulesetData
+    {
+        public required IReadOnlyList<WealthRowData> WealthTable { get; init; }
+    }
+
+    private sealed class WealthRowData
+    {
+        public required int Minimum { get; init; }
+
+        public required int Maximum { get; init; }
+
+        public required string SocialRank { get; init; }
+
+        public required string WealthRating { get; init; }
+
+        public required string MaximumWealth { get; init; }
+    }
+}

--- a/src/Brp.Data/wealth-ruleset.json
+++ b/src/Brp.Data/wealth-ruleset.json
@@ -1,0 +1,15 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 3: Skills",
+    "notes": "Money & Wealth levels (Issue #229, sub-issue of #116): Ch 3, 'Status Skill, Social Status, & Character Wealth' (p.51) prints three era tables (Prehistoric, Ancient/Dark Age/Medieval/Imperial, Victorian/Western/Pulp/Modern) that assign a Social Rank, a typical Wealth Rating, and a Wealth Cap by Status rating. NoiRPG always uses the modern-era baseline (AGENTS.md invariant 4), so only the 'Victorian/Western/Pulp/Modern Status' table is shipped -- see docs/decisions/0030-money-and-wealth-levels.md. The five Wealth levels themselves (Destitute, Poor, Average, Affluent, Wealthy) are described in Ch 2: Characters, 'Wealth' (p.19)."
+  },
+  "wealthTable": [
+    { "minimum": 1, "maximum": 14, "socialRank": "Lower Class", "wealthRating": "Destitute", "maximumWealth": "Poor" },
+    { "minimum": 15, "maximum": 29, "socialRank": "Lower Class", "wealthRating": "Poor", "maximumWealth": "Average" },
+    { "minimum": 30, "maximum": 39, "socialRank": "Lower Middle Class", "wealthRating": "Average", "maximumWealth": "Affluent" },
+    { "minimum": 40, "maximum": 75, "socialRank": "Middle Class", "wealthRating": "Average", "maximumWealth": "Affluent" },
+    { "minimum": 76, "maximum": 95, "socialRank": "Upper Middle Class", "wealthRating": "Affluent", "maximumWealth": "Wealthy" },
+    { "minimum": 96, "maximum": 100, "socialRank": "Upper Class", "wealthRating": "Wealthy", "maximumWealth": "Wealthy" }
+  ]
+}

--- a/src/Brp.Rules/Wealth/WealthBand.cs
+++ b/src/Brp.Rules/Wealth/WealthBand.cs
@@ -1,0 +1,27 @@
+namespace Brp.Rules.Wealth;
+
+/// <summary>
+/// One row of Ch 3: Skills, "Status Skill, Social Status, &amp; Character Wealth" -- the
+/// "Victorian/Western/Pulp/Modern Status" table (p.51), the era table NoiRPG uses (AGENTS.md
+/// invariant 4: modern-era baselines, not historical; see <c>docs/decisions/0030-money-and-wealth-levels.md</c>).
+/// Banded by the character's <c>Status</c> skill rating (Ch 3, p.51, "Base Chance: 15%"). Mirrors
+/// <see cref="Combat.MajorWoundRow"/> / <see cref="Combat.IllnessSeverityBand"/> in shape.
+/// </summary>
+/// <param name="MinimumStatus">The lowest Status rating this row covers.</param>
+/// <param name="MaximumStatus">The highest Status rating this row covers (a printed 00 is 100).</param>
+/// <param name="SocialRank">The printed social rank for this row (e.g. "Lower Class", "Nobility").</param>
+/// <param name="WealthRating">The typical <see cref="WealthLevel"/> for a character with this Status.</param>
+/// <param name="MaximumWealth">
+/// The printed "Wealth Cap" -- the highest <see cref="WealthLevel"/> a character with this Status can
+/// hold.
+/// </param>
+public sealed record WealthBand(
+    int MinimumStatus,
+    int MaximumStatus,
+    string SocialRank,
+    WealthLevel WealthRating,
+    WealthLevel MaximumWealth)
+{
+    /// <summary>Whether this row covers the given Status rating.</summary>
+    public bool Contains(int status) => status >= MinimumStatus && status <= MaximumStatus;
+}

--- a/src/Brp.Rules/Wealth/WealthLevel.cs
+++ b/src/Brp.Rules/Wealth/WealthLevel.cs
@@ -1,0 +1,27 @@
+namespace Brp.Rules.Wealth;
+
+/// <summary>
+/// A character's Money and Wealth level (Ch 2: Characters, "Wealth", p.19; Ch 3: Skills, "Status
+/// Skill, Social Status, &amp; Character Wealth", p.51): "Destitute → Wealthy", "a clean abstraction
+/// ... that suits a game where the PI's finances are a story element" (<c>orc-scope-filter.md</c>
+/// Ch 8, line 129). The five printed levels, in the book's own ascending order, so callers can
+/// compare levels ordinally (e.g. Ch 8, "Charges or Limited-Use Equipment", p.190: a resource "two
+/// or three Wealth levels lower than the equipment's cost").
+/// </summary>
+public enum WealthLevel
+{
+    /// <summary>Ch 2, p.19: "Penniless... homeless... must scavenge food and drink or rely on charity."</summary>
+    Destitute = 0,
+
+    /// <summary>Ch 2, p.19: "some money and does not want for a place to sleep or food to eat... without much luxury."</summary>
+    Poor = 1,
+
+    /// <summary>Ch 2, p.19: "a comfortable income... major purchases must be weighed carefully."</summary>
+    Average = 2,
+
+    /// <summary>Ch 2, p.19: "doing quite well... does not need to think twice about making major purchases."</summary>
+    Affluent = 3,
+
+    /// <summary>Ch 2, p.19: "vast material wealth from a near-inexhaustible source."</summary>
+    Wealthy = 4,
+}

--- a/src/Brp.Rules/Wealth/WealthRuleset.cs
+++ b/src/Brp.Rules/Wealth/WealthRuleset.cs
@@ -1,0 +1,38 @@
+namespace Brp.Rules.Wealth;
+
+/// <summary>
+/// The data-defined values for Ch 3: Skills, "Status Skill, Social Status, &amp; Character Wealth"
+/// (p.51) that a caller reads to turn a character's <c>Status</c> rating into a
+/// <see cref="WealthLevel"/> (AGENTS.md invariant 7: rules values are data, not constants). Loaded
+/// from <c>wealth-ruleset.json</c> by <c>Brp.Data.NoirWealthRuleset.Load()</c>. See
+/// <c>docs/decisions/0030-money-and-wealth-levels.md</c>.
+/// <para>
+/// Deliberately does not model starting cash amounts, prices, or purchasing power -- Issue #229
+/// keeps Money and Wealth "a clean abstraction... that suits a game where the PI's finances are a
+/// story element" (<c>orc-scope-filter.md</c> Ch 8, line 129), not a full economy simulation.
+/// </para>
+/// </summary>
+public sealed class WealthRuleset
+{
+    /// <summary>Creates a wealth ruleset from a data-defined table.</summary>
+    public WealthRuleset(WealthTable table)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        Table = table;
+    }
+
+    /// <summary>Ch 3, "Victorian/Western/Pulp/Modern Status" table (p.51), as a banded lookup by Status rating.</summary>
+    public WealthTable Table { get; }
+
+    /// <summary>
+    /// The typical <see cref="WealthLevel"/> for a character with the given <c>Status</c> skill
+    /// rating (the table's "Wealth Rating" column, p.51).
+    /// </summary>
+    public WealthLevel WealthLevelForStatus(int status) => Table.ForStatus(status).WealthRating;
+
+    /// <summary>
+    /// The highest <see cref="WealthLevel"/> a character with the given <c>Status</c> skill rating
+    /// can hold (the table's "Wealth Cap" column, p.51).
+    /// </summary>
+    public WealthLevel MaximumWealthForStatus(int status) => Table.ForStatus(status).MaximumWealth;
+}

--- a/src/Brp.Rules/Wealth/WealthTable.cs
+++ b/src/Brp.Rules/Wealth/WealthTable.cs
@@ -1,0 +1,41 @@
+namespace Brp.Rules.Wealth;
+
+/// <summary>
+/// Data-backed lookup for Ch 3: Skills, "Status Skill, Social Status, &amp; Character Wealth", the
+/// "Victorian/Western/Pulp/Modern Status" table (p.51). The six printed rows (01-14 through 96-00)
+/// are represented as ruleset bands, cross-indexed by a character's <c>Status</c> skill rating.
+/// Mirrors <see cref="Combat.MajorWoundTable"/> / <see cref="Combat.IllnessSeverityTable"/>.
+/// </summary>
+public sealed class WealthTable
+{
+    private readonly List<WealthBand> _bands;
+
+    /// <summary>Creates a table from ordered ruleset rows.</summary>
+    public WealthTable(IEnumerable<WealthBand> bands)
+    {
+        ArgumentNullException.ThrowIfNull(bands);
+        _bands = bands.ToList();
+        if (_bands.Count == 0)
+        {
+            throw new ArgumentException("Wealth table must contain at least one row.", nameof(bands));
+        }
+    }
+
+    /// <summary>Every printed row, in load order.</summary>
+    public IReadOnlyList<WealthBand> Bands => _bands;
+
+    /// <summary>
+    /// Returns the row that covers the given Status skill rating (a printed 00 read as 100, matching
+    /// the book's own d100 convention).
+    /// </summary>
+    public WealthBand ForStatus(int status)
+    {
+        if (status is < 1 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(status), status, "A Status rating is in [1, 100].");
+        }
+
+        return _bands.SingleOrDefault(band => band.Contains(status))
+            ?? throw new ArgumentOutOfRangeException(nameof(status), status, "No wealth band covers this Status rating.");
+    }
+}

--- a/tests/Brp.Data.Tests/NoirWealthRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirWealthRulesetTests.cs
@@ -1,0 +1,60 @@
+using Brp.Rules.Wealth;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped wealth data loads and reproduces every row of Ch 3: Skills, "Status Skill,
+/// Social Status, &amp; Character Wealth", the "Victorian/Western/Pulp/Modern Status" table (p.51)
+/// -- row by row rather than sampled, per AGENTS.md's "table-backed rule" convention. See
+/// <c>docs/decisions/0030-money-and-wealth-levels.md</c>.
+/// </summary>
+public class NoirWealthRulesetTests
+{
+    private static readonly WealthRuleset Ruleset = NoirWealthRuleset.Load();
+
+    // (minimum, maximum, socialRank, wealthRating, maximumWealth) -- one case per printed row, p.51.
+    public static IEnumerable<object?[]> PrintedRows()
+    {
+        yield return new object?[] { 1, 14, "Lower Class", WealthLevel.Destitute, WealthLevel.Poor };
+        yield return new object?[] { 15, 29, "Lower Class", WealthLevel.Poor, WealthLevel.Average };
+        yield return new object?[] { 30, 39, "Lower Middle Class", WealthLevel.Average, WealthLevel.Affluent };
+        yield return new object?[] { 40, 75, "Middle Class", WealthLevel.Average, WealthLevel.Affluent };
+        yield return new object?[] { 76, 95, "Upper Middle Class", WealthLevel.Affluent, WealthLevel.Wealthy };
+        yield return new object?[] { 96, 100, "Upper Class", WealthLevel.Wealthy, WealthLevel.Wealthy };
+    }
+
+    [Theory]
+    [MemberData(nameof(PrintedRows))]
+    public void Every_printed_table_row_matches_the_book(
+        int minimum, int maximum, string socialRank, WealthLevel wealthRating, WealthLevel maximumWealth)
+    {
+        // A row is looked up by its own range so a mis-ordered or mis-ranged transcription surfaces here.
+        var band = Ruleset.Table.ForStatus(minimum);
+        Assert.Same(band, Ruleset.Table.ForStatus(maximum));
+
+        Assert.Equal(minimum, band.MinimumStatus);
+        Assert.Equal(maximum, band.MaximumStatus);
+        Assert.Equal(socialRank, band.SocialRank);
+        Assert.Equal(wealthRating, band.WealthRating);
+        Assert.Equal(maximumWealth, band.MaximumWealth);
+
+        Assert.Equal(wealthRating, Ruleset.WealthLevelForStatus(minimum));
+        Assert.Equal(maximumWealth, Ruleset.MaximumWealthForStatus(minimum));
+    }
+
+    [Fact]
+    public void The_shipped_table_has_exactly_the_six_printed_rows()
+    {
+        Assert.Equal(6, Ruleset.Table.Bands.Count);
+    }
+
+    [Fact]
+    public void The_table_covers_every_status_result_exactly_once()
+    {
+        // No gaps and no overlaps across the whole 1-100 range (a printed 00 read as 100).
+        for (var status = 1; status <= 100; status++)
+        {
+            Assert.Single(Ruleset.Table.Bands, band => band.Contains(status));
+        }
+    }
+}

--- a/tests/Brp.Rules.Tests/Wealth/WealthTableTests.cs
+++ b/tests/Brp.Rules.Tests/Wealth/WealthTableTests.cs
@@ -1,0 +1,60 @@
+using Brp.Rules.Wealth;
+
+namespace Brp.Rules.Tests.Wealth;
+
+/// <summary>
+/// Construction and lookup edge cases for <see cref="WealthTable"/>, independent of the shipped
+/// data (covered row-by-row in <c>Brp.Data.Tests.NoirWealthRulesetTests</c>).
+/// </summary>
+public class WealthTableTests
+{
+    private static WealthBand Band(int minimum, int maximum) =>
+        new(minimum, maximum, "Test Rank", WealthLevel.Average, WealthLevel.Affluent);
+
+    [Fact]
+    public void Constructor_rejects_an_empty_band_list()
+    {
+        Assert.Throws<ArgumentException>(() => new WealthTable([]));
+    }
+
+    [Fact]
+    public void Constructor_rejects_a_null_band_list()
+    {
+        Assert.Throws<ArgumentNullException>(() => new WealthTable(null!));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void ForStatus_rejects_a_result_outside_1_to_100(int status)
+    {
+        var table = new WealthTable([Band(1, 100)]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => table.ForStatus(status));
+    }
+
+    [Fact]
+    public void ForStatus_throws_when_no_band_covers_the_result()
+    {
+        var table = new WealthTable([Band(1, 50)]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => table.ForStatus(75));
+    }
+
+    [Fact]
+    public void ForStatus_returns_the_band_covering_the_boundary_values()
+    {
+        var band = Band(40, 75);
+        var table = new WealthTable([Band(1, 39), band, Band(76, 100)]);
+
+        Assert.Same(band, table.ForStatus(40));
+        Assert.Same(band, table.ForStatus(75));
+    }
+
+    [Fact]
+    public void WealthLevel_is_ordered_ascending_by_the_book()
+    {
+        Assert.True(WealthLevel.Destitute < WealthLevel.Poor);
+        Assert.True(WealthLevel.Poor < WealthLevel.Average);
+        Assert.True(WealthLevel.Average < WealthLevel.Affluent);
+        Assert.True(WealthLevel.Affluent < WealthLevel.Wealthy);
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #229

## Exact behavioral claim

Given a character's Status skill rating (1-100), the engine now returns the printed
Wealth Rating and Wealth Cap (Destitute → Wealthy) from Ch 3's modern-era Status
table, as data rather than a hardcoded constant. Previously there was no code path
at all for turning Status into a wealth level.

## Scope

Added:
- `Brp.Rules.Wealth`: `WealthLevel` (five-value ordinal enum), `WealthBand`
  (one printed row), `WealthTable` (banded lookup by Status rating, mirroring
  `MajorWoundTable`/`IllnessSeverityTable`), `WealthRuleset` (wraps the table with
  `WealthLevelForStatus`/`MaximumWealthForStatus` convenience reads).
- `Brp.Data.NoirWealthRuleset` + `wealth-ruleset.json`, loading the six printed rows
  of the "Victorian/Western/Pulp/Modern Status" table (Ch 3, p.51) — the only era
  table shipped, matching the project's existing modern-era-baseline policy.
- `docs/decisions/NNNN-money-and-wealth-levels.md`, recording why only the modern
  table is shipped and what is deliberately out of scope.

Deliberately did not change: no wiring into `Brp.Rules.Characters.Character`, no
starting-cash/price modeling, no touching of the other Ch 8 sub-issues (#228, #230,
#231, #232) or their gear/vehicle/drug machinery.

## Rules conformance

Ch 3: Skills, "Status Skill, Social Status, & Character Wealth" (p.51) —
"Victorian/Western/Pulp/Modern Status" table, transcribed row by row (verified via
`tools/source-slice.py --pages 51 --expect "Victorian"`). Ch 2: Characters, "Wealth"
(p.19) supplies the five level names/descriptions the enum documents.

## Tests and evidence

- `dotnet build` — Build succeeded, 0 warnings, 0 errors.
- `dotnet test` — all four suites passed: Brp.Cli.Tests 51/51, Brp.Data.Tests 371/371
  (includes the new `NoirWealthRulesetTests`, which reproduces all six printed rows
  and asserts full 1-100 coverage with no gaps/overlaps), Brp.Rules.Tests 499/499
  (includes the new `WealthTableTests` construction/edge-case tests), Brp.Core.Tests
  1557/1557.
- `dotnet format --verify-no-changes` — clean, no output, exit 0.

## Decisions and tradeoffs

Shipped only the modern-era Status table rather than all three printed era tables,
per the project's existing "modern era baselines, not historical" policy — recorded
in the ADR rather than decided silently. `WealthLevel` is an ordinal enum (not a
plain string) so a future issue needing level comparisons (the book's own "two or
three Wealth levels lower" language, Ch 8 p.190) has something to compare against
without redesigning this type.

## Known limitations

- No character-level wiring: nothing yet reads a specific `Character`'s Status skill
  and calls `WealthRuleset` automatically. That was left to a future consumer since
  #229 asks for the mechanic, not for Layer 4 state.
- The book's alternate "begin at the lowest wealth range, adjusted upward per
  successful Status roll" creation-time procedure (Ch 2, p.19) is not implemented —
  this PR is the lookup table only.

## Agent provenance

Implemented by Claude Opus 4.8 (claude-sonnet-5 harness — worktree agent), acting on
the Issue #229 task packet.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-verification:start -->
### agent-verification — `success` for `d0bfb45`

| gate | result | evidence |
|---|---|---|
| `ci` | pass | GitHub `build-and-test` @ this SHA |
| `scope-warden` | pass | bound — haiku, packet `1a751243be8a` |
| `rules-conformance` | pass | bound — opus, packet `1a751243be8a` |
| `codex-conformance` | pass | bound — codex, packet `1a751243be8a` |
| `architecture-review` | pass | bound — opus, packet `1a751243be8a` |

_5/5 gates passed [route: formulas]. Regenerated per head SHA by `tools/agent-verify.sh`; semantic verdicts bound to head + review packet via `tools/gate-evidence.sh`._
<!-- agent-verification:end -->