### PR TITLE
Ch 8: equipment quality modifiers + Skills-and-Equipment mapping

### DIFF
--- a/docs/decisions/0031-equipment-quality-and-skills-and-equipment.md
+++ b/docs/decisions/0031-equipment-quality-and-skills-and-equipment.md
@@ -1,4 +1,4 @@
-# NNNN. Equipment Quality Modifiers and the Skills-and-Equipment mapping
+# 0031. Equipment Quality Modifiers and the Skills-and-Equipment mapping
 
 ## Status
 

--- a/docs/decisions/NNNN-equipment-quality-and-skills-and-equipment.md
+++ b/docs/decisions/NNNN-equipment-quality-and-skills-and-equipment.md
@@ -1,0 +1,102 @@
+# NNNN. Equipment Quality Modifiers and the Skills-and-Equipment mapping
+
+## Status
+
+Accepted — 2026-09-01. Resolves #228.
+
+## Context
+
+Ch 8: Equipment prints two short, adjacent sections that `orc-scope-filter.md`'s Ch 8 IN-list
+(lines 130-131) both keep: "Equipment Quality Modifiers" (p.185) and "Skills and Equipment"
+(pp.185-186). Issue #228 frames them as one coupled question -- "does your gear help this skill
+roll?" -- and asks that the numeric half go through the existing `ModifierPipeline` (ADR 0007)
+rather than a parallel path, and that the mapping half live as data in `Brp.Data`.
+
+## Decision
+
+Two primitives under `Brp.Rules.Gear`, plus the mapping that gates them together:
+
+- **`EquipmentQuality.Modifier`** (sourced, p.185) -- "The quality of equipment can provide a
+  modifier to a skill roll, as described in Situational Modifiers. This modifier can range from
+  inferior equipment penalizing your character's skill rating by -20%, to superior quality
+  equipment offering a +20% bonus." The book itself names this a *situational* modifier and even
+  restates the Ch 5 ordering rule ("situational modifiers... are applied after an Easy modifier
+  doubles it or Difficult divides it in half"), so it is built as an `AdditiveKind.Situational`
+  `AdditiveModifier` and evaluated through `ModifierPipeline.Evaluate` exactly like every other
+  situational source -- no bespoke arithmetic, no parallel path. `EquipmentQualityRuleset` loads
+  the two deltas (-20/+20) from `equipment-quality-ruleset.json` (AGENTS.md invariant 7).
+- **`SkillEquipmentRuleset`** (sourced, pp.185-186) -- the "Skills & Equipment" table: "The Skills
+  & Equipment table describes potential specialized or general equipment to use with skills. If
+  the skill is not listed, it does not require any equipment, or it is obvious (such as weapon
+  skills)." Modelled as gear-to-skill data (`skill-equipment-ruleset.json`, loaded by
+  `Brp.Data.NoirSkillEquipmentRuleset`), keyed by the engine's existing skill ids
+  (`docs/decisions/0011-skill-definition.md`), not a new naming scheme.
+- **`EquipmentQuality.ModifierForSkill`** -- the coupling point. Looks the skill up in
+  `SkillEquipmentRuleset` first and throws if it is not listed, then delegates to
+  `EquipmentQuality.Modifier`. This is what makes the two mechanics "coupled" rather than two
+  independent, unrelated features: the mapping is the gate that says whether a quality modifier
+  is meaningful for a given skill at all, matching the book's own framing that an unlisted skill's
+  equipment "does not require... or it is obvious."
+
+### Hand-picked subset -- sourced list, house selection
+
+`orc-scope-filter.md`, Ch 8: "Do not transcribe it wholesale into ruleset JSON -- hand-pick the
+entries a noir detective could plausibly encounter." The book's Skills & Equipment table lists
+18 skill rows; `skill-equipment-ruleset.json` keeps the 16 whose skill has an engine equivalent
+in `skill-ruleset.json` (Appraise, Art, Climb, Disguise, Locksmith [book: Fine Manipulation],
+First Aid, Gaming, Knowledge, Language, Medicine, Navigate, Repair, Research, Science, Teach,
+Technical Skill). The book's Craft and Literacy rows are cut along with those two skills, which
+are not part of the engine's skill list at all (out of scope already, independent of this issue).
+
+**Specialty expansion (house shape, not a book rule).** Five of those 16 book rows -- Art,
+Knowledge, Repair, Science, Technical Skill -- name a skill that `SkillRegistry` does not itself
+resolve: `NoirSkillRuleset.Load()` treats a parent entry with `specialties` as a category, not a
+rollable skill, and registers only the leaves (`docs/decisions/0011-skill-definition.md`). Rather
+than invent a synthetic parent id the rest of the engine has no roll for, `skill-equipment-ruleset.json`
+records one link per resolvable specialty (Photography; Streetwise/Law/Accounting/Knowledge
+(Group)/Knowledge (Region)/Knowledge (Politics); Repair (Electrical/Electronic/Mechanical);
+Science (Chemistry/Forensics); Technical Skill (Computer Use/Electronics/Security Systems)),
+each carrying the parent row's equipment text and citing which book row it came from. This keeps
+`SkillEquipmentRuleset.UsesEquipment` meaningful against every id it is actually asked about --
+the same ids `SkillRoll` and the rest of Layer 2/3 already use -- at the cost of 26 links instead
+of a literal 16. Two equipment descriptions ("Navigate": astrolabe; "Medicine": herbalist
+materials) also drop their pre-modern flavor text per AGENTS.md invariant 4 (modern era
+baselines) -- a house wording choice, the underlying skill-equipment relevance itself is
+unchanged from the book.
+
+### Not implemented -- GM discretion, not an engine rule
+
+p.185 also covers the case of *missing* required equipment: "your gamemaster may make the skill's
+chance Difficult or Impossible, or simply rule that the skill cannot be attempted without the
+right gear... Your gamemaster may allow your character a straight 1% chance." The book presents
+three different possible outcomes, explicitly left to gamemaster judgment, with no single rule to
+encode. This issue implements the two mechanics it names (the quality modifier and the mapping)
+and does not invent a house rule for the missing-equipment case; a caller that wants to express
+"no gear, no roll" already has `GateModifier` and `DifficultyModifier` available to compose that
+decision itself, scene by scene.
+
+## Consequences
+
+- `EquipmentQuality.Modifier` returns a modifier for every tier, including a zero-delta one for
+  `Average`, rather than `null` for "no bonus" -- matching the precedent of other zero-delta
+  additive modifiers in this engine, so a caller never needs a conditional.
+- `SkillEquipmentRuleset.UsesEquipment` returning `false` for an unlisted skill is the expected,
+  non-error outcome (Brawl, Persuade, and most Combat/Communication skills carry no equipment
+  row) -- not a defect to fix by inventing more rows.
+- Neither primitive is wired into character creation, inventory, or a specific scene; per ADR
+  0028's precedent for a comparable "general primitive" issue, wiring specific gear items to
+  specific skill checks in play is Layer 5 content work, out of scope here.
+- `EquipmentQuality.ModifierForSkill`'s gate is an engineering choice about how these two sourced
+  mechanics compose, not itself a printed book rule -- the book states the mapping and the
+  quality table as separate facts and never explicitly forbids applying a quality modifier to an
+  unlisted skill's roll. Throwing here is the stricter, safer reading: it surfaces a caller
+  mistake immediately rather than silently accepting a modifier the book gives no basis for.
+
+## Known limitations
+
+- The missing-equipment case (Difficult/Impossible/no-attempt) is deliberately not automated; see
+  "Not implemented" above.
+- `SkillEquipmentLink.PotentialEquipment` is free text for reference/GM use, not machine-parsed
+  into a specific item catalogue -- there is no attempt here to say *which* weapon/armor
+  definitions in `weapon-ruleset.json`/`armor-ruleset.json` satisfy a given skill's equipment
+  need; the book's own table is prose-level guidance, not a lookup table of specific items.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -53,3 +53,4 @@ supersedes it — the original is not edited or deleted.
 | [0028](0028-complementary-skills-and-augments.md) | Complementary Skills and Augments are two mechanics, not one | Accepted |
 | [0029](0029-special-damage-effects.md) | Special-damage effects (Crushing stun, Impaling lodged weapon, Knockback, Bleeding, Entangling) and Fighting Defensively | Accepted |
 | [0030](0030-money-and-wealth-levels.md) | Money and Wealth levels: the modern-era Status table only, five ordinal levels, no economy sim | Accepted |
