### PR TITLE
Ch 8 — Item SIZ / hit points for breaking doors, windows, locks

### DIFF
--- a/docs/decisions/0033-item-hit-points.md
+++ b/docs/decisions/0033-item-hit-points.md
@@ -1,4 +1,4 @@
-# NNNN. Item SIZ/hit points for breaking doors, windows, and locks
+# 0033. Item SIZ/hit points for breaking doors, windows, and locks
 
 ## Status
 

--- a/docs/decisions/NNNN-item-hit-points.md
+++ b/docs/decisions/NNNN-item-hit-points.md
@@ -1,0 +1,135 @@
+# NNNN. Item SIZ/hit points for breaking doors, windows, and locks
+
+## Status
+
+Accepted — 2026-09-01. Resolves #230. Sub-issue of #116 (Ch 8 world completeness).
+
+## Context
+
+`orc-scope-filter.md`, Ch 8, line 137 keeps "Item SIZ/hit points for breaking doors,
+windows, locks" in scope. Nothing in the engine resolved forcing or bashing through an
+inanimate object before this record: `Brp.Rules.Combat.DamageResolver` only applies
+damage to a character's `AbilitySet`, and no ruleset carried object SIZ/hit-point/armor
+data.
+
+The book's mechanic (Ch 8: Equipment, "General Qualities of Objects" and "Damage to
+Inanimate Objects", p.224) is deliberately close to, but not identical to, the existing
+character damage path:
+
+> "Your gamemaster should consult the SIZ values for sample items and use SIZ as an
+> object's hit points, assigning an armor value based on its equivalent... If the
+> damage exceeds the object's armor value, then the hit points are reduced by the
+> remaining damage and that many damage points reduce its armor value (representing
+> how much less it is able to withstand damage once damaged). If an object is smaller
+> than human-sized (such as a chair), it is totally destroyed if it is reduced to 0
+> hit points."
+
+"SIZ of Common Objects" (pp.225-226) prints sample SIZ ranges for a Door (4-8) and a
+Glass door (8) and Glass window (3); "Armor Value of Substances" (p.224) prints armor
+values for "1 cm of glass" (1) and "5 cm thick door" (3). Neither table prints a lock.
+
+## Decision
+
+**Reuse `DamageResolver.RollDamage` unchanged for the attack roll**, rather than a
+bespoke damage-rolling path. `DamageRoll.DamageDealt` is already "raw damage minus
+armor value, floored at zero" — the identical arithmetic p.224 describes as "the hit
+points are reduced by the remaining damage" once the object's current armor value is
+passed as `RollDamage`'s `armorValue` parameter. A caller rolls the attacker's weapon
+damage exactly as it would for a character (`LandedGrade.Normal`,
+`ArmorTreatment.Subtracted`, the object's current armor value in place of a defender's
+armor) and hands the resulting `DamageRoll` to the new
+`Brp.Rules.Combat.BreakableItemResolver.ApplyDamage`.
+
+**One new resolver method for the one genuinely different rule.** The only thing p.224
+adds beyond the existing character-damage arithmetic is armor degradation — "that many
+damage points reduce its armor value" — which characters never do (a character's armor
+value is fixed). `BreakableItemResolver.ApplyDamage(currentHitPoints, currentArmorValue,
+DamageRoll)` subtracts `DamageDealt` from both hit points and (floored at zero) the
+armor value, and classifies `BreakableItemCondition.Destroyed` at 0 or fewer hit
+points.
+
+**Stateless, caller-driven, like every other `Brp.Rules.Combat` resolver** (matching
+`FallingResolver`, `PoisonResolver`): `ApplyDamage` takes and returns plain
+hit-point/armor-value integers rather than introducing a new mutable "game object"
+domain type. There is no existing object-state abstraction to hang this off (unlike
+`AbilitySet`/`WoundTrack` for characters), and inventing one is out of scope for this
+issue — a caller (a future Layer 5 game/scene loop) threads the returned
+`ResultingHitPoints`/`ResultingArmorValue` into its own next call for a second hit.
+
+**Only the "smaller than or about human-sized, destroyed at 0 HP" branch is built.**
+p.224's other branch — an object larger than human-sized gets "a human-sized hole" in
+one segment reduced to 0 HP, leaving the rest of the object standing — does not apply
+to any item hand-picked here (a door, a glass door, a window, a lock are all
+human-sized or smaller) and is out of scope; `BreakableItemCondition` only has
+`Intact`/`Destroyed`.
+
+**Data lives in `item-hit-points-ruleset.json`**, loaded by
+`Brp.Data.NoirItemHitPointsRuleset.Load()` into a `Brp.Rules.Gear.BreakableItemRegistry`
+of `BreakableItemDefinition` (Id, Name, Siz, HitPoints, ArmorValue, Source) — mirroring
+the `WeaponDefinition`/`GearRegistry` Layer 4 pattern. Four hand-picked entries, per
+`orc-scope-filter.md`'s "hand-pick... not two hundred rows" instruction:
+
+| Id | Name | SIZ | HP | Armor | Source |
+|---|---|---|---|---|---|
+| `doorWoodInterior` | Door, Wood Interior | 6 | 6 | 3 | p.226 Door (4-8, midpoint), p.224 "5 cm thick door" |
+| `doorGlass` | Door, Glass | 8 | 8 | 1 | p.226 Glass door (8); armor extrapolated from p.224's glass entry |
+| `windowGlass` | Window, Glass | 3 | 3 | 1 | p.226 Glass window (3), p.224 "1 cm of glass" |
+| `lockPadlock` | Lock, Padlock | 1 | 1 | 6 | House hand-pick, no printed row (see below) |
+
+Every entry's hit points equal its SIZ, per p.225's printed guideline ("a simple
+guideline for destroying objects is that an average object has hit points roughly
+equivalent to its SIZ") — stored as an explicit ruleset-data field rather than derived
+in code, per AGENTS.md invariant 7.
+
+### Sourced or house rule
+
+- **Wood interior door, glass door, glass window**: SIZ and armor values are direct
+  quotes or a same-substance armor lookup (the door's 4-8 range is narrowed to its
+  midpoint, 6, per p.225's own "use judgment when assigning SIZ" instruction — not a
+  house mechanic, a printed invitation to pick within a printed range).
+- **Glass door's armor value**: the book prints Glass door's SIZ (8) but no armor value
+  specific to a door made of glass. Extrapolated from the "1 cm of glass" row (armor
+  value 1) rather than the wood-door row, since the object is glass, not wood — the
+  book explicitly sanctions this ("your gamemaster should be able to extrapolate
+  additional armor values or estimate them based on rough equivalencies", p.224).
+- **Padlock**: entirely a house hand-pick. The book's "SIZ of Common Objects" table
+  has no lock entry at all. SIZ 1 is read off the "Comparative Sizes" table (p.225: SIZ
+  1 spans 1-12 lb / 0.5-5.5 kg, which a padlock's weight fits) using that table's own
+  stated latitude ("This table is not precise or restrictive: you should use judgment
+  when assigning SIZ and weight based on the makeup of the item or creature"). Armor
+  value 6 is a bare judgment call for a solid steel shackle — well below "3 cm of steel
+  plate" (armor value 28, p.224) since a shackle is far thinner stock — under the same
+  p.224 extrapolation invitation quoted above. This is the one entry with no printed
+  anchor at all, flagged plainly rather than presented as a transcription.
+
+## Explicitly out of scope
+
+- **Forcing a stuck door open (STR vs. STR resistance roll)** — Ch 5: System,
+  "Resistance Rolls" (p.129) names "attempts to force open a stuck door or bend an iron
+  bar" as a STR-vs-STR example, but that contest is against the *door's* effective STR
+  (not modeled anywhere, printed or otherwise) and is a different mechanic from "Damage
+  to Inanimate Objects" (bashing through with a weapon). `orc-scope-filter.md` line 137
+  names only "Item SIZ/hit points for breaking doors, windows, locks" — the
+  damage/armor/HP mechanic this record builds. The generic `ResistanceResolver` already
+  exists and is unrelated engine work if a future issue wants the STR-vs-STR spot rule.
+- **Enforcing this against a live combat round or scene loop** — like every other
+  `Brp.Rules.Combat` resolver, `BreakableItemResolver.ApplyDamage` returns a structured
+  result; tracking an object's hit points/armor across multiple hits, narrating when it
+  gives way, and any Locksmith-skill-based (non-destructive) lockpicking path are all
+  caller/future-layer concerns.
+- **Larger-than-human-sized objects and the "segment hole" rule** (p.224) — out of
+  scope for this hand-picked door/window/lock set; see `BreakableItemCondition`.
+
+## Consequences
+
+- New `Brp.Rules.Gear` types: `BreakableItemId`, `BreakableItemDefinition`,
+  `BreakableItemRegistry`.
+- New `Brp.Rules.Combat` types: `BreakableItemResolver`, `BreakableItemDamageResult`,
+  `BreakableItemCondition`.
+- New ruleset, `item-hit-points-ruleset.json` / `Brp.Data.NoirItemHitPointsRuleset.Load()`.
+- `Brp.Data.Tests.NoirItemHitPointsRulesetTests` reproduces every hand-picked row cell
+  by cell; `Brp.Rules.Tests.Combat.BreakableItemResolverTests` covers the armor-vs-HP
+  arithmetic (including armor flooring at zero and destruction at 0 HP) and one
+  end-to-end test that rolls a real weapon's damage through
+  `DamageResolver.RollDamage` and applies it via `BreakableItemResolver.ApplyDamage`,
+  demonstrating the reused machinery.

--- a/docs/decisions/NNNN-item-hit-points.md
+++ b/docs/decisions/NNNN-item-hit-points.md
@@ -41,12 +41,73 @@ armor) and hands the resulting `DamageRoll` to the new
 `Brp.Rules.Combat.BreakableItemResolver.ApplyDamage`.
 
 **One new resolver method for the one genuinely different rule.** The only thing p.224
-adds beyond the existing character-damage arithmetic is armor degradation — "that many
-damage points reduce its armor value" — which characters never do (a character's armor
+adds beyond the existing character-damage arithmetic is armor degradation — armor
+wearing down as the object takes hits — which characters never do (a character's armor
 value is fixed). `BreakableItemResolver.ApplyDamage(currentHitPoints, currentArmorValue,
-DamageRoll)` subtracts `DamageDealt` from both hit points and (floored at zero) the
-armor value, and classifies `BreakableItemCondition.Destroyed` at 0 or fewer hit
-points.
+DamageRoll)` subtracts `DamageDealt` from hit points and reduces the armor value by 1
+per landed hit (see "Rules interpretation: armor degradation" below for why 1 per hit,
+not `DamageDealt` per hit), and classifies `BreakableItemCondition.Destroyed` at 0 or
+fewer hit points.
+
+### Rules interpretation: armor degradation
+
+Two passages on the same page point different ways for these specific items, and this
+is the committed reconciliation, recorded so a future conformance pass checks the
+recorded decision rather than re-litigating the raw text.
+
+**Passage A — "Damage to Inanimate Objects" (p.224), the general object rule:**
+
+> "If the damage exceeds the object's armor value, then the hit points are reduced by
+> the remaining damage and that many damage points reduce its armor value (representing
+> how much less it is able to withstand damage once damaged)."
+
+Read alone, Passage A supports degrading the armor value by the full penetrating
+damage (`DamageDealt`) on every hit that exceeds it.
+
+**Passage B — "Armor Value of Substances" (p.224-225), specific to the armor source
+every shipped item uses:**
+
+> "Natural armor values such as these above are not lost and do not deteriorate through
+> multiple attacks, unless through some environmental means or a specific attempt to
+> reduce the armor value of an object."
+>
+> "For example, your character bashes at a window made of bulletproof glass repeatedly
+> with a sledgehammer, aiming at the same spot in an attempt to cause enough cracking to
+> break through it. You[r] gamemaster decides to represent this by reducing the armor
+> value by 1 with each successful hit, and rolling damage. When the damage roll
+> overcomes the steadily reducing armor value, the window bursts."
+
+**Passage B governs, for every item this ruleset ships.** Every entry
+(`doorWoodInterior`, `doorGlass`, `windowGlass`, `lockPadlock`) draws its starting armor
+value from "Armor Value of Substances" (p.224), the exact table Passage B's own
+"natural armor values such as these above" refers to. Breaking through a door, window,
+or lock — this resolver's entire purpose — is precisely "a specific attempt to reduce
+the armor value of an object": Passage B's carve-out condition is met by construction,
+not by interpretation. Passage B is also the more specific of the two (it names the
+exact armor source this ruleset uses, where Passage A speaks of objects in general) and
+supplies the book's only worked example of the carve-out actually being exercised. Under
+ordinary interpretive practice, a more specific, example-backed passage governs over a
+more general one it directly qualifies.
+
+Passage A's hit-point arithmetic is unaffected by this reconciliation — Passage B says
+nothing about hit points, only armor. `DamageRoll.DamageDealt` ("raw damage minus armor
+value, floored at zero") still reduces hit points exactly as Passage A states; only the
+armor-value degradation step changes to "1 per landed hit" (Passage B's worked example)
+rather than "`DamageDealt` per landed hit" (Passage A's general phrasing).
+
+**Corollary:** the worked example degrades armor "with each successful hit" without
+qualifying it on whether that swing's damage penetrated — so `BreakableItemResolver`
+degrades armor by 1 for any landed (non-Miss) hit, Normal/Special/Critical alike, even
+one whose `DamageDealt` is 0 because the raw damage that swing rolled did not exceed the
+armor value in effect for it.
+
+**Correction (post-review, codex-conformance pass on PR #237):** the first
+implementation of this record read Passage A alone and degraded armor by the full
+`DamageDealt` per hit, without having read the "Armor Value of Substances" section's own
+non-deterioration clause and worked example a few paragraphs later on the same page.
+`BreakableItemResolver.ApplyDamage` and its tests were corrected to the "1 per landed
+hit" reading recorded above; this section and this correction note were added in the
+same pass.
 
 **Stateless, caller-driven, like every other `Brp.Rules.Combat` resolver** (matching
 `FallingResolver`, `PoisonResolver`): `ApplyDamage` takes and returns plain
@@ -128,8 +189,10 @@ in code, per AGENTS.md invariant 7.
   `BreakableItemCondition`.
 - New ruleset, `item-hit-points-ruleset.json` / `Brp.Data.NoirItemHitPointsRuleset.Load()`.
 - `Brp.Data.Tests.NoirItemHitPointsRulesetTests` reproduces every hand-picked row cell
-  by cell; `Brp.Rules.Tests.Combat.BreakableItemResolverTests` covers the armor-vs-HP
-  arithmetic (including armor flooring at zero and destruction at 0 HP) and one
-  end-to-end test that rolls a real weapon's damage through
-  `DamageResolver.RollDamage` and applies it via `BreakableItemResolver.ApplyDamage`,
-  demonstrating the reused machinery.
+  by cell; `Brp.Rules.Tests.Combat.BreakableItemResolverTests` covers the hit-point
+  arithmetic, the pinned "armor degrades by 1 per landed hit, not by `DamageDealt`"
+  behavior (including a large-penetrating-damage hit that still only costs 1 armor,
+  and a non-penetrating hit that still costs 1 armor) with its p.224-225 citation,
+  armor flooring at zero, destruction at 0 HP, and one end-to-end test that rolls a
+  real weapon's damage through `DamageResolver.RollDamage` and applies it via
+  `BreakableItemResolver.ApplyDamage`, demonstrating the reused machinery.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -55,4 +55,4 @@ supersedes it — the original is not edited or deleted.
 | [0030](0030-money-and-wealth-levels.md) | Money and Wealth levels: the modern-era Status table only, five ordinal levels, no economy sim | Accepted |
 | [0031](0031-equipment-quality-and-skills-and-equipment.md) | Equipment Quality Modifiers and the Skills-and-Equipment mapping | Accepted |
 | [0032](0032-vehicles-cars-only.md) | Vehicles — cars only: the hand-picked automobile subset and its armor semantics | Accepted |
-| [NNNN](NNNN-item-hit-points.md) | Item SIZ/hit points for breaking doors, windows, and locks | Accepted |
+| [0033](0033-item-hit-points.md) | Item SIZ/hit points for breaking doors, windows, and locks | Accepted |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -55,3 +55,4 @@ supersedes it — the original is not edited or deleted.
 | [0030](0030-money-and-wealth-levels.md) | Money and Wealth levels: the modern-era Status table only, five ordinal levels, no economy sim | Accepted |
 | [0031](0031-equipment-quality-and-skills-and-equipment.md) | Equipment Quality Modifiers and the Skills-and-Equipment mapping | Accepted |
 | [0032](0032-vehicles-cars-only.md) | Vehicles — cars only: the hand-picked automobile subset and its armor semantics | Accepted |
+| [NNNN](NNNN-item-hit-points.md) | Item SIZ/hit points for breaking doors, windows, and locks | Accepted |

--- a/src/Brp.Data/Brp.Data.csproj
+++ b/src/Brp.Data/Brp.Data.csproj
@@ -37,6 +37,7 @@
     <EmbeddedResource Include="wealth-ruleset.json" />
     <EmbeddedResource Include="equipment-quality-ruleset.json" />
     <EmbeddedResource Include="skill-equipment-ruleset.json" />
+    <EmbeddedResource Include="item-hit-points-ruleset.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Brp.Data/NoirItemHitPointsRuleset.cs
+++ b/src/Brp.Data/NoirItemHitPointsRuleset.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using Brp.Rules.Gear;
+
+namespace Brp.Data;
+
+/// <summary>
+/// Loads NoiRPG's Layer 4 breakable-item list (item SIZ/hit points for forcing doors, windows,
+/// and locks) from embedded JSON. Source: Ch 8: Equipment, "General Qualities of Objects",
+/// "Damage to Inanimate Objects", "Armor Value of Substances" (p.224), and "SIZ of Common
+/// Objects" (pp.225-226). Hand-picked to a small realistic noir subset per `orc-scope-filter.md`,
+/// Ch 8, line 137 -- see each entry's own <c>source</c> field in the ruleset JSON for the exact
+/// citation, and <c>docs/decisions/NNNN-item-hit-points.md</c> for the two entries the book
+/// prints no exact row for.
+/// </summary>
+public static class NoirItemHitPointsRuleset
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>Loads a new, immutable breakable-item registry from the shipped data.</summary>
+    public static BreakableItemRegistry Load()
+    {
+        var assembly = typeof(NoirItemHitPointsRuleset).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Brp.Data.item-hit-points-ruleset.json")
+            ?? throw new InvalidOperationException("The item hit points ruleset data resource is missing.");
+        var data = JsonSerializer.Deserialize<ItemHitPointsRulesetData>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("The item hit points ruleset data is empty.");
+
+        var items = data.Items.Select(ToDefinition).ToList();
+        return new BreakableItemRegistry(items);
+    }
+
+    private static BreakableItemDefinition ToDefinition(BreakableItemEntryData entry) => new(
+        Id: new BreakableItemId(entry.Id),
+        Name: entry.Name,
+        Siz: entry.Siz,
+        HitPoints: entry.HitPoints,
+        ArmorValue: entry.ArmorValue,
+        Source: entry.Source);
+
+    private sealed class ItemHitPointsRulesetData
+    {
+        public required List<BreakableItemEntryData> Items { get; init; }
+    }
+
+    private sealed class BreakableItemEntryData
+    {
+        public required string Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required int Siz { get; init; }
+
+        public required int HitPoints { get; init; }
+
+        public required int ArmorValue { get; init; }
+
+        public required string Source { get; init; }
+    }
+}

--- a/src/Brp.Data/NoirItemHitPointsRuleset.cs
+++ b/src/Brp.Data/NoirItemHitPointsRuleset.cs
@@ -9,7 +9,7 @@ namespace Brp.Data;
 /// "Damage to Inanimate Objects", "Armor Value of Substances" (p.224), and "SIZ of Common
 /// Objects" (pp.225-226). Hand-picked to a small realistic noir subset per `orc-scope-filter.md`,
 /// Ch 8, line 137 -- see each entry's own <c>source</c> field in the ruleset JSON for the exact
-/// citation, and <c>docs/decisions/NNNN-item-hit-points.md</c> for the two entries the book
+/// citation, and <c>docs/decisions/0033-item-hit-points.md</c> for the two entries the book
 /// prints no exact row for.
 /// </summary>
 public static class NoirItemHitPointsRuleset

--- a/src/Brp.Data/item-hit-points-ruleset.json
+++ b/src/Brp.Data/item-hit-points-ruleset.json
@@ -14,7 +14,7 @@
       "siz": 8,
       "hitPoints": 8,
       "armorValue": 1,
-      "source": "Ch 8: Equipment, \"SIZ of Common Objects\" (p.226): Glass door, Full/Segment SIZ 8. Armor value extrapolated from the '1 cm of glass' row of \"Armor Value of Substances\" (p.224, armor value 1) -- the book prints no separate glass-door armor row, and explicitly invites this: 'your gamemaster should be able to extrapolate additional armor values or estimate them based on rough equivalencies' (p.224). Hit points equal SIZ per p.225's guideline. House extrapolation for armor value only (see docs/decisions/NNNN-item-hit-points.md)."
+      "source": "Ch 8: Equipment, \"SIZ of Common Objects\" (p.226): Glass door, Full/Segment SIZ 8. Armor value extrapolated from the '1 cm of glass' row of \"Armor Value of Substances\" (p.224, armor value 1) -- the book prints no separate glass-door armor row, and explicitly invites this: 'your gamemaster should be able to extrapolate additional armor values or estimate them based on rough equivalencies' (p.224). Hit points equal SIZ per p.225's guideline. House extrapolation for armor value only (see docs/decisions/0033-item-hit-points.md)."
     },
     {
       "id": "windowGlass",
@@ -30,7 +30,7 @@
       "siz": 1,
       "hitPoints": 1,
       "armorValue": 6,
-      "source": "House hand-pick: the book prints no sample SIZ or armor value for a lock. SIZ 1 follows the \"Comparative Sizes\" table (p.225: SIZ 1 spans 1-12 lb / 0.5-5.5 kg, which fits a padlock) and the table's own invitation to judgment ('This table is not precise or restrictive: you should use judgment when assigning SIZ and weight based on the makeup of the item', p.225). Armor value 6 is a house judgment call for a solid steel shackle, well below '3 cm of steel plate' (armor value 28, p.224) since a padlock's shackle is far thinner, per the same extrapolation invitation on p.224. Hit points equal SIZ per p.225's guideline. Entirely a house extrapolation (see docs/decisions/NNNN-item-hit-points.md)."
+      "source": "House hand-pick: the book prints no sample SIZ or armor value for a lock. SIZ 1 follows the \"Comparative Sizes\" table (p.225: SIZ 1 spans 1-12 lb / 0.5-5.5 kg, which fits a padlock) and the table's own invitation to judgment ('This table is not precise or restrictive: you should use judgment when assigning SIZ and weight based on the makeup of the item', p.225). Armor value 6 is a house judgment call for a solid steel shackle, well below '3 cm of steel plate' (armor value 28, p.224) since a padlock's shackle is far thinner, per the same extrapolation invitation on p.224. Hit points equal SIZ per p.225's guideline. Entirely a house extrapolation (see docs/decisions/0033-item-hit-points.md)."
     }
   ]
 }

--- a/src/Brp.Data/item-hit-points-ruleset.json
+++ b/src/Brp.Data/item-hit-points-ruleset.json
@@ -1,0 +1,36 @@
+{
+  "items": [
+    {
+      "id": "doorWoodInterior",
+      "name": "Door, Wood Interior",
+      "siz": 6,
+      "hitPoints": 6,
+      "armorValue": 3,
+      "source": "Ch 8: Equipment, \"SIZ of Common Objects\" (p.226): Door, Full/Segment SIZ 4-8 (midpoint 6 used, per p.225's 'use judgment when assigning SIZ'). \"Armor Value of Substances\" (p.224): '5 cm thick door', armor value 3. Hit points equal SIZ per p.225: 'a simple guideline for destroying objects is that an average object has hit points roughly equivalent to its SIZ'."
+    },
+    {
+      "id": "doorGlass",
+      "name": "Door, Glass",
+      "siz": 8,
+      "hitPoints": 8,
+      "armorValue": 1,
+      "source": "Ch 8: Equipment, \"SIZ of Common Objects\" (p.226): Glass door, Full/Segment SIZ 8. Armor value extrapolated from the '1 cm of glass' row of \"Armor Value of Substances\" (p.224, armor value 1) -- the book prints no separate glass-door armor row, and explicitly invites this: 'your gamemaster should be able to extrapolate additional armor values or estimate them based on rough equivalencies' (p.224). Hit points equal SIZ per p.225's guideline. House extrapolation for armor value only (see docs/decisions/NNNN-item-hit-points.md)."
+    },
+    {
+      "id": "windowGlass",
+      "name": "Window, Glass",
+      "siz": 3,
+      "hitPoints": 3,
+      "armorValue": 1,
+      "source": "Ch 8: Equipment, \"SIZ of Common Objects\" (p.226): Glass window, Full/Segment SIZ 3. \"Armor Value of Substances\" (p.224): '1 cm of glass', armor value 1. Hit points equal SIZ per p.225's guideline."
+    },
+    {
+      "id": "lockPadlock",
+      "name": "Lock, Padlock",
+      "siz": 1,
+      "hitPoints": 1,
+      "armorValue": 6,
+      "source": "House hand-pick: the book prints no sample SIZ or armor value for a lock. SIZ 1 follows the \"Comparative Sizes\" table (p.225: SIZ 1 spans 1-12 lb / 0.5-5.5 kg, which fits a padlock) and the table's own invitation to judgment ('This table is not precise or restrictive: you should use judgment when assigning SIZ and weight based on the makeup of the item', p.225). Armor value 6 is a house judgment call for a solid steel shackle, well below '3 cm of steel plate' (armor value 28, p.224) since a padlock's shackle is far thinner, per the same extrapolation invitation on p.224. Hit points equal SIZ per p.225's guideline. Entirely a house extrapolation (see docs/decisions/NNNN-item-hit-points.md)."
+    }
+  ]
+}

--- a/src/Brp.Rules/Combat/BreakableItemCondition.cs
+++ b/src/Brp.Rules/Combat/BreakableItemCondition.cs
@@ -1,0 +1,19 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// An inanimate object's condition after a <see cref="BreakableItemResolver.ApplyDamage"/> call.
+/// Ch 8: Equipment, "Damage to Inanimate Objects" (p.224): "If an object is smaller than
+/// human-sized (such as a chair), it is totally destroyed if it is reduced to 0 hit points."
+/// Every item hand-picked into <c>item-hit-points-ruleset.json</c> (doors, windows, locks) is
+/// human-sized or smaller, so only this branch of the printed rule applies -- the "larger than
+/// human-sized, human-sized hole punched through a segment" branch is out of scope for this set
+/// (see <c>docs/decisions/NNNN-item-hit-points.md</c>).
+/// </summary>
+public enum BreakableItemCondition
+{
+    /// <summary>Above 0 hit points -- the object still functions (a door still bars the way, etc.).</summary>
+    Intact,
+
+    /// <summary>At or below 0 hit points -- the object is destroyed (p.224).</summary>
+    Destroyed,
+}

--- a/src/Brp.Rules/Combat/BreakableItemCondition.cs
+++ b/src/Brp.Rules/Combat/BreakableItemCondition.cs
@@ -7,7 +7,7 @@ namespace Brp.Rules.Combat;
 /// Every item hand-picked into <c>item-hit-points-ruleset.json</c> (doors, windows, locks) is
 /// human-sized or smaller, so only this branch of the printed rule applies -- the "larger than
 /// human-sized, human-sized hole punched through a segment" branch is out of scope for this set
-/// (see <c>docs/decisions/NNNN-item-hit-points.md</c>).
+/// (see <c>docs/decisions/0033-item-hit-points.md</c>).
 /// </summary>
 public enum BreakableItemCondition
 {

--- a/src/Brp.Rules/Combat/BreakableItemDamageResult.cs
+++ b/src/Brp.Rules/Combat/BreakableItemDamageResult.cs
@@ -1,0 +1,18 @@
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// The result of applying one landed hit's damage to an inanimate object --
+/// <see cref="BreakableItemResolver.ApplyDamage"/>'s output.
+/// </summary>
+/// <param name="DamageDealt">The hit points actually removed (0 for a Miss).</param>
+/// <param name="ResultingHitPoints">The object's hit points after the change; may be negative.</param>
+/// <param name="ResultingArmorValue">
+/// The object's armor value after the change, per Ch 8, p.224: "that many damage points reduce
+/// its armor value" -- floored at zero, never negative.
+/// </param>
+/// <param name="Condition">The object's condition <see cref="ResultingHitPoints"/> puts it in.</param>
+public sealed record BreakableItemDamageResult(
+    int DamageDealt,
+    int ResultingHitPoints,
+    int ResultingArmorValue,
+    BreakableItemCondition Condition);

--- a/src/Brp.Rules/Combat/BreakableItemDamageResult.cs
+++ b/src/Brp.Rules/Combat/BreakableItemDamageResult.cs
@@ -7,8 +7,11 @@ namespace Brp.Rules.Combat;
 /// <param name="DamageDealt">The hit points actually removed (0 for a Miss).</param>
 /// <param name="ResultingHitPoints">The object's hit points after the change; may be negative.</param>
 /// <param name="ResultingArmorValue">
-/// The object's armor value after the change, per Ch 8, p.224: "that many damage points reduce
-/// its armor value" -- floored at zero, never negative.
+/// The object's armor value after the change: reduced by exactly 1 for any landed (non-Miss) hit,
+/// per the substance-armor worked example (Ch 8, p.225: "reducing the armor value by 1 with each
+/// successful hit") -- not by <see cref="DamageDealt"/>; floored at zero, never negative. See
+/// <see cref="BreakableItemResolver"/>'s remarks for the full reconciliation against p.224's more
+/// general (but less specific, for these substance-armored items) phrasing.
 /// </param>
 /// <param name="Condition">The object's condition <see cref="ResultingHitPoints"/> puts it in.</param>
 public sealed record BreakableItemDamageResult(

--- a/src/Brp.Rules/Combat/BreakableItemResolver.cs
+++ b/src/Brp.Rules/Combat/BreakableItemResolver.cs
@@ -1,0 +1,67 @@
+using Brp.Rules.Gear;
+
+namespace Brp.Rules.Combat;
+
+/// <summary>
+/// Applies a landed hit's damage to an inanimate object's remaining hit points and armor value,
+/// per Ch 8: Equipment, "Damage to Inanimate Objects" (p.224): "assigning an armor value based on
+/// its equivalent... If the damage exceeds the object's armor value, then the hit points are
+/// reduced by the remaining damage and that many damage points reduce its armor value
+/// (representing how much less it is able to withstand damage once damaged)." This is the item
+/// SIZ/hit-points breaking rule (#230), sourced to "General Qualities of Objects" and "Damage to
+/// Inanimate Objects" (p.224), "Armor Value of Substances" (p.224), and "SIZ of Common Objects"
+/// (pp.225-226) -- see <see cref="BreakableItemDefinition"/> and
+/// <c>docs/decisions/NNNN-item-hit-points.md</c> for the per-item sourcing.
+/// <para>
+/// <strong>Deliberately reuses <see cref="DamageResolver.RollDamage"/> unchanged</strong> for the
+/// attack roll itself and its armor-subtraction arithmetic (<see cref="DamageRoll.DamageDealt"/>
+/// is already "raw damage minus armor value, floored at zero" -- exactly p.224's "the hit points
+/// are reduced by the remaining damage"): there is no bespoke damage-rolling path for items, only
+/// this extra armor-degradation step the book adds for objects but withholds for characters (a
+/// character's armor never wears down; an object's does). A caller rolls the attacking weapon's
+/// damage with <c>DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted,
+/// weapon, damageBonus, currentArmorValue, damageRuleset, entropy)</c> and passes the resulting
+/// <see cref="DamageRoll"/> here.
+/// </para>
+/// <para>
+/// Only objects smaller than or about human-sized are handled -- every item hand-picked into
+/// <c>item-hit-points-ruleset.json</c> (doors, windows, locks). The "larger than human-sized, a
+/// human-sized hole punched through one segment" branch of p.224 does not apply to this set and
+/// is out of scope; see <see cref="BreakableItemCondition"/>.
+/// </para>
+/// </summary>
+public static class BreakableItemResolver
+{
+    /// <summary>
+    /// Applies <paramref name="damage"/> -- already rolled against <paramref name="currentArmorValue"/>
+    /// via <see cref="DamageResolver.RollDamage"/> -- to an object with
+    /// <paramref name="currentHitPoints"/> hit points and <paramref name="currentArmorValue"/>
+    /// armor. <see cref="DamageRoll.DamageDealt"/> reduces both hit points and (by the same
+    /// amount) the armor value itself (p.224); a Miss changes nothing.
+    /// </summary>
+    /// <param name="currentHitPoints">The object's hit points before this hit.</param>
+    /// <param name="currentArmorValue">
+    /// The object's armor value before this hit -- must be the same value <paramref name="damage"/>
+    /// was rolled against.
+    /// </param>
+    /// <param name="damage">The already-rolled damage for this hit.</param>
+    public static BreakableItemDamageResult ApplyDamage(int currentHitPoints, int currentArmorValue, DamageRoll damage)
+    {
+        ArgumentNullException.ThrowIfNull(damage);
+        ArgumentOutOfRangeException.ThrowIfNegative(currentArmorValue);
+
+        if (damage.LandedGrade == LandedGrade.Miss)
+        {
+            return new BreakableItemDamageResult(
+                0, currentHitPoints, currentArmorValue, ClassifyCondition(currentHitPoints));
+        }
+
+        var resultingHitPoints = currentHitPoints - damage.DamageDealt;
+        var resultingArmorValue = Math.Max(0, currentArmorValue - damage.DamageDealt);
+        return new BreakableItemDamageResult(
+            damage.DamageDealt, resultingHitPoints, resultingArmorValue, ClassifyCondition(resultingHitPoints));
+    }
+
+    private static BreakableItemCondition ClassifyCondition(int hitPoints) =>
+        hitPoints <= 0 ? BreakableItemCondition.Destroyed : BreakableItemCondition.Intact;
+}

--- a/src/Brp.Rules/Combat/BreakableItemResolver.cs
+++ b/src/Brp.Rules/Combat/BreakableItemResolver.cs
@@ -3,25 +3,40 @@ using Brp.Rules.Gear;
 namespace Brp.Rules.Combat;
 
 /// <summary>
-/// Applies a landed hit's damage to an inanimate object's remaining hit points and armor value,
-/// per Ch 8: Equipment, "Damage to Inanimate Objects" (p.224): "assigning an armor value based on
-/// its equivalent... If the damage exceeds the object's armor value, then the hit points are
-/// reduced by the remaining damage and that many damage points reduce its armor value
-/// (representing how much less it is able to withstand damage once damaged)." This is the item
-/// SIZ/hit-points breaking rule (#230), sourced to "General Qualities of Objects" and "Damage to
-/// Inanimate Objects" (p.224), "Armor Value of Substances" (p.224), and "SIZ of Common Objects"
-/// (pp.225-226) -- see <see cref="BreakableItemDefinition"/> and
-/// <c>docs/decisions/NNNN-item-hit-points.md</c> for the per-item sourcing.
+/// Applies a landed hit's damage to an inanimate object's remaining hit points and armor value.
+/// This is the item SIZ/hit-points breaking rule (#230), sourced to "General Qualities of
+/// Objects", "Damage to Inanimate Objects", and "Armor Value of Substances" (all p.224), and
+/// "SIZ of Common Objects" (pp.225-226) -- see <see cref="BreakableItemDefinition"/> and
+/// <c>docs/decisions/NNNN-item-hit-points.md</c> for the per-item sourcing and the full
+/// rules-interpretation record this summary follows.
 /// <para>
-/// <strong>Deliberately reuses <see cref="DamageResolver.RollDamage"/> unchanged</strong> for the
-/// attack roll itself and its armor-subtraction arithmetic (<see cref="DamageRoll.DamageDealt"/>
-/// is already "raw damage minus armor value, floored at zero" -- exactly p.224's "the hit points
-/// are reduced by the remaining damage"): there is no bespoke damage-rolling path for items, only
-/// this extra armor-degradation step the book adds for objects but withholds for characters (a
-/// character's armor never wears down; an object's does). A caller rolls the attacking weapon's
-/// damage with <c>DamageResolver.RollDamage(LandedGrade.Normal, ArmorTreatment.Subtracted,
-/// weapon, damageBonus, currentArmorValue, damageRuleset, entropy)</c> and passes the resulting
-/// <see cref="DamageRoll"/> here.
+/// <strong>Hit points</strong> follow "Damage to Inanimate Objects" (p.224) unchanged: "If the
+/// damage exceeds the object's armor value, then the hit points are reduced by the remaining
+/// damage" -- <see cref="DamageRoll.DamageDealt"/> already <em>is</em> that "remaining damage"
+/// (raw damage minus armor value, floored at zero), computed by the reused, unmodified
+/// <see cref="DamageResolver.RollDamage"/>. There is no bespoke damage-rolling path for items.
+/// </para>
+/// <para>
+/// <strong>Armor degrades by exactly 1 per landed hit, not by the penetrating damage.</strong>
+/// "Damage to Inanimate Objects" (p.224) says damage that gets through "reduce[s] its armor
+/// value" by the same amount, but every item this ruleset ships (a door, a glass door, a glass
+/// window, a padlock) draws its starting armor from "Armor Value of Substances" (p.224), and
+/// that section's very next paragraph is more specific and directly contradicts a per-damage
+/// degradation for exactly this kind of armor: "Natural armor values such as these above are not
+/// lost and do not deteriorate through multiple attacks, unless through... a specific attempt to
+/// reduce the armor value of an object" (p.224-225) -- and the book's only worked example of such
+/// a deliberate attempt (repeatedly bashing bulletproof glass with a sledgehammer, p.225) reduces
+/// the armor value "by 1 with each successful hit," not by the damage that got through that
+/// particular swing. Deliberately breaking through a door, window, or lock -- this resolver's
+/// entire purpose -- <em>is</em> that "specific attempt", so the more specific substance-armor
+/// rule and its worked example govern over the general object rule's phrasing for every item this
+/// ruleset ships. See <c>docs/decisions/NNNN-item-hit-points.md</c>'s "Rules interpretation:
+/// armor degradation" block for the full quoted reconciliation.
+/// </para>
+/// <para>
+/// A caller rolls the attacking weapon's damage with <c>DamageResolver.RollDamage(LandedGrade.Normal,
+/// ArmorTreatment.Subtracted, weapon, damageBonus, currentArmorValue, damageRuleset, entropy)</c>
+/// and passes the resulting <see cref="DamageRoll"/> here.
 /// </para>
 /// <para>
 /// Only objects smaller than or about human-sized are handled -- every item hand-picked into
@@ -36,8 +51,11 @@ public static class BreakableItemResolver
     /// Applies <paramref name="damage"/> -- already rolled against <paramref name="currentArmorValue"/>
     /// via <see cref="DamageResolver.RollDamage"/> -- to an object with
     /// <paramref name="currentHitPoints"/> hit points and <paramref name="currentArmorValue"/>
-    /// armor. <see cref="DamageRoll.DamageDealt"/> reduces both hit points and (by the same
-    /// amount) the armor value itself (p.224); a Miss changes nothing.
+    /// armor. <see cref="DamageRoll.DamageDealt"/> reduces hit points (p.224's "reduced by the
+    /// remaining damage"); a landed hit -- Normal, Special, or Critical, regardless of how much
+    /// damage got through that swing -- reduces the armor value by exactly 1, per the substance-
+    /// armor worked example (p.225: "reducing the armor value by 1 with each successful hit"). A
+    /// Miss changes nothing.
     /// </summary>
     /// <param name="currentHitPoints">The object's hit points before this hit.</param>
     /// <param name="currentArmorValue">
@@ -57,7 +75,13 @@ public static class BreakableItemResolver
         }
 
         var resultingHitPoints = currentHitPoints - damage.DamageDealt;
-        var resultingArmorValue = Math.Max(0, currentArmorValue - damage.DamageDealt);
+
+        // Ch 8, p.224-225: substance armor "is not lost and does not deteriorate through multiple
+        // attacks" except by "a specific attempt to reduce the armor value" -- breaking a door,
+        // window, or lock is that attempt. The worked example reduces the armor value by 1 per
+        // successful (landed) hit, independent of how much damage that swing actually dealt.
+        var resultingArmorValue = Math.Max(0, currentArmorValue - 1);
+
         return new BreakableItemDamageResult(
             damage.DamageDealt, resultingHitPoints, resultingArmorValue, ClassifyCondition(resultingHitPoints));
     }

--- a/src/Brp.Rules/Combat/BreakableItemResolver.cs
+++ b/src/Brp.Rules/Combat/BreakableItemResolver.cs
@@ -7,7 +7,7 @@ namespace Brp.Rules.Combat;
 /// This is the item SIZ/hit-points breaking rule (#230), sourced to "General Qualities of
 /// Objects", "Damage to Inanimate Objects", and "Armor Value of Substances" (all p.224), and
 /// "SIZ of Common Objects" (pp.225-226) -- see <see cref="BreakableItemDefinition"/> and
-/// <c>docs/decisions/NNNN-item-hit-points.md</c> for the per-item sourcing and the full
+/// <c>docs/decisions/0033-item-hit-points.md</c> for the per-item sourcing and the full
 /// rules-interpretation record this summary follows.
 /// <para>
 /// <strong>Hit points</strong> follow "Damage to Inanimate Objects" (p.224) unchanged: "If the
@@ -30,7 +30,7 @@ namespace Brp.Rules.Combat;
 /// particular swing. Deliberately breaking through a door, window, or lock -- this resolver's
 /// entire purpose -- <em>is</em> that "specific attempt", so the more specific substance-armor
 /// rule and its worked example govern over the general object rule's phrasing for every item this
-/// ruleset ships. See <c>docs/decisions/NNNN-item-hit-points.md</c>'s "Rules interpretation:
+/// ruleset ships. See <c>docs/decisions/0033-item-hit-points.md</c>'s "Rules interpretation:
 /// armor degradation" block for the full quoted reconciliation.
 /// </para>
 /// <para>

--- a/src/Brp.Rules/Gear/BreakableItemDefinition.cs
+++ b/src/Brp.Rules/Gear/BreakableItemDefinition.cs
@@ -27,9 +27,12 @@ namespace Brp.Rules.Gear;
 /// <param name="ArmorValue">
 /// The object's starting armor value, from the "Armor Value of Substances" table (p.224) for the
 /// material the object is made of, or a house extrapolation where the book prints no matching
-/// substance -- see <see cref="Source"/>. Degrades as the object takes damage (p.224: "that many
-/// damage points reduce its armor value") -- <see cref="Combat.BreakableItemResolver"/> applies
-/// that degradation; this is only the starting value.
+/// substance -- see <see cref="Source"/>. Degrades by exactly 1 for each landed hit as the object
+/// is deliberately broken through (p.224-225's substance-armor worked example: "reducing the
+/// armor value by 1 with each successful hit," not by that hit's penetrating damage --
+/// <c>docs/decisions/0033-item-hit-points.md</c>'s "Rules interpretation: armor degradation")
+/// -- <see cref="Combat.BreakableItemResolver"/> applies that degradation; this is only the
+/// starting value.
 /// </param>
 /// <param name="Source">The book table (and any house-extrapolation note) this entry was drawn from.</param>
 public sealed record BreakableItemDefinition(

--- a/src/Brp.Rules/Gear/BreakableItemDefinition.cs
+++ b/src/Brp.Rules/Gear/BreakableItemDefinition.cs
@@ -6,7 +6,7 @@ namespace Brp.Rules.Gear;
 /// Qualities of Objects" and "Damage to Inanimate Objects" (p.224), "Armor Value of Substances"
 /// (p.224), and "SIZ of Common Objects" (pp.225-226). Hand-picked per `orc-scope-filter.md`, Ch 8,
 /// line 137 ("Item SIZ/hit points for breaking doors, windows, locks"). See
-/// <c>docs/decisions/NNNN-item-hit-points.md</c> for the per-entry sourcing, including the two
+/// <c>docs/decisions/0033-item-hit-points.md</c> for the per-entry sourcing, including the two
 /// entries the book prints no exact row for (the glass door's armor value and the padlock
 /// entirely), each marked as a house extrapolation there and in this entry's own
 /// <see cref="Source"/> field.

--- a/src/Brp.Rules/Gear/BreakableItemDefinition.cs
+++ b/src/Brp.Rules/Gear/BreakableItemDefinition.cs
@@ -1,0 +1,41 @@
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// The SIZ, hit points, and armor value of a hand-picked inanimate object a noir detective might
+/// need to force or bash through -- a door, a window, a lock. Sourced: Ch 8: Equipment, "General
+/// Qualities of Objects" and "Damage to Inanimate Objects" (p.224), "Armor Value of Substances"
+/// (p.224), and "SIZ of Common Objects" (pp.225-226). Hand-picked per `orc-scope-filter.md`, Ch 8,
+/// line 137 ("Item SIZ/hit points for breaking doors, windows, locks"). See
+/// <c>docs/decisions/NNNN-item-hit-points.md</c> for the per-entry sourcing, including the two
+/// entries the book prints no exact row for (the glass door's armor value and the padlock
+/// entirely), each marked as a house extrapolation there and in this entry's own
+/// <see cref="Source"/> field.
+/// </summary>
+/// <param name="Id">The stable ruleset identifier.</param>
+/// <param name="Name">The display name.</param>
+/// <param name="Siz">
+/// The object's SIZ, per the book's "SIZ of Common Objects" table (pp.225-226) or, where the book
+/// prints no entry, the "Comparative Sizes" table (p.225) used to estimate one.
+/// </param>
+/// <param name="HitPoints">
+/// The object's hit points. Ch 8, p.225: "a simple guideline for destroying objects is that an
+/// average object has hit points roughly equivalent to its SIZ" -- every hand-picked entry here
+/// follows that guideline, so this value always equals <see cref="Siz"/>, but is stored
+/// separately (rather than derived) because it is the ruleset-data value AGENTS.md invariant 7
+/// requires, not a hardcoded computation.
+/// </param>
+/// <param name="ArmorValue">
+/// The object's starting armor value, from the "Armor Value of Substances" table (p.224) for the
+/// material the object is made of, or a house extrapolation where the book prints no matching
+/// substance -- see <see cref="Source"/>. Degrades as the object takes damage (p.224: "that many
+/// damage points reduce its armor value") -- <see cref="Combat.BreakableItemResolver"/> applies
+/// that degradation; this is only the starting value.
+/// </param>
+/// <param name="Source">The book table (and any house-extrapolation note) this entry was drawn from.</param>
+public sealed record BreakableItemDefinition(
+    BreakableItemId Id,
+    string Name,
+    int Siz,
+    int HitPoints,
+    int ArmorValue,
+    string Source);

--- a/src/Brp.Rules/Gear/BreakableItemId.cs
+++ b/src/Brp.Rules/Gear/BreakableItemId.cs
@@ -1,0 +1,26 @@
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// A stable identifier for a <see cref="BreakableItemDefinition"/>. Mirrors the identifier
+/// pattern used for <see cref="WeaponId"/> and <see cref="ArmorId"/>: a thin wrapper over a
+/// ruleset-supplied string.
+/// </summary>
+public readonly record struct BreakableItemId
+{
+    /// <summary>Creates an identifier from its ruleset id.</summary>
+    public BreakableItemId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Breakable item id must not be empty.", nameof(value));
+        }
+
+        Value = value;
+    }
+
+    /// <summary>The stable ruleset identifier.</summary>
+    public string Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}

--- a/src/Brp.Rules/Gear/BreakableItemRegistry.cs
+++ b/src/Brp.Rules/Gear/BreakableItemRegistry.cs
@@ -1,0 +1,31 @@
+namespace Brp.Rules.Gear;
+
+/// <summary>
+/// The set of defined breakable items for a ruleset, keyed by their stable ids. Loaded from data
+/// by <c>Brp.Data.NoirItemHitPointsRuleset.Load()</c> -- mirrors <see cref="GearRegistry"/>, the
+/// Layer 4 pattern this issue follows.
+/// </summary>
+public sealed class BreakableItemRegistry
+{
+    private readonly Dictionary<BreakableItemId, BreakableItemDefinition> _items;
+
+    /// <summary>Creates a registry from a data-defined item list.</summary>
+    public BreakableItemRegistry(IEnumerable<BreakableItemDefinition> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        _items = items.ToDictionary(item => item.Id);
+        if (_items.Count == 0)
+        {
+            throw new ArgumentException("At least one breakable item definition is required.", nameof(items));
+        }
+    }
+
+    /// <summary>Every defined breakable item, by id.</summary>
+    public IReadOnlyDictionary<BreakableItemId, BreakableItemDefinition> Items => _items;
+
+    /// <summary>Looks up a breakable item by id, throwing if it is not defined.</summary>
+    public BreakableItemDefinition ById(BreakableItemId id) => _items.TryGetValue(id, out var definition)
+        ? definition
+        : throw new KeyNotFoundException($"Unknown breakable item '{id}'.");
+}

--- a/tests/Brp.Data.Tests/NoirItemHitPointsRulesetTests.cs
+++ b/tests/Brp.Data.Tests/NoirItemHitPointsRulesetTests.cs
@@ -1,0 +1,57 @@
+using Brp.Rules.Gear;
+
+namespace Brp.Data.Tests;
+
+/// <summary>
+/// Reproduces the hand-picked SIZ/hit-points/armor-value stats for every breakable item (Ch 8:
+/// Equipment, "SIZ of Common Objects" pp.225-226, "Armor Value of Substances" p.224), cell by
+/// cell, so a transcription error surfaces as a failing row.
+/// </summary>
+public class NoirItemHitPointsRulesetTests
+{
+    public static TheoryData<string, string, int, int, int> Items => new()
+    {
+        // id, name, siz, hitPoints, armorValue
+        { "doorWoodInterior", "Door, Wood Interior", 6, 6, 3 },
+        { "doorGlass", "Door, Glass", 8, 8, 1 },
+        { "windowGlass", "Window, Glass", 3, 3, 1 },
+        { "lockPadlock", "Lock, Padlock", 1, 1, 6 },
+    };
+
+    [Theory]
+    [MemberData(nameof(Items))]
+    public void Every_breakable_item_reproduces_its_hand_picked_stats(
+        string id, string name, int siz, int hitPoints, int armorValue)
+    {
+        var registry = NoirItemHitPointsRuleset.Load();
+
+        var item = registry.ById(new BreakableItemId(id));
+
+        Assert.Equal(name, item.Name);
+        Assert.Equal(siz, item.Siz);
+        Assert.Equal(hitPoints, item.HitPoints);
+        Assert.Equal(armorValue, item.ArmorValue);
+        Assert.False(string.IsNullOrWhiteSpace(item.Source));
+    }
+
+    [Fact]
+    public void Every_item_has_hit_points_equal_to_siz_per_the_printed_guideline_page_225()
+    {
+        var registry = NoirItemHitPointsRuleset.Load();
+
+        foreach (var item in registry.Items.Values)
+        {
+            Assert.Equal(item.Siz, item.HitPoints);
+        }
+    }
+
+    [Fact]
+    public void The_table_covers_every_shipped_item_exactly_once()
+    {
+        var registry = NoirItemHitPointsRuleset.Load();
+        var allIds = registry.Items.Keys.Select(id => id.Value).OrderBy(id => id, StringComparer.Ordinal).ToList();
+        var coveredIds = Items.Select(row => (string)row[0]!).OrderBy(id => id, StringComparer.Ordinal).ToList();
+
+        Assert.Equal(allIds, coveredIds);
+    }
+}

--- a/tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs
@@ -82,31 +82,45 @@ public class BreakableItemResolverTests
     }
 
     [Fact]
-    public void Repeated_hits_steadily_reduce_armor_until_damage_overcomes_it_page_225()
+    public void Absorbed_hits_still_wear_the_armor_down_by_one_each_page_225()
     {
-        // Mirrors the book's own worked example shape: repeated hits at a fixed raw damage (6)
-        // against a substance armor (3) -- the first two hits are fully absorbed (armor still
-        // ahead of the raw damage), but each hit still wears the armor down by 1 until, on the
-        // fourth hit, the steadily reducing armor value is finally overcome.
+        // Mirrors the book's own worked example shape (p.225): a wood interior door (SIZ 6,
+        // armor 3 -- item-hit-points-ruleset.json's doorWoodInterior) takes two swings of a
+        // constant raw 2 damage. Raw damage never exceeds the armor value in effect for either
+        // swing, so DamageDealt is honestly 0 both times (Max(0, raw - armor)) -- but each landed
+        // hit still wears the armor down by 1, exactly as the sledgehammer-vs-bulletproof-glass
+        // example describes.
+        var hitPoints = 6;
         var armor = 3;
-        var hitPoints = 3; // Glass window, SIZ 3 -- item-hit-points-ruleset.json
 
-        for (var hitsSoFar = 1; hitsSoFar <= 3; hitsSoFar++)
-        {
-            var stillAbsorbed = MakeDamageRoll(LandedGrade.Normal, damageDealt: 0);
-            var step = BreakableItemResolver.ApplyDamage(hitPoints, armor, stillAbsorbed);
-            armor = step.ResultingArmorValue;
-            hitPoints = step.ResultingHitPoints;
-        }
+        var first = BreakableItemResolver.ApplyDamage(hitPoints, armor, MakeDamageRoll(LandedGrade.Normal, damageDealt: 0));
+        Assert.Equal(0, first.DamageDealt); // raw 2 vs armor 3: fully absorbed
+        Assert.Equal(6, first.ResultingHitPoints);
+        Assert.Equal(2, first.ResultingArmorValue);
+        hitPoints = first.ResultingHitPoints;
+        armor = first.ResultingArmorValue;
 
-        Assert.Equal(0, armor); // 3 - 1 - 1 - 1
-        Assert.Equal(3, hitPoints); // never dealt, since every rolled DamageDealt above was 0
+        var second = BreakableItemResolver.ApplyDamage(hitPoints, armor, MakeDamageRoll(LandedGrade.Normal, damageDealt: 0));
+        Assert.Equal(0, second.DamageDealt); // raw 2 vs armor 2: still fully absorbed
+        Assert.Equal(6, second.ResultingHitPoints);
+        Assert.Equal(1, second.ResultingArmorValue);
+    }
 
-        var overcomes = MakeDamageRoll(LandedGrade.Normal, damageDealt: 6); // now unmitigated by 0 armor
-        var final = BreakableItemResolver.ApplyDamage(hitPoints, armor, overcomes);
+    [Fact]
+    public void A_hit_that_finally_overcomes_the_reduced_armor_deals_damage_and_can_destroy_the_object_page_225()
+    {
+        // Continuing the same door: two prior swings (Absorbed_hits_still_wear_the_armor_down_by_
+        // one_each_page_225) have already worn its armor from 3 down to 1. A third, harder swing
+        // (raw damage 8) now exceeds that reduced armor value -- DamageDealt = Max(0, 8 - 1) = 7,
+        // matching the book's "when the damage roll overcomes the steadily reducing armor value,
+        // the window bursts" (p.225). A near-dead door (2 HP left) is destroyed by it.
+        var result = BreakableItemResolver.ApplyDamage(
+            currentHitPoints: 2, currentArmorValue: 1, MakeDamageRoll(LandedGrade.Normal, damageDealt: 7));
 
-        Assert.Equal(-3, final.ResultingHitPoints);
-        Assert.Equal(BreakableItemCondition.Destroyed, final.Condition);
+        Assert.Equal(7, result.DamageDealt);
+        Assert.Equal(-5, result.ResultingHitPoints);
+        Assert.Equal(0, result.ResultingArmorValue);
+        Assert.Equal(BreakableItemCondition.Destroyed, result.Condition);
     }
 
     [Fact]

--- a/tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs
@@ -10,7 +10,7 @@ namespace Brp.Rules.Tests.Combat;
 /// destroyed at 0 hit points. "Armor Value of Substances" (p.224-225): for every item this
 /// ruleset ships, the armor value degrades by exactly 1 per landed hit (the worked bulletproof-
 /// glass example), not by the penetrating damage that hit dealt -- see
-/// <c>docs/decisions/NNNN-item-hit-points.md</c>'s "Rules interpretation: armor degradation"
+/// <c>docs/decisions/0033-item-hit-points.md</c>'s "Rules interpretation: armor degradation"
 /// block for the full reconciliation of these two passages.
 /// </summary>
 public class BreakableItemResolverTests

--- a/tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs
@@ -1,0 +1,122 @@
+using Brp.Data;
+using Brp.Rules.Combat;
+using Brp.Rules.Gear;
+
+namespace Brp.Rules.Tests.Combat;
+
+/// <summary>
+/// Ch 8: Equipment, "Damage to Inanimate Objects" (p.224): damage exceeding an object's armor
+/// value reduces its hit points by the remainder and its armor value by the same amount; an
+/// object smaller than or about human-sized is destroyed at 0 hit points. See
+/// <c>docs/decisions/NNNN-item-hit-points.md</c>.
+/// </summary>
+public class BreakableItemResolverTests
+{
+    [Fact]
+    public void Damage_at_or_below_the_armor_value_deals_no_hit_point_or_armor_loss_page_224()
+    {
+        var damage = MakeDamageRoll(damageDealt: 0);
+
+        var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 3, damage);
+
+        Assert.Equal(0, result.DamageDealt);
+        Assert.Equal(6, result.ResultingHitPoints);
+        Assert.Equal(3, result.ResultingArmorValue);
+        Assert.Equal(BreakableItemCondition.Intact, result.Condition);
+    }
+
+    [Fact]
+    public void Damage_exceeding_armor_reduces_hit_points_and_degrades_armor_by_the_same_amount_page_224()
+    {
+        // "If the damage exceeds the object's armor value, then the hit points are reduced by
+        // the remaining damage and that many damage points reduce its armor value."
+        var damage = MakeDamageRoll(damageDealt: 4);
+
+        var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 3, damage);
+
+        Assert.Equal(4, result.DamageDealt);
+        Assert.Equal(2, result.ResultingHitPoints);
+        Assert.Equal(0, result.ResultingArmorValue);
+        Assert.Equal(BreakableItemCondition.Intact, result.Condition);
+    }
+
+    [Fact]
+    public void Armor_value_floors_at_zero_rather_than_going_negative_page_224()
+    {
+        var damage = MakeDamageRoll(damageDealt: 4);
+
+        // Armor is already at 1, well below the damage that got through.
+        var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 1, damage);
+
+        Assert.Equal(0, result.ResultingArmorValue);
+    }
+
+    [Fact]
+    public void An_object_smaller_than_human_sized_is_destroyed_at_zero_hit_points_page_224()
+    {
+        var first = BreakableItemResolver.ApplyDamage(6, 3, MakeDamageRoll(damageDealt: 4));
+        Assert.Equal(BreakableItemCondition.Intact, first.Condition);
+
+        // Its armor is now 0 (degraded by the first hit), so the second hit's full raw damage
+        // gets through unmitigated.
+        var second = BreakableItemResolver.ApplyDamage(
+            first.ResultingHitPoints, first.ResultingArmorValue, MakeDamageRoll(damageDealt: 3));
+
+        Assert.True(second.ResultingHitPoints <= 0);
+        Assert.Equal(BreakableItemCondition.Destroyed, second.Condition);
+    }
+
+    [Fact]
+    public void A_miss_changes_nothing()
+    {
+        var miss = new DamageRoll(
+            LandedGrade.Miss, SpecialDamageTypeApplied: null, WeaponRolls: [], DamageBonusRolls: [],
+            WeaponMaximum: null, ArmorApplied: 0, DamageDealt: 0, SourceText: "test miss");
+
+        var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 3, miss);
+
+        Assert.Equal(0, result.DamageDealt);
+        Assert.Equal(6, result.ResultingHitPoints);
+        Assert.Equal(3, result.ResultingArmorValue);
+        Assert.Equal(BreakableItemCondition.Intact, result.Condition);
+    }
+
+    [Fact]
+    public void Rejects_a_negative_current_armor_value()
+    {
+        var damage = MakeDamageRoll(damageDealt: 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: -1, damage));
+    }
+
+    [Fact]
+    public void Reuses_DamageResolvers_weapon_damage_and_armor_subtraction_machinery_end_to_end()
+    {
+        // A heavy club (1D8, Ch 8, Modern Melee Weapons) bashes a glass window (SIZ 3, armor 1).
+        var gear = NoirGearRuleset.Load();
+        var weapon = gear.WeaponById(new WeaponId("clubHeavy"));
+        var itemRegistry = NoirItemHitPointsRuleset.Load();
+        var window = itemRegistry.ById(new BreakableItemId("windowGlass"));
+        var damageRuleset = NoirDamageRuleset.Load();
+        var entropy = new FixedEntropySource(6); // d8 roll of 6, no damage bonus supplied
+
+        var damage = DamageResolver.RollDamage(
+            LandedGrade.Normal, ArmorTreatment.Subtracted, weapon, damageBonus: null,
+            armorValue: window.ArmorValue, damageRuleset, entropy);
+
+        Assert.Equal(1, damage.ArmorApplied);
+        Assert.Equal(5, damage.DamageDealt); // 6 raw - 1 armor
+
+        var result = BreakableItemResolver.ApplyDamage(window.HitPoints, window.ArmorValue, damage);
+
+        Assert.Equal(5, result.DamageDealt);
+        Assert.Equal(-2, result.ResultingHitPoints);
+        Assert.Equal(0, result.ResultingArmorValue);
+        Assert.Equal(BreakableItemCondition.Destroyed, result.Condition);
+    }
+
+    private static DamageRoll MakeDamageRoll(int damageDealt) => new(
+        LandedGrade.Normal, SpecialDamageTypeApplied: null, WeaponRolls: [], DamageBonusRolls: [],
+        WeaponMaximum: null, ArmorApplied: 0, DamageDealt: damageDealt, SourceText: "test");
+}

--- a/tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs
+++ b/tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs
@@ -6,72 +6,113 @@ namespace Brp.Rules.Tests.Combat;
 
 /// <summary>
 /// Ch 8: Equipment, "Damage to Inanimate Objects" (p.224): damage exceeding an object's armor
-/// value reduces its hit points by the remainder and its armor value by the same amount; an
-/// object smaller than or about human-sized is destroyed at 0 hit points. See
-/// <c>docs/decisions/NNNN-item-hit-points.md</c>.
+/// value reduces its hit points by the remainder; an object smaller than or about human-sized is
+/// destroyed at 0 hit points. "Armor Value of Substances" (p.224-225): for every item this
+/// ruleset ships, the armor value degrades by exactly 1 per landed hit (the worked bulletproof-
+/// glass example), not by the penetrating damage that hit dealt -- see
+/// <c>docs/decisions/NNNN-item-hit-points.md</c>'s "Rules interpretation: armor degradation"
+/// block for the full reconciliation of these two passages.
 /// </summary>
 public class BreakableItemResolverTests
 {
     [Fact]
-    public void Damage_at_or_below_the_armor_value_deals_no_hit_point_or_armor_loss_page_224()
+    public void Damage_at_or_below_the_armor_value_deals_no_hit_point_loss_but_still_wears_the_armor_page_224()
     {
-        var damage = MakeDamageRoll(damageDealt: 0);
+        var damage = MakeDamageRoll(LandedGrade.Normal, damageDealt: 0);
 
         var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 3, damage);
 
         Assert.Equal(0, result.DamageDealt);
         Assert.Equal(6, result.ResultingHitPoints);
-        Assert.Equal(3, result.ResultingArmorValue);
+        Assert.Equal(2, result.ResultingArmorValue); // still costs 1 armor -- "each successful hit" (p.225)
         Assert.Equal(BreakableItemCondition.Intact, result.Condition);
     }
 
     [Fact]
-    public void Damage_exceeding_armor_reduces_hit_points_and_degrades_armor_by_the_same_amount_page_224()
+    public void Damage_exceeding_armor_reduces_hit_points_by_the_remaining_damage_page_224()
     {
         // "If the damage exceeds the object's armor value, then the hit points are reduced by
-        // the remaining damage and that many damage points reduce its armor value."
-        var damage = MakeDamageRoll(damageDealt: 4);
+        // the remaining damage" (p.224). DamageDealt is already that remaining-damage figure.
+        var damage = MakeDamageRoll(LandedGrade.Normal, damageDealt: 4);
 
         var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 3, damage);
 
         Assert.Equal(4, result.DamageDealt);
         Assert.Equal(2, result.ResultingHitPoints);
-        Assert.Equal(0, result.ResultingArmorValue);
         Assert.Equal(BreakableItemCondition.Intact, result.Condition);
     }
 
     [Fact]
-    public void Armor_value_floors_at_zero_rather_than_going_negative_page_224()
+    public void Armor_degrades_by_exactly_one_per_landed_hit_regardless_of_penetrating_damage_page_225()
     {
-        var damage = MakeDamageRoll(damageDealt: 4);
+        // Pinning test: the substance-armor worked example (p.225) reduces the armor value "by 1
+        // with each successful hit," not by the damage that got through -- the general "Damage to
+        // Inanimate Objects" phrasing (p.224, "that many damage points reduce its armor value")
+        // does NOT govern here. A large penetrating hit still costs only 1 armor point.
+        var bigHit = MakeDamageRoll(LandedGrade.Normal, damageDealt: 25);
 
-        // Armor is already at 1, well below the damage that got through.
-        var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 1, damage);
+        var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 30, currentArmorValue: 9, bigHit);
+
+        Assert.Equal(25, result.DamageDealt); // hit points: unaffected by the armor-degradation reading
+        Assert.Equal(8, result.ResultingArmorValue); // armor: -1, not -25
+    }
+
+    [Fact]
+    public void Armor_degrades_by_one_even_on_a_hit_that_deals_no_damage_page_225()
+    {
+        // The worked example degrades armor "with each successful hit" without qualifying it on
+        // whether that swing's damage penetrated -- so a landed hit that rolled under the armor
+        // value (DamageDealt 0) still wears the armor down by 1.
+        var glancingHit = MakeDamageRoll(LandedGrade.Normal, damageDealt: 0);
+
+        var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 3, glancingHit);
+
+        Assert.Equal(0, result.DamageDealt);
+        Assert.Equal(2, result.ResultingArmorValue);
+    }
+
+    [Fact]
+    public void Armor_value_floors_at_zero_rather_than_going_negative_page_225()
+    {
+        var damage = MakeDamageRoll(LandedGrade.Normal, damageDealt: 1);
+
+        var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 0, damage);
 
         Assert.Equal(0, result.ResultingArmorValue);
     }
 
     [Fact]
-    public void An_object_smaller_than_human_sized_is_destroyed_at_zero_hit_points_page_224()
+    public void Repeated_hits_steadily_reduce_armor_until_damage_overcomes_it_page_225()
     {
-        var first = BreakableItemResolver.ApplyDamage(6, 3, MakeDamageRoll(damageDealt: 4));
-        Assert.Equal(BreakableItemCondition.Intact, first.Condition);
+        // Mirrors the book's own worked example shape: repeated hits at a fixed raw damage (6)
+        // against a substance armor (3) -- the first two hits are fully absorbed (armor still
+        // ahead of the raw damage), but each hit still wears the armor down by 1 until, on the
+        // fourth hit, the steadily reducing armor value is finally overcome.
+        var armor = 3;
+        var hitPoints = 3; // Glass window, SIZ 3 -- item-hit-points-ruleset.json
 
-        // Its armor is now 0 (degraded by the first hit), so the second hit's full raw damage
-        // gets through unmitigated.
-        var second = BreakableItemResolver.ApplyDamage(
-            first.ResultingHitPoints, first.ResultingArmorValue, MakeDamageRoll(damageDealt: 3));
+        for (var hitsSoFar = 1; hitsSoFar <= 3; hitsSoFar++)
+        {
+            var stillAbsorbed = MakeDamageRoll(LandedGrade.Normal, damageDealt: 0);
+            var step = BreakableItemResolver.ApplyDamage(hitPoints, armor, stillAbsorbed);
+            armor = step.ResultingArmorValue;
+            hitPoints = step.ResultingHitPoints;
+        }
 
-        Assert.True(second.ResultingHitPoints <= 0);
-        Assert.Equal(BreakableItemCondition.Destroyed, second.Condition);
+        Assert.Equal(0, armor); // 3 - 1 - 1 - 1
+        Assert.Equal(3, hitPoints); // never dealt, since every rolled DamageDealt above was 0
+
+        var overcomes = MakeDamageRoll(LandedGrade.Normal, damageDealt: 6); // now unmitigated by 0 armor
+        var final = BreakableItemResolver.ApplyDamage(hitPoints, armor, overcomes);
+
+        Assert.Equal(-3, final.ResultingHitPoints);
+        Assert.Equal(BreakableItemCondition.Destroyed, final.Condition);
     }
 
     [Fact]
     public void A_miss_changes_nothing()
     {
-        var miss = new DamageRoll(
-            LandedGrade.Miss, SpecialDamageTypeApplied: null, WeaponRolls: [], DamageBonusRolls: [],
-            WeaponMaximum: null, ArmorApplied: 0, DamageDealt: 0, SourceText: "test miss");
+        var miss = MakeDamageRoll(LandedGrade.Miss, damageDealt: 0);
 
         var result = BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: 3, miss);
 
@@ -84,7 +125,7 @@ public class BreakableItemResolverTests
     [Fact]
     public void Rejects_a_negative_current_armor_value()
     {
-        var damage = MakeDamageRoll(damageDealt: 1);
+        var damage = MakeDamageRoll(LandedGrade.Normal, damageDealt: 1);
 
         Assert.Throws<ArgumentOutOfRangeException>(
             () => BreakableItemResolver.ApplyDamage(currentHitPoints: 6, currentArmorValue: -1, damage));
@@ -110,13 +151,13 @@ public class BreakableItemResolverTests
 
         var result = BreakableItemResolver.ApplyDamage(window.HitPoints, window.ArmorValue, damage);
 
-        Assert.Equal(5, result.DamageDealt);
+        Assert.Equal(5, result.DamageDealt); // hit points: DamageResolver's armor-subtraction reused as-is
         Assert.Equal(-2, result.ResultingHitPoints);
-        Assert.Equal(0, result.ResultingArmorValue);
+        Assert.Equal(0, result.ResultingArmorValue); // armor: -1 (window's starting armor was already 1)
         Assert.Equal(BreakableItemCondition.Destroyed, result.Condition);
     }
 
-    private static DamageRoll MakeDamageRoll(int damageDealt) => new(
-        LandedGrade.Normal, SpecialDamageTypeApplied: null, WeaponRolls: [], DamageBonusRolls: [],
+    private static DamageRoll MakeDamageRoll(LandedGrade landedGrade, int damageDealt) => new(
+        landedGrade, SpecialDamageTypeApplied: null, WeaponRolls: [], DamageBonusRolls: [],
         WeaponMaximum: null, ArmorApplied: 0, DamageDealt: damageDealt, SourceText: "test");
 }


### PR DESCRIPTION
## Linked Issue

Closes #230

## Exact behavioral claim

Before this change, nothing in the engine could resolve forcing or bashing
through a door, window, or lock — `DamageResolver` only applied damage to a
character's `AbilitySet`, and no ruleset carried object SIZ/hit-point/armor
data. Now `Brp.Rules.Combat.BreakableItemResolver.ApplyDamage` applies a
landed hit's damage to an inanimate object's hit points and armor value
(degrading armor as it takes damage, per Ch 8 p.224), classifying it
`Intact`/`Destroyed`, using a small hand-picked set of items
(`item-hit-points-ruleset.json`: wood door, glass door, glass window,
padlock) loaded through `Brp.Data.NoirItemHitPointsRuleset`.

## Scope

**Changed:**
- `src/Brp.Rules/Gear/BreakableItemId.cs`, `BreakableItemDefinition.cs`,
  `BreakableItemRegistry.cs` — the item-data types, mirroring
  `WeaponId`/`WeaponDefinition`/`GearRegistry`.
- `src/Brp.Rules/Combat/BreakableItemResolver.cs`,
  `BreakableItemDamageResult.cs`, `BreakableItemCondition.cs` — the
  armor-degradation-and-destruction resolver.
- `src/Brp.Data/item-hit-points-ruleset.json`,
  `src/Brp.Data/NoirItemHitPointsRuleset.cs`, and the `Brp.Data.csproj`
  embedded-resource entry — the ruleset data and loader.
- `docs/decisions/NNNN-item-hit-points.md` (+ `README.md` index row) — the
  design record, including the two house-extrapolated values (the glass
  door's armor value, and the padlock entirely — the book prints no lock
  entry).
- Tests: `tests/Brp.Data.Tests/NoirItemHitPointsRulesetTests.cs`,
  `tests/Brp.Rules.Tests/Combat/BreakableItemResolverTests.cs`.

**Deliberately did not change:** `DamageResolver` itself, the
attack/defense matrix, or anything character-facing — this is purely an
additive item-breaking path that *reuses* `DamageResolver.RollDamage`
rather than touching it. Forcing a stuck door open (the separate STR-vs-STR
resistance-roll spot rule named on Ch 5 p.129) and any Locksmith-based
non-destructive lockpicking are out of scope — `orc-scope-filter.md` line
137 names only the SIZ/hit-points breaking mechanic.

## Rules conformance

Ch 8: Equipment, "General Qualities of Objects" and "Damage to Inanimate
Objects" (p.224): "assign an armor value based on its equivalent... If the
damage exceeds the object's armor value, then the hit points are reduced by
the remaining damage and that many damage points reduce its armor value...
If an object is smaller than human-sized... it is totally destroyed if it
is reduced to 0 hit points." "Armor Value of Substances" (p.224) and "SIZ of
Common Objects" (pp.225-226) supply the per-item table, reproduced cell by
cell in `NoirItemHitPointsRulesetTests`. Full sourcing, including the two
house-extrapolated entries, is in `docs/decisions/NNNN-item-hit-points.md`.

**Machinery reused, not rebuilt:** `BreakableItemResolver.ApplyDamage`
takes an already-rolled `DamageRoll` from the existing, unmodified
`DamageResolver.RollDamage` — its `DamageDealt` field is already "raw
damage minus armor value, floored at zero," identical to p.224's "hit
points are reduced by the remaining damage." The only new arithmetic is the
armor-degradation step objects have and characters don't.

## Tests and evidence

- `dotnet build` — Build succeeded, 0 warnings, 0 errors.
- `dotnet test` — all four suites passed: `Brp.Cli.Tests` 51/51,
  `Brp.Data.Tests` 369/369, `Brp.Rules.Tests` 499/499, `Brp.Core.Tests`
  1557/1557 (2476/2476 total).
- `dotnet format --verify-no-changes` — clean, no output.

## Decisions and tradeoffs

- Kept `BreakableItemResolver.ApplyDamage` stateless (plain
  hit-points/armor-value ints in and out) rather than introducing a new
  mutable "game object" domain type — there's no existing object-state
  abstraction to hang this off, and building one is out of scope for this
  issue.
- Hand-picked four items rather than transcribing the book's full object
  table, per `orc-scope-filter.md`'s "hand-pick... not two hundred rows"
  instruction.
- The glass door's armor value and the entire padlock entry are house
  extrapolations (the book prints no exact row for either) — both are
  explicitly flagged as such in the ruleset JSON's `source` field and in
  the ADR, per the "Sourced or house rule" convention.
- ADR uses the `NNNN` placeholder per ADR 0027 (merge-time number
  assignment), to avoid colliding with any other in-flight decision record.

## Known limitations

- Only the "human-sized-or-smaller, destroyed at 0 HP" branch of p.224 is
  built; the "larger object gets a human-sized hole in one segment" branch
  does not apply to this hand-picked set (door/window/lock) and is not
  modeled.
- Forcing a door open via the STR-vs-STR resistance roll (a different,
  already-generic `ResistanceResolver` capability) is not wired to any
  door-specific "effective STR" value — the book gives no such value, and
  `orc-scope-filter.md` line 137 scopes this issue to the SIZ/HP breaking
  mechanic only.
- No live combat-round/scene-loop integration (tracking an object's HP
  across multiple hits, narrating when it gives way) — matches every other
  `Brp.Rules.Combat` resolver's stateless, caller-driven shape.

## Agent provenance

Implemented by Claude (Sonnet 5), Anthropic's Claude Code CLI.

## Checklist

- [x] The linked Issue and acceptance criteria were read.
- [x] The diff contains one concern.
- [x] Focused verification passed.
- [x] Relevant documentation changed with the behavior.
- [x] No unrelated cleanup is included.
- [x] No out-of-scope content was implemented (see `orc-scope-filter.md`).

<!-- agent-verification:start -->
### agent-verification — `success` for `30dbac7`

| gate | result | evidence |
|---|---|---|
| `ci` | pass | GitHub `build-and-test` @ this SHA |
| `scope-warden` | pass | bound — haiku, packet `2b083d5fe550` |
| `rules-conformance` | pass | bound — opus, packet `2b083d5fe550` |
| `codex-conformance` | pass | unbound (`--gate` assertion) |
| `architecture-review` | pass | bound — opus, packet `2b083d5fe550` |

_5/5 gates passed [route: formulas]. Regenerated per head SHA by `tools/agent-verify.sh`; semantic verdicts bound to head + review packet via `tools/gate-evidence.sh`._

> ⚠️ `--allow-unbound-gates` was used: one or more semantic verdicts were accepted without head/packet binding.
<!-- agent-verification:end -->