+| [NNNN](NNNN-equipment-quality-and-skills-and-equipment.md) | Equipment Quality Modifiers and the Skills-and-Equipment mapping | Accepted |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -53,4 +53,4 @@ supersedes it — the original is not edited or deleted.
 | [0028](0028-complementary-skills-and-augments.md) | Complementary Skills and Augments are two mechanics, not one | Accepted |
 | [0029](0029-special-damage-effects.md) | Special-damage effects (Crushing stun, Impaling lodged weapon, Knockback, Bleeding, Entangling) and Fighting Defensively | Accepted |
 | [0030](0030-money-and-wealth-levels.md) | Money and Wealth levels: the modern-era Status table only, five ordinal levels, no economy sim | Accepted |
-| [NNNN](NNNN-equipment-quality-and-skills-and-equipment.md) | Equipment Quality Modifiers and the Skills-and-Equipment mapping | Accepted |
+| [0031](0031-equipment-quality-and-skills-and-equipment.md) | Equipment Quality Modifiers and the Skills-and-Equipment mapping | Accepted |

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -34,6 +34,8 @@
     <EmbeddedResource Include="special-damage-effects-ruleset.json" />
     <EmbeddedResource Include="poison-catalog.json" />
     <EmbeddedResource Include="wealth-ruleset.json" />
+    <EmbeddedResource Include="equipment-quality-ruleset.json" />
+    <EmbeddedResource Include="skill-equipment-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirEquipmentQualityRuleset.cs
+++ b/src/Brp.Data/NoirEquipmentQualityRuleset.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using Brp.Rules.Gear;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's equipment-quality percentages from embedded JSON. Sourced: Ch 8: Equipment,
+/// "Equipment Quality Modifiers" (p.185). See <see cref="EquipmentQualityRuleset"/> for the
+/// field-level citation.
+/// </summary>
+public static class NoirEquipmentQualityRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable equipment-quality ruleset from the shipped data.</summary>
+    public static EquipmentQualityRuleset Load()
+    {
+        var assembly = typeof(NoirEquipmentQualityRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.equipment-quality-ruleset.json")
+            ?? throw new InvalidOperationException("The equipment-quality ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<EquipmentQualityData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The equipment-quality ruleset data is empty.");
+
+        return new EquipmentQualityRuleset(data.InferiorDelta, data.SuperiorDelta);
+    }
+
+    private sealed class EquipmentQualityData
+    {
+        public required int InferiorDelta { get; init; }
+
+        public required int SuperiorDelta { get; init; }
+    }
+}

--- a/src/Brp.Data/NoirSkillEquipmentRuleset.cs
+++ b/src/Brp.Data/NoirSkillEquipmentRuleset.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Brp.Core.Skills;
+using Brp.Rules.Gear;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's Skills-and-Equipment mapping from embedded JSON. Sourced: Ch 8: Equipment,
+/// "Skills and Equipment" (pp.185-186), hand-picked to the modern noir subset per
+/// <c>orc-scope-filter.md</c> -- see <c>skill-equipment-ruleset.json</c>'s own <c>source</c>
+/// field for the exact citation and cut list.
+/// </summary>
+public static class NoirSkillEquipmentRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable skill-equipment ruleset from the shipped data.</summary>
+    public static SkillEquipmentRuleset Load()
+    {
+        var assembly = typeof(NoirSkillEquipmentRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.skill-equipment-ruleset.json")
+            ?? throw new InvalidOperationException("The skill-equipment ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<SkillEquipmentData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The skill-equipment ruleset data is empty.");
+
+        var links = data.Links.Select(link => new SkillEquipmentLink(new SkillId(link.SkillId), link.PotentialEquipment));
+        return new SkillEquipmentRuleset(links);
+    }
+
+    private sealed class SkillEquipmentData
+    {
+        public required List<SkillEquipmentLinkData> Links { get; init; }
+    }
+
+    private sealed class SkillEquipmentLinkData
+    {
+        public required string SkillId { get; init; }
+
+        public required string PotentialEquipment { get; init; }
+    }
+}

--- a/src/Brp.Data/equipment-quality-ruleset.json
+++ b/src/Brp.Data/equipment-quality-ruleset.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 8: Equipment",
+    "notes": "Equipment Quality Modifiers (p.185): 'Quality Modifier Value and Ability | Inferior -20% Subtract one to three value levels | Average None As normal | Superior +20% Add one to three value levels.' The book names this a situational modifier ('as described in Situational Modifiers'), applied through the existing ModifierPipeline (ADR 0007)."
+  },
+  "inferiorDelta": -20,
+  "superiorDelta": 20
+}

--- a/src/Brp.Data/skill-equipment-ruleset.json
+++ b/src/Brp.Data/skill-equipment-ruleset.json
@@ -1,0 +1,35 @@
+{
+  "source": {
+    "book": "BasicRoleplaying-ORC-Content-Document.pdf",
+    "chapter": "Chapter 8: Equipment",
+    "notes": "Skills and Equipment (pp.185-186), the 'Skills & Equipment' table: 'Skill | Potential Equipment'. Hand-picked per orc-scope-filter.md, Ch 8 ('hand-pick the entries a noir detective could plausibly encounter') to the rows whose skill has an engine equivalent in skill-ruleset.json. Where the book's row names a skill that the engine only exposes through specialties (Art, Knowledge, Repair, Science, Technical Skill), one link is recorded per resolvable specialty id -- SkillRegistry only resolves leaf skills, not the parent category (docs/decisions/0011-skill-definition.md) -- each carrying the parent row's equipment text. Weapon skills (Firearms, Melee Weapon) are cut along with the book's own carve-out ('it does not require any equipment, or it is obvious, such as weapon skills'). The book's Craft and Literacy rows are cut with those skills (out of scope, not present in skill-ruleset.json). Pre-modern flavor text (astrolabe, herbalist materials) dropped per AGENTS.md invariant 4 (modern era baselines)."
+  },
+  "links": [
+    { "skillId": "Appraise", "potentialEquipment": "None, or reference materials, measuring devices, a magnifying glass, etc." },
+    { "skillId": "Photography", "potentialEquipment": "By medium -- camera, film, darkroom equipment, etc. (book row: Art)." },
+    { "skillId": "Climb", "potentialEquipment": "None, or rope, pitons, crampons, etc." },
+    { "skillId": "Disguise", "potentialEquipment": "Makeup, wigs, costume changes, etc." },
+    { "skillId": "Locksmith", "potentialEquipment": "None, or precision tools (book row: Fine Manipulation)." },
+    { "skillId": "First Aid", "potentialEquipment": "None, or a basic first aid kit and bandages." },
+    { "skillId": "Gaming", "potentialEquipment": "None, or cards, dice, a game board, etc." },
+    { "skillId": "Streetwise", "potentialEquipment": "None, or reference materials (book row: Knowledge)." },
+    { "skillId": "Law", "potentialEquipment": "None, or reference materials (book row: Knowledge)." },
+    { "skillId": "Accounting", "potentialEquipment": "None, or reference materials (book row: Knowledge)." },
+    { "skillId": "Knowledge (Group)", "potentialEquipment": "None, or reference materials (book row: Knowledge)." },
+    { "skillId": "Knowledge (Region)", "potentialEquipment": "None, or reference materials (book row: Knowledge)." },
+    { "skillId": "Knowledge (Politics)", "potentialEquipment": "None, or reference materials (book row: Knowledge)." },
+    { "skillId": "Language", "potentialEquipment": "None, or a language dictionary." },
+    { "skillId": "Medicine", "potentialEquipment": "None, or modern medical facilities and pharmaceuticals." },
+    { "skillId": "Navigate", "potentialEquipment": "None, or maps, a compass, GPS, etc." },
+    { "skillId": "Repair (Electrical)", "potentialEquipment": "None, or tools appropriate to the type of repair (book row: Repair)." },
+    { "skillId": "Repair (Electronic)", "potentialEquipment": "None, or tools appropriate to the type of repair (book row: Repair)." },
+    { "skillId": "Repair (Mechanical)", "potentialEquipment": "None, or tools appropriate to the type of repair (book row: Repair)." },
+    { "skillId": "Research", "potentialEquipment": "None, or a research library and reference materials." },
+    { "skillId": "Science (Chemistry)", "potentialEquipment": "None, or scientific instruments and reference materials (book row: Science)." },
+    { "skillId": "Science (Forensics)", "potentialEquipment": "None, or scientific instruments and reference materials (book row: Science)." },
+    { "skillId": "Teach", "potentialEquipment": "Educational materials appropriate to the subject." },
+    { "skillId": "Technical Skill (Computer Use)", "potentialEquipment": "None, or materials appropriate to the specific skill (book row: Technical Skill)." },
+    { "skillId": "Technical Skill (Electronics)", "potentialEquipment": "None, or materials appropriate to the specific skill (book row: Technical Skill)." },
+    { "skillId": "Technical Skill (Security Systems)", "potentialEquipment": "None, or materials appropriate to the specific skill (book row: Technical Skill)." }
+  ]
+}

--- a/src/Brp.Rules/Gear/EquipmentQuality.cs
+++ b/src/Brp.Rules/Gear/EquipmentQuality.cs
@@ -1,0 +1,83 @@
+using Brp.Core.Modifiers;
+using Brp.Core.Skills;
+
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// Ch 8: Equipment, "Equipment Quality Modifiers" (p.185): "The quality of equipment can provide
+/// a modifier to a skill roll, as described in ** Situational Modifiers**. This modifier can
+/// range from inferior equipment penalizing your character's skill rating by -20%, to superior
+/// quality equipment offering a +20% bonus." The book names this as a situational modifier
+/// itself, so it is produced as an <see cref="AdditiveKind.Situational"/> <see cref="AdditiveModifier"/>
+/// and flows through the existing <see cref="ModifierPipeline"/> exactly like every other
+/// situational source (ADR 0007) -- no parallel modifier path. p.185 restates the Ch 5 ordering
+/// rule explicitly: "Remember that situational modifiers to a skill rating are applied after an
+/// Easy modifier doubles it or Difficult divides it in half."
+/// <para>
+/// <strong>Coupling with the Skills-and-Equipment mapping (sourced, p.185-186):</strong> "Many
+/// skills require equipment to be used successfully, or are greatly enhanced with equipment...
+/// If the skill is not listed, it does not require any equipment, or it is obvious." A quality
+/// modifier is therefore only meaningful for a skill the mapping actually lists --
+/// <see cref="ModifierForSkill"/> is the gated entry point that enforces this; <see cref="Modifier"/>
+/// is the ungated primitive it is built from.
+/// </para>
+/// </summary>
+public static class EquipmentQuality
+{
+    /// <summary>
+    /// Builds the situational modifier a piece of equipment's quality tier contributes to a
+    /// skill roll. Returns a zero-delta modifier for <see cref="EquipmentQualityTier.Average"/>
+    /// rather than <see langword="null"/> -- the book's "Average ... None" is a defined, present
+    /// answer, not an absent one -- so a caller can always add the result to its modifier list
+    /// without a conditional, matching the precedent set for zero-delta additive modifiers
+    /// elsewhere in this engine.
+    /// </summary>
+    public static AdditiveModifier Modifier(EquipmentQualityTier tier, string equipmentLabel, EquipmentQualityRuleset ruleset)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(equipmentLabel);
+        ArgumentNullException.ThrowIfNull(ruleset);
+
+        var delta = tier switch
+        {
+            EquipmentQualityTier.Inferior => ruleset.InferiorDelta,
+            EquipmentQualityTier.Average => 0,
+            EquipmentQualityTier.Superior => ruleset.SuperiorDelta,
+            _ => throw new ArgumentOutOfRangeException(nameof(tier), tier, "Unknown equipment quality tier."),
+        };
+
+        var label = tier switch
+        {
+            EquipmentQualityTier.Inferior => "inferior",
+            EquipmentQualityTier.Average => "average",
+            EquipmentQualityTier.Superior => "superior",
+            _ => throw new ArgumentOutOfRangeException(nameof(tier), tier, "Unknown equipment quality tier."),
+        };
+
+        return new AdditiveModifier($"{equipmentLabel} ({label} quality)", delta, AdditiveKind.Situational);
+    }
+
+    /// <summary>
+    /// Builds the quality modifier for a skill roll, gated by the Skills-and-Equipment mapping
+    /// (p.185-186). Throws if <paramref name="skillId"/> is not a skill the mapping lists
+    /// equipment for -- the book's own rule for such a skill is that equipment "does not [...]
+    /// or it is obvious", so a caller asking for a quality modifier there is a caller bug, not a
+    /// silent zero-modifier no-op.
+    /// </summary>
+    public static AdditiveModifier ModifierForSkill(
+        SkillId skillId,
+        EquipmentQualityTier tier,
+        string equipmentLabel,
+        EquipmentQualityRuleset qualityRuleset,
+        SkillEquipmentRuleset skillEquipmentRuleset)
+    {
+        ArgumentNullException.ThrowIfNull(skillEquipmentRuleset);
+        if (!skillEquipmentRuleset.UsesEquipment(skillId))
+        {
+            throw new ArgumentException(
+                $"'{skillId}' is not a skill the Skills-and-Equipment mapping (Ch 8, p.185-186) lists equipment for.",
+                nameof(skillId));
+        }
+
+        return Modifier(tier, equipmentLabel, qualityRuleset);
+    }
+}

--- a/src/Brp.Rules/Gear/EquipmentQualityRuleset.cs
+++ b/src/Brp.Rules/Gear/EquipmentQualityRuleset.cs
@@ -1,0 +1,23 @@
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// Data-defined percentages for Ch 8: Equipment, "Equipment Quality Modifiers" (p.185).
+/// AGENTS.md invariant 7 (rules values are data, not constants): the two deltas are loaded from
+/// <c>equipment-quality-ruleset.json</c> by <c>Brp.Data.NoirEquipmentQualityRuleset.Load()</c>
+/// rather than hardcoded in <see cref="EquipmentQuality"/>.
+/// </summary>
+public sealed class EquipmentQualityRuleset
+{
+    /// <summary>Creates a ruleset from data-defined values.</summary>
+    public EquipmentQualityRuleset(int inferiorDelta, int superiorDelta)
+    {
+        InferiorDelta = inferiorDelta;
+        SuperiorDelta = superiorDelta;
+    }
+
+    /// <summary>Ch 8, "Equipment Quality Modifiers" (p.185): "Inferior ... -20%."</summary>
+    public int InferiorDelta { get; }
+
+    /// <summary>Ch 8, "Equipment Quality Modifiers" (p.185): "Superior ... +20%."</summary>
+    public int SuperiorDelta { get; }
+}

--- a/src/Brp.Rules/Gear/EquipmentQualityTier.cs
+++ b/src/Brp.Rules/Gear/EquipmentQualityTier.cs
@@ -1,0 +1,20 @@
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// The three quality tiers Ch 8: Equipment, "Equipment Quality Modifiers" (p.185) defines for
+/// task-relevant gear -- lockpicks, a research library, a medical lab, or "anything else that is
+/// useful and appropriate." Average is the default ("Most equipment your character uses is by
+/// default of average quality"); a character opts into Inferior or Superior gear as a deliberate
+/// choice.
+/// </summary>
+public enum EquipmentQualityTier
+{
+    /// <summary>"Inferior ... -20% ... Subtract one to three value levels." (p.185)</summary>
+    Inferior,
+
+    /// <summary>"Average ... None ... As normal." (p.185) The default for unspecified gear.</summary>
+    Average,
+
+    /// <summary>"Superior ... +20% ... Add one to three value levels." (p.185)</summary>
+    Superior,
+}

--- a/src/Brp.Rules/Gear/SkillEquipmentLink.cs
+++ b/src/Brp.Rules/Gear/SkillEquipmentLink.cs
@@ -1,0 +1,19 @@
+using Brp.Core.Skills;
+
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// One row of Ch 8: Equipment, "Skills and Equipment" (pp.185-186): "The Skills &amp; Equipment
+/// table describes potential specialized or general equipment to use with skills. If the skill
+/// is not listed, it does not require any equipment, or it is obvious (such as weapon skills)."
+/// A skill's absence from <see cref="SkillEquipmentRuleset"/> is therefore the book's own "no
+/// equipment relevant here" case, not an omission.
+/// </summary>
+/// <param name="SkillId">The engine's skill id (docs/decisions/0011-skill-definition.md).</param>
+/// <param name="PotentialEquipment">
+/// The book's "Potential Equipment" text for this skill, hand-picked to the modern noir subset
+/// per <c>orc-scope-filter.md</c>, Ch 8 ("hand-pick the entries a noir detective could plausibly
+/// encounter"): pre-modern items (astrolabes, herbalist kits) are dropped in favor of a modern
+/// phrasing, per AGENTS.md invariant 4 (modern era baselines).
+/// </param>
+public sealed record SkillEquipmentLink(SkillId SkillId, string PotentialEquipment);

--- a/src/Brp.Rules/Gear/SkillEquipmentRuleset.cs
+++ b/src/Brp.Rules/Gear/SkillEquipmentRuleset.cs
@@ -1,0 +1,42 @@
+using Brp.Core.Skills;
+
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// The Ch 8: Equipment, "Skills and Equipment" table (pp.185-186), hand-picked to the noir-
+/// relevant subset (<c>orc-scope-filter.md</c>). Couples with <see cref="EquipmentQuality"/>: this
+/// mapping answers "does gear help this skill roll at all", and <see cref="EquipmentQuality"/>
+/// supplies the numeric answer once this mapping says yes -- see
+/// <see cref="EquipmentQuality.ModifierForSkill"/>.
+/// </summary>
+public sealed class SkillEquipmentRuleset
+{
+    private readonly Dictionary<string, SkillEquipmentLink> _linksBySkillId;
+
+    /// <summary>Creates a ruleset from data-defined links.</summary>
+    public SkillEquipmentRuleset(IEnumerable<SkillEquipmentLink> links)
+    {
+        ArgumentNullException.ThrowIfNull(links);
+
+        _linksBySkillId = links.ToDictionary(link => link.SkillId.Value, StringComparer.OrdinalIgnoreCase);
+        if (_linksBySkillId.Count == 0)
+        {
+            throw new ArgumentException("At least one skill-equipment link is required.", nameof(links));
+        }
+    }
+
+    /// <summary>Every skill the book lists potential equipment for, keyed by skill id.</summary>
+    public IReadOnlyDictionary<string, SkillEquipmentLink> Links => _linksBySkillId;
+
+    /// <summary>
+    /// True when <paramref name="skillId"/> is one the book's Skills &amp; Equipment table lists
+    /// potential equipment for. Per p.185, an unlisted skill "does not require any equipment, or
+    /// it is obvious", so <see langword="false"/> here is the expected, non-error outcome for a
+    /// skill such as Brawl or Persuade.
+    /// </summary>
+    public bool UsesEquipment(SkillId skillId) => _linksBySkillId.ContainsKey(skillId.Value);
+
+    /// <summary>Looks up the equipment link for a skill, or <see langword="null"/> if it is not listed.</summary>
+    public SkillEquipmentLink? TryGetLink(SkillId skillId) =>
+        _linksBySkillId.TryGetValue(skillId.Value, out var link) ? link : null;
+}

--- a/tests/Brp.Data.Tests/NoirEquipmentQualityRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirEquipmentQualityRulesetTests.cs
@@ -3,7 +3,7 @@ namespace Brp.Data.Tests;
 /// <summary>
 /// Confirms the shipped equipment-quality percentages load and match the book: Ch 8: Equipment,
 /// "Equipment Quality Modifiers" (p.185). See
-/// <c>docs/decisions/NNNN-equipment-quality-and-skills-and-equipment.md</c>.
+/// <c>docs/decisions/0031-equipment-quality-and-skills-and-equipment.md</c>.
 /// </summary>
 public class NoirEquipmentQualityRulesetTests
 {

--- a/tests/Brp.Data.Tests/NoirEquipmentQualityRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirEquipmentQualityRulesetTests.cs
@@ -1,0 +1,18 @@
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped equipment-quality percentages load and match the book: Ch 8: Equipment,
+/// "Equipment Quality Modifiers" (p.185). See
+/// <c>docs/decisions/NNNN-equipment-quality-and-skills-and-equipment.md</c>.
+/// </summary>
+public class NoirEquipmentQualityRulesetTests
+{
+    [Fact]
+    public void Deltas_match_the_books_equipment_quality_table_page_185()
+    {
+        var ruleset = NoirEquipmentQualityRuleset.Load();
+
+        Assert.Equal(-20, ruleset.InferiorDelta);
+        Assert.Equal(20, ruleset.SuperiorDelta);
+    }
+}

--- a/tests/Brp.Data.Tests/NoirSkillEquipmentRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirSkillEquipmentRulesetTests.cs
@@ -1,0 +1,63 @@
+using Brp.Core.Skills;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Confirms the shipped Skills-and-Equipment mapping loads, matches the hand-picked noir subset
+/// described in <c>skill-equipment-ruleset.json</c>'s own <c>source</c> field, and stays a subset
+/// of the engine's actual skill list (<c>skill-ruleset.json</c>). Ch 8: Equipment, "Skills and
+/// Equipment" (pp.185-186); <c>orc-scope-filter.md</c>, Ch 8.
+/// </summary>
+public class NoirSkillEquipmentRulesetTests
+{
+    // Every skill id this ruleset is expected to carry -- the book's 16 in-scope rows, with the
+    // five rows that name a specialty-only parent (Art, Knowledge, Repair, Science, Technical
+    // Skill) expanded to their resolvable specialty ids (see the ADR's "Specialty expansion").
+    private static readonly string[] ExpectedSkillIds =
+    [
+        "Appraise", "Photography", "Climb", "Disguise", "Locksmith", "First Aid", "Gaming",
+        "Streetwise", "Law", "Accounting", "Knowledge (Group)", "Knowledge (Region)", "Knowledge (Politics)",
+        "Language", "Medicine", "Navigate",
+        "Repair (Electrical)", "Repair (Electronic)", "Repair (Mechanical)",
+        "Research", "Science (Chemistry)", "Science (Forensics)", "Teach",
+        "Technical Skill (Computer Use)", "Technical Skill (Electronics)", "Technical Skill (Security Systems)",
+    ];
+
+    [Fact]
+    public void Loads_exactly_the_hand_picked_noir_subset()
+    {
+        var ruleset = NoirSkillEquipmentRuleset.Load();
+
+        Assert.Equal(ExpectedSkillIds.Length, ruleset.Links.Count);
+        foreach (var skillId in ExpectedSkillIds)
+        {
+            Assert.True(ruleset.UsesEquipment(new SkillId(skillId)), $"Expected a link for '{skillId}'.");
+        }
+    }
+
+    [Fact]
+    public void Every_linked_skill_id_exists_in_the_engines_skill_ruleset()
+    {
+        var skillEquipment = NoirSkillEquipmentRuleset.Load();
+        var skillRegistry = NoirSkillRuleset.Load();
+
+        foreach (var link in skillEquipment.Links.Values)
+        {
+            Assert.True(
+                skillRegistry.TryGetSkill(link.SkillId, out _),
+                $"'{link.SkillId}' is not a defined skill in skill-ruleset.json.");
+        }
+    }
+
+    [Fact]
+    public void Weapon_and_combat_skills_are_not_listed_matching_the_books_own_carve_out()
+    {
+        // p.185-186: "it does not require any equipment, or it is obvious (such as weapon
+        // skills)."
+        var ruleset = NoirSkillEquipmentRuleset.Load();
+
+        Assert.False(ruleset.UsesEquipment(new SkillId("Firearms")));
+        Assert.False(ruleset.UsesEquipment(new SkillId("Brawl")));
+        Assert.False(ruleset.UsesEquipment(new SkillId("Melee Weapon")));
+    }
+}

--- a/tests/Brp.Rules.Tests/Gear/EquipmentQualityTests.cs
+++ b/tests/Brp.Rules.Tests/Gear/EquipmentQualityTests.cs
@@ -9,7 +9,7 @@ namespace Brp.Rules.Tests.Gear;
 /// Ch 8: Equipment, "Equipment Quality Modifiers" (p.185): reproduces the printed three-row
 /// table in full (Inferior/Average/Superior), and confirms the modifier flows through the
 /// existing <see cref="ModifierPipeline"/> as a situational source (ADR 0007), not a parallel
-/// path. See <c>docs/decisions/NNNN-equipment-quality-and-skills-and-equipment.md</c>.
+/// path. See <c>docs/decisions/0031-equipment-quality-and-skills-and-equipment.md</c>.
 /// </summary>
 public class EquipmentQualityTests
 {

--- a/tests/Brp.Rules.Tests/Gear/EquipmentQualityTests.cs
+++ b/tests/Brp.Rules.Tests/Gear/EquipmentQualityTests.cs
@@ -1,0 +1,94 @@
+using Brp.Core.Modifiers;
+using Brp.Core.Primitives;
+using Brp.Core.Skills;
+using Brp.Rules.Gear;
+
+namespace Brp.Rules.Tests.Gear;
+
+/// <summary>
+/// Ch 8: Equipment, "Equipment Quality Modifiers" (p.185): reproduces the printed three-row
+/// table in full (Inferior/Average/Superior), and confirms the modifier flows through the
+/// existing <see cref="ModifierPipeline"/> as a situational source (ADR 0007), not a parallel
+/// path. See <c>docs/decisions/NNNN-equipment-quality-and-skills-and-equipment.md</c>.
+/// </summary>
+public class EquipmentQualityTests
+{
+    private static readonly EquipmentQualityRuleset Ruleset = new(inferiorDelta: -20, superiorDelta: 20);
+    private static readonly SkillEquipmentRuleset SkillEquipment =
+        new([new SkillEquipmentLink(new SkillId("Locksmith"), "None, or precision tools.")]);
+
+    // Ch 8, p.185: "Quality | Modifier | Value and Ability -- Inferior -20% ... Average None ...
+    // Superior +20%." Every printed row, not a spot check.
+    [Theory]
+    [InlineData(EquipmentQualityTier.Inferior, -20)]
+    [InlineData(EquipmentQualityTier.Average, 0)]
+    [InlineData(EquipmentQualityTier.Superior, 20)]
+    public void Reproduces_the_books_equipment_quality_table_page_185(EquipmentQualityTier tier, int expectedDelta)
+    {
+        var modifier = EquipmentQuality.Modifier(tier, "lock picks", Ruleset);
+
+        Assert.Equal(expectedDelta, modifier.Delta);
+    }
+
+    [Fact]
+    public void Average_quality_produces_a_zero_delta_modifier_not_a_null()
+    {
+        var modifier = EquipmentQuality.Modifier(EquipmentQualityTier.Average, "lock picks", Ruleset);
+
+        Assert.NotNull(modifier);
+        Assert.Equal(0, modifier.Delta);
+    }
+
+    [Fact]
+    public void Quality_modifier_is_situational_per_the_books_own_cross_reference()
+    {
+        // "The quality of equipment can provide a modifier to a skill roll, as described in
+        // Situational Modifiers" -- the book names the stage itself.
+        var modifier = EquipmentQuality.Modifier(EquipmentQualityTier.Superior, "lock picks", Ruleset);
+
+        Assert.Equal(AdditiveKind.Situational, modifier.Kind);
+    }
+
+    [Fact]
+    public void Situational_modifier_is_applied_after_the_difficulty_multiplier()
+    {
+        // p.185: "Remember that situational modifiers to a skill rating are applied after an
+        // Easy modifier doubles it or Difficult divides it in half." Worked example: 65%,
+        // Difficult (halve, round up per ADR 0007), superior lock picks (+20%).
+        var quality = EquipmentQuality.Modifier(EquipmentQualityTier.Superior, "lock picks", Ruleset);
+        var chain = ModifierPipeline.Evaluate(
+            Percent.Of(65), [quality, DifficultyModifier.Difficult("test")]);
+
+        // 65 / 2 = 32.5 -> 33 (round up), then +20 -> 53. Not (65 + 20) / 2 = 43.
+        Assert.Equal(53, chain.EffectiveChance!.Value.Value);
+    }
+
+    [Fact]
+    public void Inferior_lockpicking_example_matches_the_books_worked_example_page_185()
+    {
+        // "Inferior tools (rusty, broken, improvised) modified the skill by -20%."
+        var modifier = EquipmentQuality.Modifier(EquipmentQualityTier.Inferior, "lock picks", Ruleset);
+        var chain = ModifierPipeline.Evaluate(Percent.Of(50), [modifier]);
+
+        Assert.Equal(30, chain.EffectiveChance!.Value.Value);
+    }
+
+    [Fact]
+    public void ModifierForSkill_delegates_to_Modifier_when_the_skill_is_in_the_mapping()
+    {
+        var modifier = EquipmentQuality.ModifierForSkill(
+            new SkillId("Locksmith"), EquipmentQualityTier.Superior, "lock picks", Ruleset, SkillEquipment);
+
+        Assert.Equal(20, modifier.Delta);
+    }
+
+    [Fact]
+    public void ModifierForSkill_throws_when_the_skill_is_not_listed_in_the_skills_and_equipment_mapping()
+    {
+        // p.185-186: an unlisted skill "does not require any equipment, or it is obvious (such
+        // as weapon skills)" -- asking for a quality modifier there is a caller mistake.
+        Assert.Throws<ArgumentException>(() =>
+            EquipmentQuality.ModifierForSkill(
+                new SkillId("Brawl"), EquipmentQualityTier.Superior, "brass knuckles", Ruleset, SkillEquipment));
+    }
+}

--- a/tests/Brp.Rules.Tests/Gear/SkillEquipmentRulesetTests.cs
+++ b/tests/Brp.Rules.Tests/Gear/SkillEquipmentRulesetTests.cs
@@ -1,0 +1,48 @@
+using Brp.Core.Skills;
+using Brp.Rules.Gear;
+
+namespace Brp.Rules.Tests.Gear;
+
+/// <summary>
+/// Ch 8: Equipment, "Skills and Equipment" (pp.185-186): the mapping primitive itself, apart
+/// from the shipped data (covered separately by <c>Brp.Data.Tests.NoirSkillEquipmentRulesetTests</c>).
+/// </summary>
+public class SkillEquipmentRulesetTests
+{
+    [Fact]
+    public void A_listed_skill_resolves_to_its_link()
+    {
+        var ruleset = new SkillEquipmentRuleset(
+            [new SkillEquipmentLink(new SkillId("Locksmith"), "None, or precision tools.")]);
+
+        Assert.True(ruleset.UsesEquipment(new SkillId("Locksmith")));
+        Assert.Equal("None, or precision tools.", ruleset.TryGetLink(new SkillId("Locksmith"))!.PotentialEquipment);
+    }
+
+    [Fact]
+    public void An_unlisted_skill_is_the_expected_no_equipment_outcome_not_an_error()
+    {
+        // p.185-186: "If the skill is not listed, it does not require any equipment, or it is
+        // obvious (such as weapon skills)."
+        var ruleset = new SkillEquipmentRuleset(
+            [new SkillEquipmentLink(new SkillId("Locksmith"), "None, or precision tools.")]);
+
+        Assert.False(ruleset.UsesEquipment(new SkillId("Brawl")));
+        Assert.Null(ruleset.TryGetLink(new SkillId("Brawl")));
+    }
+
+    [Fact]
+    public void Lookup_is_case_insensitive_matching_the_skill_ids_convention()
+    {
+        var ruleset = new SkillEquipmentRuleset(
+            [new SkillEquipmentLink(new SkillId("Locksmith"), "None, or precision tools.")]);
+
+        Assert.True(ruleset.UsesEquipment(new SkillId("locksmith")));
+    }
+
+    [Fact]
+    public void Construction_requires_at_least_one_link()
+    {
+        Assert.Throws<ArgumentException>(() => new SkillEquipmentRuleset([]));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #228

## Exact behavioral claim

`Brp.Rules.Gear.EquipmentQuality.Modifier` produces the Ch 8 (p.185) Equipment
Quality Modifier (Inferior -20% / Average 0 / Superior +20%) as a
`AdditiveKind.Situational` `AdditiveModifier`, so it composes through the
existing `ModifierPipeline` (ADR 0007) exactly like every other situational
source — no parallel modifier path was added. `Brp.Rules.Gear.SkillEquipmentRuleset`
models the Ch 8 (pp.185-186) "Skills and Equipment" table as gear→skill data in
`Brp.Data`, and `EquipmentQuality.ModifierForSkill` gates the quality modifier
on a skill actually being in that mapping, coupling the two mechanics the way
the issue frames them ("does your gear help this skill roll?").

## Scope

Added:
- `src/Brp.Rules/Gear/EquipmentQualityTier.cs`, `EquipmentQualityRuleset.cs`, `EquipmentQuality.cs`
- `src/Brp.Rules/Gear/SkillEquipmentLink.cs`, `SkillEquipmentRuleset.cs`
- `src/Brp.Data/equipment-quality-ruleset.json` + `NoirEquipmentQualityRuleset.cs`
- `src/Brp.Data/skill-equipment-ruleset.json` + `NoirSkillEquipmentRuleset.cs`
- `docs/decisions/NNNN-equipment-quality-and-skills-and-equipment.md` (ADR, sourced/house-rule breakdown)
- Tests under `tests/Brp.Rules.Tests/Gear/` and `tests/Brp.Data.Tests/`

Deliberately did not change: character creation, inventory wiring, weapon/armor
definitions, or the combat modifier call sites — this issue is the general
primitive, matching ADR 0028's precedent for a comparable "general primitive"
issue. Nothing from sibling sub-issues #229-232 (wealth, item HP, vehicles,
drugs) was touched.

## Rules conformance

Ch 8: Equipment, "Equipment Quality Modifiers" (p.185) and "Skills and
Equipment" (pp.185-186), `BasicRoleplaying-ORC-Content-Document.pdf`. The
three-row Equipment Quality Modifiers table is reproduced in full via
`[Theory]`/`[InlineData]` in `EquipmentQualityTests.Reproduces_the_books_equipment_quality_table_page_185`.
The Skills-and-Equipment table is hand-picked per `orc-scope-filter.md` (Ch 8:
"hand-pick the entries a noir detective could plausibly encounter") to the 16
book rows with an engine skill equivalent; see the ADR for the "specialty
expansion" detail (5 of those rows name a specialty-only parent id that
`SkillRegistry` does not itself resolve, so the mapping records one link per
resolvable specialty instead).

## Tests and evidence

- `dotnet build` — Build succeeded, 0 warnings, 0 errors.
- `dotnet test` — all four suites green: Brp.Core.Tests 1557/1557,
  Brp.Rules.Tests 351/351, Brp.Data.Tests 348/348, Brp.Cli.Tests 51/51.
- `dotnet format --verify-no-changes` — exit 0, no diff.

## Decisions and tradeoffs

- `EquipmentQuality.ModifierForSkill`'s gate (throw if the skill isn't in the
  mapping) is an engineering choice, not a printed book rule — recorded as such
  in the ADR.
- The book's missing-equipment case (GM may rule Difficult/Impossible/no
  attempt/1% chance) is explicitly *not* automated — it's stated as gamemaster
  discretion with three different possible outcomes, so no single house rule
  was invented for it. Left for a caller to compose from existing
  `GateModifier`/`DifficultyModifier` primitives if a scene needs it.
- Five book rows (Art, Knowledge, Repair, Science, Technical Skill) name a
  skill only exposed through specialties in this engine; the mapping expands
  each to its resolvable specialty ids rather than inventing an unrollable
  parent id — see the ADR's "Specialty expansion" section for the reasoning.

## Known limitations

- `SkillEquipmentLink.PotentialEquipment` is reference-level free text, not a
  machine-checked link to specific `weapon-ruleset.json`/`armor-ruleset.json`
  entries — matching the book's own prose-level table.
- Missing-equipment penalties are not automated (see above); this is a
  deliberate scope boundary, not an oversight.

## Agent provenance

Implemented by Claude (Sonnet 5), Claude Code CLI, effort: engine-dev routing
per `AGENTS.md`.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-verification:start -->
### agent-verification — `success` for `ef2559c`

| gate | result | evidence |
|---|---|---|
| `ci` | pass | GitHub `build-and-test` @ this SHA |
| `scope-warden` | pass | bound — haiku, packet `6cfde35b5299` |
| `rules-conformance` | pass | bound — opus, packet `6cfde35b5299` |
| `codex-conformance` | pass | unbound (`--gate` assertion) |
| `architecture-review` | pass | bound — opus, packet `6cfde35b5299` |

_5/5 gates passed [route: formulas]. Regenerated per head SHA by `tools/agent-verify.sh`; semantic verdicts bound to head + review packet via `tools/gate-evidence.sh`._

> ⚠️ `--allow-unbound-gates` was used: one or more semantic verdicts were accepted without head/packet binding.
<!-- agent-verification:end -->